### PR TITLE
feat: backport fixes for sdk ut fail into monorepo

### DIFF
--- a/modules/bvs-api/chainio/api/bvs_directory.go
+++ b/modules/bvs-api/chainio/api/bvs_directory.go
@@ -4,16 +4,14 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"strconv"
-	"time"
 
 	coretypes "github.com/cometbft/cometbft/rpc/core/types"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
-	"golang.org/x/exp/rand"
 
 	"github.com/satlayer/satlayer-bvs/bvs-api/chainio/io"
 	"github.com/satlayer/satlayer-bvs/bvs-api/chainio/types"
+	"github.com/satlayer/satlayer-bvs/bvs-api/utils"
 )
 
 type BVSDirectory interface {
@@ -90,7 +88,11 @@ func (a *bvsDirectoryImpl) RegisterOperator(ctx context.Context, operator string
 		return nil, err
 	}
 	expiry := uint64(nodeStatus.SyncInfo.LatestBlockTime.Unix() + 1000)
-	salt := "salt" + strconv.FormatUint(rand.New(rand.NewSource(uint64(time.Now().Unix()))).Uint64(), 10)
+	randomStr, err := utils.GenerateRandomString(16)
+	if err != nil {
+		return nil, err
+	}
+	salt := "salt" + randomStr
 	msgHashResp, err := a.CalculateDigestHash(publicKey, operator, salt, expiry)
 	if err != nil {
 		return nil, err

--- a/modules/bvs-api/chainio/api/delegation_manager.go
+++ b/modules/bvs-api/chainio/api/delegation_manager.go
@@ -4,16 +4,14 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"strconv"
-	"time"
 
 	coretypes "github.com/cometbft/cometbft/rpc/core/types"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
-	"golang.org/x/exp/rand"
 
 	"github.com/satlayer/satlayer-bvs/bvs-api/chainio/io"
 	"github.com/satlayer/satlayer-bvs/bvs-api/chainio/types"
+	"github.com/satlayer/satlayer-bvs/bvs-api/utils"
 )
 
 const zeroValueAddr = "0"
@@ -161,7 +159,11 @@ func (d *delegationImpl) DelegateTo(ctx context.Context, operator, approver, app
 			return nil, err
 		}
 		expiry := uint64(nodeStatus.SyncInfo.LatestBlockTime.Unix() + 1000)
-		salt := "salt" + strconv.FormatUint(rand.New(rand.NewSource(uint64(time.Now().Unix()))).Uint64(), 10)
+		randomStr, err := utils.GenerateRandomString(16)
+		if err != nil {
+			return nil, err
+		}
+		salt := "salt" + randomStr
 		approverDigestHashReq := types.ApproverDigestHashParams{
 			Staker:            stakerAccount.GetAddress().String(),
 			Operator:          operator,
@@ -242,7 +244,11 @@ func (d *delegationImpl) DelegateToBySignature(
 	}}
 
 	if approver != zeroValueAddr && approverKeyName != "" && approverPublicKey != nil {
-		salt := "salt" + strconv.FormatUint(rand.New(rand.NewSource(uint64(time.Now().Unix()))).Uint64(), 10)
+		randomStr, err := utils.GenerateRandomString(16)
+		if err != nil {
+			return nil, err
+		}
+		salt := "salt" + randomStr
 		approverDigestHashReq := types.ApproverDigestHashParams{
 			Staker:            staker,
 			Operator:          operator,

--- a/modules/bvs-api/chainio/io/cosmos.go
+++ b/modules/bvs-api/chainio/io/cosmos.go
@@ -178,7 +178,7 @@ func (c chainIO) BroadcastTx(signedTx sdktypes.Tx) (*sdktypes.TxResponse, error)
 }
 
 func (c chainIO) waitForConfirmation(ctx context.Context, txHash string) (*coretypes.ResultTx, error) {
-	ticker := time.NewTicker(3 * time.Second)
+	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()
 
 	timeout := time.After(c.params.ConfirmationTimeout)

--- a/modules/bvs-api/tests/e2e/chainio_test.go
+++ b/modules/bvs-api/tests/e2e/chainio_test.go
@@ -38,7 +38,7 @@ func (suite *ioTestSuite) SetupTest() {
 	chainIO, err := io.NewChainIO(chainID, rpcURI, homeDir, "bbn", logger, metricsIndicators, types.TxManagerParams{
 		MaxRetries:             3,
 		RetryInterval:          2 * time.Second,
-		ConfirmationTimeout:    60 * time.Second,
+		ConfirmationTimeout:    15 * time.Second,
 		GasPriceAdjustmentRate: "1.1",
 	})
 	suite.Require().NoError(err)

--- a/modules/bvs-api/tests/e2e/eth_bvs_directory_test.go
+++ b/modules/bvs-api/tests/e2e/eth_bvs_directory_test.go
@@ -36,7 +36,7 @@ func (suite *ethBVSDirectoryTestSuite) SetupTest() {
 	ethChainIO, err := io.NewETHChainIO(endpoint, keystorePath, logger, metricsIndicators, types.TxManagerParams{
 		MaxRetries:                 3,
 		RetryInterval:              2 * time.Second,
-		ConfirmationTimeout:        60 * time.Second,
+		ConfirmationTimeout:        15 * time.Second,
 		ETHGasFeeCapAdjustmentRate: 2,
 		ETHGasLimitAdjustmentRate:  1.1,
 		GasLimit:                   1000000000,

--- a/modules/bvs-api/tests/e2e/eth_bvs_driver_test.go
+++ b/modules/bvs-api/tests/e2e/eth_bvs_driver_test.go
@@ -36,7 +36,7 @@ func (suite *ethBVSDriverTestSuite) SetupTest() {
 	ethChainIO, err := io.NewETHChainIO(endpoint, keystorePath, logger, metricsIndicators, types.TxManagerParams{
 		MaxRetries:                 3,
 		RetryInterval:              2 * time.Second,
-		ConfirmationTimeout:        60 * time.Second,
+		ConfirmationTimeout:        15 * time.Second,
 		ETHGasFeeCapAdjustmentRate: 2,
 		ETHGasLimitAdjustmentRate:  1.1,
 		GasLimit:                   1000000000,

--- a/modules/bvs-api/tests/e2e/eth_slash_manager_test.go
+++ b/modules/bvs-api/tests/e2e/eth_slash_manager_test.go
@@ -37,7 +37,7 @@ func (suite *ethSlashManagerTestSuite) SetupTest() {
 	ethChainIO, err := io.NewETHChainIO(endpoint, keystorePath, logger, metricsIndicators, types.TxManagerParams{
 		MaxRetries:                 3,
 		RetryInterval:              2 * time.Second,
-		ConfirmationTimeout:        60 * time.Second,
+		ConfirmationTimeout:        15 * time.Second,
 		ETHGasFeeCapAdjustmentRate: 2,
 		ETHGasLimitAdjustmentRate:  1.1,
 		GasLimit:                   1000000000,

--- a/modules/bvs-api/tests/e2e/eth_statebank_test.go
+++ b/modules/bvs-api/tests/e2e/eth_statebank_test.go
@@ -38,7 +38,7 @@ func (suite *ethStateBankTestSuite) SetupTest() {
 	ethChainIO, err := io.NewETHChainIO(endpoint, keystorePath, logger, metricsIndicators, types.TxManagerParams{
 		MaxRetries:                 3,
 		RetryInterval:              2 * time.Second,
-		ConfirmationTimeout:        60 * time.Second,
+		ConfirmationTimeout:        15 * time.Second,
 		ETHGasFeeCapAdjustmentRate: 2,
 		ETHGasLimitAdjustmentRate:  1.1,
 		GasLimit:                   1000000000,

--- a/modules/bvs-api/tests/e2e/rewards_coordinator_test.go
+++ b/modules/bvs-api/tests/e2e/rewards_coordinator_test.go
@@ -41,7 +41,7 @@ func (suite *rewardsTestSuite) SetupTest() {
 	chainIO, err := io.NewChainIO(chainID, rpcURI, homeDir, "bbn", logger, metricsIndicators, types.TxManagerParams{
 		MaxRetries:             3,
 		RetryInterval:          2 * time.Second,
-		ConfirmationTimeout:    60 * time.Second,
+		ConfirmationTimeout:    15 * time.Second,
 		GasPriceAdjustmentRate: "1.1",
 	})
 	suite.Require().NoError(err)

--- a/modules/bvs-api/tests/e2e/signer_test.go
+++ b/modules/bvs-api/tests/e2e/signer_test.go
@@ -52,7 +52,7 @@ func (suite *signerTestSuite) SetupTest() {
 	chainIO, err := io.NewChainIO(chainID, rpcURI, homeDir, "bbn", logger, metricsIndicators, types.TxManagerParams{
 		MaxRetries:             3,
 		RetryInterval:          1 * time.Second,
-		ConfirmationTimeout:    60 * time.Second,
+		ConfirmationTimeout:    15 * time.Second,
 		GasPriceAdjustmentRate: "1.1",
 	})
 	suite.Require().NoError(err)

--- a/modules/bvs-api/tests/e2e/slash_manager_test.go
+++ b/modules/bvs-api/tests/e2e/slash_manager_test.go
@@ -34,7 +34,7 @@ func (suite *slashManagerTestSuite) SetupTest() {
 	chainIO, err := io.NewChainIO(chainID, rpcURI, homeDir, "bbn", logger, metricsIndicators, types.TxManagerParams{
 		MaxRetries:             3,
 		RetryInterval:          2 * time.Second,
-		ConfirmationTimeout:    60 * time.Second,
+		ConfirmationTimeout:    15 * time.Second,
 		GasPriceAdjustmentRate: "1.1",
 	})
 	suite.Require().NoError(err)

--- a/modules/bvs-api/tests/e2e/statebank_test.go
+++ b/modules/bvs-api/tests/e2e/statebank_test.go
@@ -35,7 +35,7 @@ func (suite *stateBankTestSuite) SetupTest() {
 	chainIO, err := io.NewChainIO(chainID, rpcURI, homeDir, "bbn", logger, metricsIndicators, types.TxManagerParams{
 		MaxRetries:             3,
 		RetryInterval:          2 * time.Second,
-		ConfirmationTimeout:    60 * time.Second,
+		ConfirmationTimeout:    15 * time.Second,
 		GasPriceAdjustmentRate: "1.1",
 	})
 	suite.Require().NoError(err)

--- a/modules/bvs-api/tests/e2e/strategy_base_test.go
+++ b/modules/bvs-api/tests/e2e/strategy_base_test.go
@@ -33,7 +33,7 @@ func (suite *strategyBaseTestSuite) SetupTest() {
 	chainIO, err := io.NewChainIO(chainID, rpcURI, homeDir, "bbn", logger, metricsIndicators, types.TxManagerParams{
 		MaxRetries:             3,
 		RetryInterval:          2 * time.Second,
-		ConfirmationTimeout:    60 * time.Second,
+		ConfirmationTimeout:    15 * time.Second,
 		GasPriceAdjustmentRate: "1.1",
 	})
 	suite.Require().NoError(err)

--- a/modules/bvs-api/tests/e2e/strategy_base_tvl_limits_test.go
+++ b/modules/bvs-api/tests/e2e/strategy_base_tvl_limits_test.go
@@ -33,7 +33,7 @@ func (suite *strategyBaseTVLLimitsTestSuite) SetupTest() {
 	chainIO, err := io.NewChainIO(chainID, rpcURI, homeDir, "bbn", logger, metricsIndicators, types.TxManagerParams{
 		MaxRetries:             3,
 		RetryInterval:          2 * time.Second,
-		ConfirmationTimeout:    60 * time.Second,
+		ConfirmationTimeout:    15 * time.Second,
 		GasPriceAdjustmentRate: "1.1",
 	})
 	suite.Require().NoError(err)

--- a/modules/bvs-api/tests/e2e/strategy_factory_test.go
+++ b/modules/bvs-api/tests/e2e/strategy_factory_test.go
@@ -32,7 +32,7 @@ func (suite *strategyFactoryTestSuite) SetupTest() {
 	chainIO, err := io.NewChainIO(chainID, rpcURI, homeDir, "bbn", logger, metricsIndicators, types.TxManagerParams{
 		MaxRetries:             3,
 		RetryInterval:          2 * time.Second,
-		ConfirmationTimeout:    60 * time.Second,
+		ConfirmationTimeout:    15 * time.Second,
 		GasPriceAdjustmentRate: "1.1",
 	})
 	suite.Require().NoError(err)

--- a/modules/bvs-api/tests/e2e/strategy_manager_test.go
+++ b/modules/bvs-api/tests/e2e/strategy_manager_test.go
@@ -54,7 +54,7 @@ func (suite *strategyManagerTestSuite) SetupTest() {
 	chainIO, err := io.NewChainIO(chainID, rpcURI, homeDir, "bbn", logger, metricsIndicators, types.TxManagerParams{
 		MaxRetries:             3,
 		RetryInterval:          2 * time.Second,
-		ConfirmationTimeout:    60 * time.Second,
+		ConfirmationTimeout:    15 * time.Second,
 		GasPriceAdjustmentRate: "1.1",
 	})
 	suite.Require().NoError(err)

--- a/modules/bvs-api/utils/utils.go
+++ b/modules/bvs-api/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"crypto/ecdsa"
+	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -302,4 +303,17 @@ func AddAddressPrefix(address string, prefix string) string {
 
 func TrimAddressPrefix(address string, prefix string) string {
 	return strings.TrimPrefix(address, prefix+"1")
+}
+
+func GenerateRandomString(length int) (string, error) {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	b := make([]byte, length)
+	for i := range b {
+		n, err := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
+		if err != nil {
+			return "", fmt.Errorf("failed to generate random string: %w", err)
+		}
+		b[i] = charset[n.Int64()]
+	}
+	return string(b), nil
 }

--- a/modules/bvs-api/utils/utils_test.go
+++ b/modules/bvs-api/utils/utils_test.go
@@ -38,3 +38,21 @@ func TestEcdsaPrivateKeyToCosmosAddress(t *testing.T) {
 		})
 	}
 }
+
+func TestGenerateRandomString(t *testing.T) {
+	testCases := []struct {
+		name string
+		len  int
+	}{
+		{"rand16", 16},
+		{"rand10", 10},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			generatedString, err := GenerateRandomString(tc.len)
+			require.NoError(t, err)
+			assert.Len(t, generatedString, tc.len)
+			t.Log(generatedString)
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

Backport changes from our SDK repo into the mono repo that addresses bvs-api testing failure issues.

NOTE: DO NOT MERGE. There is some on chain state problem leading to test failure. Retest after fix.

<!-- remove if not applicable -->
Closes SL-64