### PR TITLE
fix: import external crate to reduce repeated definition

### DIFF
--- a/examples/squaring/cw-squaring-contract/Cargo.lock
+++ b/examples/squaring/cw-squaring-contract/Cargo.lock
@@ -1286,8 +1286,10 @@ version = "0.0.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std 2.1.0",
+ "cw-bvs-driver",
  "cw-bvs-test",
  "cw-multi-test",
+ "cw-state-bank",
  "cw-storage-plus",
  "cw2",
  "schemars",

--- a/examples/squaring/cw-squaring-contract/Cargo.toml
+++ b/examples/squaring/cw-squaring-contract/Cargo.toml
@@ -3,10 +3,7 @@ name = "squaring"
 version = "0.0.0"
 edition = "2021"
 
-exclude = [
-    "contract.wasm",
-    "hash.txt",
-]
+exclude = ["contract.wasm", "hash.txt"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -20,6 +17,8 @@ cosmwasm-std = { version = "=2.1.0", features = [
     # TODO(SL-33): Find out what cosmwasm version is used in Babylon
     "cosmwasm_1_4",
 ] }
+cw-bvs-driver = { path = "../../../crates/cw-bvs-driver" }
+cw-state-bank = { path = "../../../crates/cw-state-bank" }
 cw-storage-plus = "2.0.0"
 cw2 = "2.0.0"
 schemars = "0.8.21"


### PR DESCRIPTION
#### What this PR does / why we need it:

Import external crates to reduce repeated definition in example/squaring codes.

<!-- remove if not applicable -->
Closes SL-36