### PR TITLE
feat(SL-54): add dependabot for go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,8 @@ updates:
     directory: "/crates"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: gomod
+    directory: "/modules"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
#### What this PR does / why we need it:


<!-- remove if not applicable -->
Closes SL-54