### PR TITLE
chore: action.yml suppress npm warnings + go version and caching

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,7 +13,8 @@ runs:
     # Go
     - uses: actions/setup-go@v5
       with:
-        go-version: "1.23"
+        go-version-file: "modules/go.mod"
+        cache-dependency-path: "modules/go.sum"
 
     # Node.js, PNPM, Turbo
     - uses: actions/setup-node@v4


### PR DESCRIPTION
#### What this PR does / why we need it:

We're using Turbo for non-npm scripts as well. 
To suppress npm warnings, this simple script mkdir `node_modules` for all workspaces. 

Update `action.yml` to use `go.mod` for version and `go.sum` for caching.