### PR TITLE
fix - run cargo fmt

### DIFF
--- a/contracts/bvs-directory/src/contract.rs
+++ b/contracts/bvs-directory/src/contract.rs
@@ -1508,8 +1508,13 @@ mod tests {
             delegation_manager: delegation_manager.to_string(),
         };
 
-        let res = execute(deps.as_mut(), env.clone(), info.clone(), set_delegation_manager_msg)
-            .unwrap();
+        let res = execute(
+            deps.as_mut(),
+            env.clone(),
+            info.clone(),
+            set_delegation_manager_msg,
+        )
+        .unwrap();
 
         assert!(res
             .attributes

--- a/contracts/slash-manager/src/contract.rs
+++ b/contracts/slash-manager/src/contract.rs
@@ -146,7 +146,9 @@ pub fn execute(
             let new_delegation_manager_addr = deps.api.addr_validate(&new_delegation_manager)?;
             set_delegation_manager(deps, info, new_delegation_manager_addr)
         }
-        ExecuteMsg::SetStrategyManager { new_strategy_manager } => {
+        ExecuteMsg::SetStrategyManager {
+            new_strategy_manager,
+        } => {
             let new_strategy_manager_addr = deps.api.addr_validate(&new_strategy_manager)?;
             set_strategy_manager(deps, info, new_strategy_manager_addr)
         }
@@ -1525,11 +1527,19 @@ mod tests {
             new_strategy_manager: new_strategy_manager.clone(),
         };
 
-        let res = execute(deps.as_mut(), env.clone(), info.clone(), set_strategy_manager_msg);
+        let res = execute(
+            deps.as_mut(),
+            env.clone(),
+            info.clone(),
+            set_strategy_manager_msg,
+        );
         assert!(res.is_ok());
 
         let strategy_manager_addr = STRATEGY_MANAGER.load(&deps.storage).unwrap();
-        assert_eq!(strategy_manager_addr, Addr::unchecked(new_strategy_manager.clone()));
+        assert_eq!(
+            strategy_manager_addr,
+            Addr::unchecked(new_strategy_manager.clone())
+        );
 
         let event = res.unwrap().events[0].clone();
         assert_eq!(event.ty, "strategy_manager_set");

--- a/contracts/strategy-base-TVLLimits/src/contract.rs
+++ b/contracts/strategy-base-TVLLimits/src/contract.rs
@@ -96,7 +96,9 @@ pub fn execute(
             let token_addr = deps.api.addr_validate(&token)?;
             withdraw(deps, env, info, recipient_addr, token_addr, amount_shares)
         }
-        ExecuteMsg::SetStrategyManager { new_strategy_manager } => {
+        ExecuteMsg::SetStrategyManager {
+            new_strategy_manager,
+        } => {
             let new_strategy_manager_addr = deps.api.addr_validate(&new_strategy_manager)?;
             set_strategy_manager(deps, info, new_strategy_manager_addr)
         }
@@ -1589,13 +1591,21 @@ mod tests {
             new_strategy_manager: new_strategy_manager.clone(),
         };
 
-        let res = execute(deps.as_mut(), env.clone(), info.clone(), set_strategy_manager_msg)
-            .unwrap();
+        let res = execute(
+            deps.as_mut(),
+            env.clone(),
+            info.clone(),
+            set_strategy_manager_msg,
+        )
+        .unwrap();
 
         assert!(res.events.iter().any(|e| e.ty == "strategy_manager_set"));
 
         let state = STRATEGY_STATE.load(&deps.storage).unwrap();
-        assert_eq!(state.strategy_manager, Addr::unchecked(new_strategy_manager.clone()));
+        assert_eq!(
+            state.strategy_manager,
+            Addr::unchecked(new_strategy_manager.clone())
+        );
 
         let event = res.events[0].clone();
         assert_eq!(event.ty, "strategy_manager_set");

--- a/contracts/strategy-base/src/contract.rs
+++ b/contracts/strategy-base/src/contract.rs
@@ -93,7 +93,9 @@ pub fn execute(
             let token_addr = deps.api.addr_validate(&token)?;
             withdraw(deps, env, info, recipient_addr, token_addr, amount_shares)
         }
-        ExecuteMsg::SetStrategyManager { new_strategy_manager } => {
+        ExecuteMsg::SetStrategyManager {
+            new_strategy_manager,
+        } => {
             let new_strategy_manager_addr = deps.api.addr_validate(&new_strategy_manager)?;
             set_strategy_manager(deps, info, new_strategy_manager_addr)
         }
@@ -1354,12 +1356,20 @@ mod tests {
             new_strategy_manager: new_strategy_manager.clone(),
         };
 
-        let res = execute(deps.as_mut(), env.clone(), info.clone(), set_strategy_manager_msg)
-            .unwrap();
+        let res = execute(
+            deps.as_mut(),
+            env.clone(),
+            info.clone(),
+            set_strategy_manager_msg,
+        )
+        .unwrap();
 
         assert!(res.events.iter().any(|e| e.ty == "strategy_manager_set"));
 
         let state = STRATEGY_STATE.load(&deps.storage).unwrap();
-        assert_eq!(state.strategy_manager, Addr::unchecked(new_strategy_manager));
+        assert_eq!(
+            state.strategy_manager,
+            Addr::unchecked(new_strategy_manager)
+        );
     }
 }


### PR DESCRIPTION
## Why are these changes needed?

This pull request runs `cargo fmt` to format the Rust codebase. These changes are necessary to ensure consistent code styling across the project, which improves readability and maintainability. By adhering to standardized formatting, the code becomes easier for developers to read and understand, reducing the likelihood of errors and enhancing collaboration within the team.

## Commits included in this PR

- feat: run cargo fmt
