### PR TITLE
Feat reward - add tests for ownership transfer and reward coordinator functions

### DIFF
--- a/contracts/rewards-coordinator/src/contract.rs
+++ b/contracts/rewards-coordinator/src/contract.rs
@@ -1277,5 +1277,76 @@ mod tests {
         assert_eq!(stored_activation_delay_after_unauthorized_attempt, new_activation_delay);
     }
 
+    #[test]
+    fn test_set_rewards_updater_internal() {
+        let mut deps = mock_dependencies();
+    
+        let initial_updater = Addr::unchecked("initial_updater");
+        REWARDS_UPDATER.save(&mut deps.storage, &initial_updater).unwrap();
+    
+        let new_updater = Addr::unchecked("new_updater");
+    
+        let result = _set_rewards_updater(deps.as_mut(), new_updater.clone());
+    
+        assert!(result.is_ok());
+    
+        let response = result.unwrap();
+        assert_eq!(response.events.len(), 1);
+    
+        let event = response.events.first().unwrap();
+        assert_eq!(event.ty, "SetRewardsUpdater");
+        assert_eq!(event.attributes.len(), 2);
+        assert_eq!(event.attributes[0].key, "method");
+        assert_eq!(event.attributes[0].value, "set_rewards_updater");
+        assert_eq!(event.attributes[1].key, "new_updater");
+        assert_eq!(event.attributes[1].value, new_updater.to_string());
+    
+        let stored_updater = REWARDS_UPDATER.load(&deps.storage).unwrap();
+        assert_eq!(stored_updater, new_updater);
+    }
+
+    #[test]
+    fn test_set_rewards_updater() {
+        let mut deps = mock_dependencies();
+    
+        let owner = Addr::unchecked("owner");
+        OWNER.save(&mut deps.storage, &owner).unwrap();
+    
+        let initial_updater = Addr::unchecked("initial_updater");
+        REWARDS_UPDATER.save(&mut deps.storage, &initial_updater).unwrap();
+    
+        let new_updater = Addr::unchecked("new_updater");
+    
+        let info = message_info(&Addr::unchecked("owner"), &[]);
+        let result = set_rewards_updater(deps.as_mut(), info, new_updater.clone());
+    
+        assert!(result.is_ok());
+    
+        let response = result.unwrap();
+        assert_eq!(response.events.len(), 1);
+    
+        let event = response.events.first().unwrap();
+        assert_eq!(event.ty, "SetRewardsUpdater");
+        assert_eq!(event.attributes.len(), 2);
+        assert_eq!(event.attributes[0].key, "method");
+        assert_eq!(event.attributes[0].value, "set_rewards_updater");
+        assert_eq!(event.attributes[1].key, "new_updater");
+        assert_eq!(event.attributes[1].value, new_updater.to_string());
+    
+        let stored_updater = REWARDS_UPDATER.load(&deps.storage).unwrap();
+        assert_eq!(stored_updater, new_updater);
+    
+        let unauthorized_info = message_info(&Addr::unchecked("not_owner"), &[]);
+        let result = set_rewards_updater(deps.as_mut(), unauthorized_info, Addr::unchecked("another_updater"));
+    
+        assert!(result.is_err());
+        if let Err(err) = result {
+            assert_eq!(err, ContractError::Unauthorized {});
+        }
+    
+        let stored_updater = REWARDS_UPDATER.load(&deps.storage).unwrap();
+        assert_eq!(stored_updater, new_updater);
+    }
+
 }
 


### PR DESCRIPTION
## Why are these changes needed?

This pull request introduces several new tests to ensure the correctness and reliability of the reward coordinator module:

- **Test: add `test_transfer_ownership`**: Implements a test to verify the process of transferring ownership, ensuring that ownership transitions occur correctly and securely.
- **Test: `test_set_activation_delay_internal`**: Adds a test to validate the internal function for setting activation delays, confirming that the delay settings function as expected.
- **Test: `test_set_activation_delay`**: Introduces a test to verify the external function for setting activation delays, ensuring that users can configure delays accurately.
- **Test: add `test_set_rewards_updater_internal` / `test_set_rewards_updater`**: Adds tests for both internal and external functions to set rewards updaters, ensuring that the rewards updater settings are correctly implemented and secure.
