### PR TITLE
hack: disable registration tests until we can run testnet locally

### DIFF
--- a/modules/satlayer-cli/tests/e2e/bvs_driver_evm_test.go
+++ b/modules/satlayer-cli/tests/e2e/bvs_driver_evm_test.go
@@ -6,12 +6,14 @@ import (
 	"github.com/satlayer/satlayer-bvs/satlayer-cli/commands/bvsdriverevm"
 )
 
-func Test_EVMBVSDriverRegBVS(t *testing.T) {
-	var evmUserAddr = "0xC97705a8FaA9Bec2A50B5bbCc0661251BcB537A4"
-	var password = "123"
-	bvsContract := "0xaA0851f2939EF2D8B51971B510383Fcb5c246a17"
-	bvsdriverevm.RegBVS(evmUserAddr, password, bvsContract)
-}
+// HACK: SL-96 - disable on chain registration due to hard coded contract address
+// until we can run testnet locally
+// func Test_EVMBVSDriverRegBVS(t *testing.T) {
+// 	var evmUserAddr = "0xC97705a8FaA9Bec2A50B5bbCc0661251BcB537A4"
+// 	var password = "123"
+// 	bvsContract := "0xaA0851f2939EF2D8B51971B510383Fcb5c246a17"
+// 	bvsdriverevm.RegBVS(evmUserAddr, password, bvsContract)
+// }
 
 func Test_EVMBVSDriverGetOwner(t *testing.T) {
 	bvsdriverevm.GetOwner()

--- a/modules/satlayer-cli/tests/e2e/directory_evm_test.go
+++ b/modules/satlayer-cli/tests/e2e/directory_evm_test.go
@@ -8,13 +8,15 @@ import (
 
 //var evmUserAddr = "0xC97705a8FaA9Bec2A50B5bbCc0661251BcB537A4"
 
-func Test_EVMDirectoryRegBVS(t *testing.T) {
-	var evmUserAddr = "0xC97705a8FaA9Bec2A50B5bbCc0661251BcB537A4"
-	var password = "123"
-	bvsContract := "0xaA0851f2939EF2D8B51971B510383Fcb5c246a17"
-	bvsHash := "226466AF1CF2ECDA66821E7833C325F15037D6BB7CC0CE39A8908587D02C1046"
-	directoryevm.RegBVS(evmUserAddr, password, bvsHash, bvsContract)
-}
+// HACK: SL-96 - disable on chain registration due to hard coded contract address
+// until we can run testnet locally
+// func Test_EVMDirectoryRegBVS(t *testing.T) {
+// 	var evmUserAddr = "0xC97705a8FaA9Bec2A50B5bbCc0661251BcB537A4"
+// 	var password = "123"
+// 	bvsContract := "0xaA0851f2939EF2D8B51971B510383Fcb5c246a17"
+// 	bvsHash := "226466AF1CF2ECDA66821E7833C325F15037D6BB7CC0CE39A8908587D02C1046"
+// 	directoryevm.RegBVS(evmUserAddr, password, bvsHash, bvsContract)
+// }
 
 func Test_EVMDirectoryGetOwner(t *testing.T) {
 	directoryevm.GetOwner()

--- a/modules/satlayer-cli/tests/e2e/state_bank_evm_test.go
+++ b/modules/satlayer-cli/tests/e2e/state_bank_evm_test.go
@@ -6,12 +6,14 @@ import (
 	"github.com/satlayer/satlayer-bvs/satlayer-cli/commands/statebankevm"
 )
 
-func Test_EVMStateBankRegBVS(t *testing.T) {
-	var evmUserAddr = "0xC97705a8FaA9Bec2A50B5bbCc0661251BcB537A4"
-	var password = "123"
-	bvsContract := "0xaA0851f2939EF2D8B51971B510383Fcb5c246a17"
-	statebankevm.RegBVS(evmUserAddr, password, bvsContract)
-}
+// HACK: SL-96 - disable on chain registration due to hard coded contract address
+// until we can run testnet locally
+// func Test_EVMStateBankRegBVS(t *testing.T) {
+// 	var evmUserAddr = "0xC97705a8FaA9Bec2A50B5bbCc0661251BcB537A4"
+// 	var password = "123"
+// 	bvsContract := "0xaA0851f2939EF2D8B51971B510383Fcb5c246a17"
+// 	statebankevm.RegBVS(evmUserAddr, password, bvsContract)
+// }
 
 func Test_EVMStateBankGetOwner(t *testing.T) {
 	statebankevm.GetOwner()


### PR DESCRIPTION
#### What this PR does / why we need it:

as per discussion

> Solution 1 (the proper one)
> 
>     We upload a new contract to EVM every time the tests runs and tests against that new contract (including the subsequent querying)
>     Issue: we do not have infrastructure to upload EVM contracts in our SDK. This part has to be built out.
>         Or if we accept stuff can be dirty. Put EVM contract upload in the test itself as a part of env setup
>     We also need to install/ship a local copy of Solidity compiler + working contract (this part somewhat solved as demo BVS is part of monorepo now)
>         Alternatively, ship a precompiled EVM binary
>     Complicated and will take longer to implement

> I don't think solution 1 is feasible, given test will be run alot in the CI as well.

this at least unblocks us from testing.

disable on chain registration due to hard coded contract addressuntil we can run testnet locally

Remaining draft until onchain state resolved