### PR TITLE
fix - modify readme delegationmanager contract address and tx_hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ docker run --rm -v "$(pwd)":/code custom-cosmwasm-optimizer:latest
 
 - strategy-base2: bbn1dxmq2c5vt5en8u9llhklhqtvzdpnl5wdfentmy8hxew2cfyu0xnqygc65u, tx_hash: 8D6A003A220BE9D3B70ED7478C0B576C10AC437F8E735A1BF08D053DDF64F21A
 
-- delegation-manager: bbn18zjcdsttnfhxxjjv29twnum3gxlqj54tlcmflwqsee9crmn9pk0syy0vw0, tx_hash: A9700B31FF2923CBC3F0750B6B42BFA8D1650497E462F9C7177A2EC9CFDDE64F
+- delegation-manager: bbn1fys7yex6zgt73870uzewwglk0dzrwy6fsp0c4tent3080n3235ls6upg7c, tx_hash: 12CF607F69680E3B6E8F3AED9A52D2125A6547BB13261DDBFEF5F31F7A0150F5
 
 - bvs-directory: bbn1xnf6w2jg3uh76d4mavjpu539zcgv5wzg5xa00fnkf4fcd6carrasd6wa88, tx_hash: 9A424F59BBB7692090D5378F873C1E07B0A6F1F87056F280F969C414729172D1
 
@@ -112,7 +112,7 @@ docker run --rm -v "$(pwd)":/code custom-cosmwasm-optimizer:latest
 
 - strategy-base-TVLLimits: bbn1x6ttpp3vpzaknxcc25u0mjrlnagu3agvwnyl0wpwhtjdljaw8aks5dntmr, tx_hash: 65E96952C87DBF83D541C0A07A9EEA9D06FFAFF79DF9955551CCC94D69EDDD0A
 
-- bvs-driver: bbn1ytn4v3pd9ecklqf32pusephxpnfvnev7657rprr3jh43rchygvmqlatdtm, tx_hash:
+- bvs-driver: bbn1jskphr9zxs2yp3e9vwamyeqwxkfkg5zghyv52qcy4tlql3qjjwgsk6zhwq, tx_hash:
   1CD70B531A7ACB7195B200EBC6EFCFEC279832A8D6F92F0D1068B29A40278DB4
 
 - state-bank: bbn1xwyr5fqrgpueffa84uj8aglfea23qwlr00medkserpk3r7wpvslqpvdq6p, tx_hash:

--- a/contracts/bvs-driver/src/contract.rs
+++ b/contracts/bvs-driver/src/contract.rs
@@ -55,7 +55,7 @@ pub fn execute_bvs_offchain(
     }
 
     Ok(Response::new().add_event(
-        Event::new("ExecuteAVSOffchain")
+        Event::new("ExecuteBVSOffchain")
             .add_attribute("sender", sender.to_string())
             .add_attribute("task_id", task_id.to_string()),
     ))
@@ -126,7 +126,7 @@ mod tests {
 
         assert_eq!(1, res.events.len());
 
-        assert_eq!("ExecuteAVSOffchain", res.events[0].ty);
+        assert_eq!("ExecuteBVSOffchain", res.events[0].ty);
 
         assert_eq!(
             res.events[0].attributes,


### PR DESCRIPTION
## Why are these changes needed?

This pull request modifies the README to update the DelegationManager contract address and transaction hash. These changes are necessary to ensure that the documentation accurately reflects the current contract configuration and transaction details. Keeping this information up-to-date is crucial for developers and users who rely on the README for accurate setup and operational guidance, thereby preventing potential errors and misunderstandings.

## Commits included in this PR

- fix: modify README delegationManager contract address & tx_hash
