### PR TITLE
chore: refactor babylond with better DevEx

### DIFF
--- a/modules/babylond/babylond.go
+++ b/modules/babylond/babylond.go
@@ -2,7 +2,6 @@ package babylond
 
 import (
 	"context"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -11,10 +10,8 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 	"google.golang.org/grpc"
 
-	"cosmossdk.io/math"
 	"github.com/CosmWasm/wasmd/x/wasm"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
-	coretypes "github.com/cometbft/cometbft/rpc/core/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
@@ -22,14 +19,12 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
-	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	"github.com/cosmos/cosmos-sdk/std"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/docker/go-connections/nat"
 	"github.com/testcontainers/testcontainers-go"
 	"google.golang.org/grpc/credentials/insecure"
@@ -126,7 +121,7 @@ func newTxFactory(clientCtx client.Context) tx.Factory {
 	return txf
 }
 
-func Run(ctx context.Context) (*BabylonContainer, error) {
+func Run(ctx context.Context) *BabylonContainer {
 	cmd := []string{
 		// Setup Testnet
 		"babylond",
@@ -199,7 +194,7 @@ func Run(ctx context.Context) (*BabylonContainer, error) {
 	})
 
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
 
 	ApiUri := fmt.Sprintf("http://%s", getHost(ctx, container, apiPort))
@@ -215,79 +210,5 @@ func Run(ctx context.Context) (*BabylonContainer, error) {
 		GrpcUri,
 		ClientCtx,
 		TxFactory,
-	}, nil
-}
-
-func (c *BabylonContainer) GenerateAddress(uid string) sdk.AccAddress {
-	record, err := c.ClientCtx.Keyring.Key(uid)
-	if record == nil {
-		privKey := secp256k1.GenPrivKey()
-		err := c.ClientCtx.Keyring.ImportPrivKeyHex(uid, hex.EncodeToString(privKey.Bytes()), "secp256k1")
-		if err != nil {
-			panic(err)
-		}
-
-		record, err = c.ClientCtx.Keyring.Key(uid)
-		if record == nil {
-			panic(err)
-		}
-	} else {
-		if err != nil {
-			panic(err)
-		}
 	}
-
-	address, err := record.GetAddress()
-	if err != nil {
-		panic(err)
-	}
-	return address
-}
-
-func (c *BabylonContainer) FundAccount(address string, coin sdk.Coin) (*coretypes.ResultBroadcastTxCommit, error) {
-	ctx := context.Background()
-
-	from, err := sdk.AccAddressFromBech32("bbn1lmnc4gcvcu5dexa8p6vv2e6qkas5lu2r2nwlnv")
-	if err != nil {
-		return nil, err
-	}
-	to, err := sdk.AccAddressFromBech32(address)
-	if err != nil {
-		return nil, err
-	}
-
-	clientCtx := c.ClientCtx.WithFromName("genesis").WithFromAddress(from)
-	txf, err := c.TxFactory.Prepare(clientCtx)
-	if err != nil {
-		return nil, err
-	}
-
-	txBuilder := clientCtx.TxConfig.NewTxBuilder()
-	txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("ubbn", math.NewInt(1000))))
-	txBuilder.SetGasLimit(200000)
-	msg := banktypes.NewMsgSend(from, to, sdk.NewCoins(coin))
-	err = txBuilder.SetMsgs(msg)
-	if err != nil {
-		return nil, err
-	}
-
-	err = tx.Sign(ctx, txf, clientCtx.FromName, txBuilder, true)
-	if err != nil {
-		return nil, err
-	}
-
-	txBytes, err := clientCtx.TxConfig.TxEncoder()(txBuilder.GetTx())
-	if err != nil {
-		return nil, err
-	}
-
-	node, err := clientCtx.GetNode()
-	if err != nil {
-		return nil, err
-	}
-	return node.BroadcastTxCommit(context.Background(), txBytes)
-}
-
-func (c *BabylonContainer) FundAccountUbbn(address string, amount int64) (*coretypes.ResultBroadcastTxCommit, error) {
-	return c.FundAccount(address, sdk.NewCoin("ubbn", math.NewInt(amount)))
 }

--- a/modules/babylond/babylond_test.go
+++ b/modules/babylond/babylond_test.go
@@ -2,18 +2,8 @@ package babylond
 
 import (
 	"context"
-	"encoding/hex"
 	"testing"
-	"time"
 
-	"cosmossdk.io/math"
-	"github.com/cosmos/cosmos-sdk/client/tx"
-	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/bech32"
-	"github.com/cosmos/cosmos-sdk/types/tx/signing"
-	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
-	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -23,9 +13,7 @@ type BabylondTestSuite struct {
 }
 
 func (s *BabylondTestSuite) SetupSuite() {
-	container, err := Run(context.Background())
-	s.Require().NoError(err)
-	s.Container = container
+	s.Container = Run(context.Background())
 }
 
 func (s *BabylondTestSuite) TearDownSuite() {
@@ -46,115 +34,4 @@ func (s *BabylondTestSuite) TestClientContext() {
 	status, err := clientCtx.Client.Status(context.Background())
 	s.NoError(err)
 	s.GreaterOrEqual(status.SyncInfo.LatestBlockHeight, int64(1))
-}
-
-func (s *BabylondTestSuite) TestGenesisBalance() {
-	clientCtx := s.Container.ClientCtx
-	queryClient := banktypes.NewQueryClient(clientCtx)
-	req := banktypes.QueryBalanceRequest{
-		Address: "bbn1lmnc4gcvcu5dexa8p6vv2e6qkas5lu2r2nwlnv",
-		Denom:   "ubbn",
-	}
-
-	res, err := queryClient.Balance(context.Background(), &req)
-	s.NoError(err)
-	// Greater than 10^16, because the genesis balance is 10^17, concurrently running tests may have spent some
-	s.Greater(res.Balance.Amount.Int64(), int64(1e16))
-}
-
-func (s *BabylondTestSuite) TestSendCoinsManually() {
-	clientCtx := s.Container.ClientCtx
-
-	var receiver sdk.AccAddress
-	sender, err := sdk.AccAddressFromBech32("bbn1lmnc4gcvcu5dexa8p6vv2e6qkas5lu2r2nwlnv")
-	s.NoError(err)
-	privKeyBytes, err := hex.DecodeString("230FAE50A4FFB19125F89D8F321996A46F805E7BCF0CDAC5D102E7A42741887A")
-	s.NoError(err)
-	privKey := secp256k1.PrivKey{Key: privKeyBytes}
-
-	{
-		privateKey := secp256k1.GenPrivKey()
-		address, err := bech32.ConvertAndEncode("bbn", privateKey.PubKey().Address())
-		s.NoError(err)
-
-		receiver, err = sdk.AccAddressFromBech32(address)
-		s.NoError(err)
-	}
-
-	txBuilder := clientCtx.TxConfig.NewTxBuilder()
-	txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("ubbn", math.NewInt(1000))))
-	txBuilder.SetGasLimit(200000)
-
-	msg := banktypes.NewMsgSend(sender, receiver, sdk.NewCoins(sdk.NewCoin("ubbn", math.NewInt(10))))
-	err = txBuilder.SetMsgs(msg)
-	s.NoError(err)
-
-	account, err := clientCtx.AccountRetriever.GetAccount(clientCtx, sender)
-	s.NoError(err)
-
-	signMode := signing.SignMode(clientCtx.TxConfig.SignModeHandler().DefaultMode())
-
-	emptySig := signing.SignatureV2{
-		PubKey: privKey.PubKey(),
-		Data: &signing.SingleSignatureData{
-			SignMode:  signMode,
-			Signature: nil,
-		},
-		Sequence: account.GetSequence(),
-	}
-	err = txBuilder.SetSignatures(emptySig)
-	s.NoError(err)
-
-	signerData := authsigning.SignerData{
-		ChainID:       clientCtx.ChainID,
-		AccountNumber: account.GetAccountNumber(),
-		Sequence:      account.GetSequence(),
-	}
-
-	signV2, err := tx.SignWithPrivKey(
-		context.Background(),
-		signMode,
-		signerData,
-		txBuilder,
-		&privKey,
-		clientCtx.TxConfig,
-		account.GetSequence(),
-	)
-	s.NoError(err)
-
-	err = txBuilder.SetSignatures(signV2)
-	s.NoError(err)
-
-	txBytes, err := clientCtx.TxConfig.TxEncoder()(txBuilder.GetTx())
-	s.NoError(err)
-
-	res, err := clientCtx.BroadcastTx(txBytes)
-	s.NoError(err)
-	s.Equal("", res.RawLog)
-	s.Equal(uint32(0), res.Code)
-	s.Regexp("^[0-9A-F]{64}$", res.TxHash)
-
-	time.Sleep(2 * time.Second)
-
-	queryClient := banktypes.NewQueryClient(clientCtx)
-	balRes, err := queryClient.Balance(context.Background(), &banktypes.QueryBalanceRequest{
-		Address: receiver.String(),
-		Denom:   "ubbn",
-	})
-	s.NoError(err)
-	s.Equal("10ubbn", balRes.Balance.String())
-}
-
-func (s *BabylondTestSuite) TestFundAccount() {
-	res, err := s.Container.FundAccountUbbn("bbn1whhg5wce9g9nn6frehnagh526f6thc7y380jhl", 10000)
-	s.NoError(err)
-	s.Equal(uint32(0), res.TxResult.Code)
-
-	queryClient := banktypes.NewQueryClient(s.Container.ClientCtx)
-	balRes, err := queryClient.Balance(context.Background(), &banktypes.QueryBalanceRequest{
-		Address: "bbn1whhg5wce9g9nn6frehnagh526f6thc7y380jhl",
-		Denom:   "ubbn",
-	})
-	s.NoError(err)
-	s.Equal("10000ubbn", balRes.Balance.String())
 }

--- a/modules/babylond/bvs.go
+++ b/modules/babylond/bvs.go
@@ -1,0 +1,38 @@
+package babylond
+
+import (
+	bvscw "github.com/satlayer/satlayer-bvs/bvs-cw"
+	statebank "github.com/satlayer/satlayer-bvs/bvs-cw/state-bank"
+)
+
+func (c *BabylonContainer) deployCrate(crate string, initMsg []byte, label string) (*DeployedWasmContract, error) {
+	wasmByteCode, err := bvscw.ReadWasmFile(crate)
+	if err != nil {
+		panic(err)
+	}
+
+	return c.StoreAndInitWasm(wasmByteCode, initMsg, label, "genesis")
+}
+
+type DeployedStateBank struct {
+	DeployedWasmContract
+	Owner string
+}
+
+func (c *BabylonContainer) DeployStateBank() *DeployedStateBank {
+	initialOwner := c.GenerateAddress("state-bank:initial_owner").String()
+	initMsg := statebank.InstantiateMsg{InitialOwner: initialOwner}
+	initBytes, err := initMsg.Marshal()
+	if err != nil {
+		panic(err)
+	}
+
+	contract, err := c.deployCrate("bvs-state-bank", initBytes, "BVS State Bank")
+	if err != nil {
+		panic(err)
+	}
+	return &DeployedStateBank{
+		DeployedWasmContract: *contract,
+		Owner:                initialOwner,
+	}
+}

--- a/modules/babylond/chainio.go
+++ b/modules/babylond/chainio.go
@@ -10,13 +10,17 @@ import (
 	transactionprocess "github.com/satlayer/satlayer-bvs/bvs-api/metrics/indicators/transaction_process"
 )
 
-func (c *BabylonContainer) NewChainIO(homeDir string) (io.ChainIO, error) {
+func (c *BabylonContainer) NewChainIO(homeDir string) io.ChainIO {
 	logger := apilogger.NewMockELKLogger()
-	metricsIndicators := transactionprocess.NewPromIndicators(prometheus.NewRegistry(), "io")
-	return io.NewChainIO(ChainId, c.RpcUri, homeDir, "bbn", logger, metricsIndicators, types.TxManagerParams{
+	metricsIndicators := transactionprocess.NewPromIndicators(prometheus.NewRegistry(), "testcontainers")
+	chainIo, err := io.NewChainIO(ChainId, c.RpcUri, homeDir, "bbn", logger, metricsIndicators, types.TxManagerParams{
 		MaxRetries:             3,
 		RetryInterval:          2 * time.Second,
 		ConfirmationTimeout:    60 * time.Second,
 		GasPriceAdjustmentRate: "1.1",
 	})
+	if err != nil {
+		panic(err)
+	}
+	return chainIo
 }

--- a/modules/babylond/chainio_test.go
+++ b/modules/babylond/chainio_test.go
@@ -8,11 +8,8 @@ import (
 )
 
 func TestChainIOQueryNodeStatus(t *testing.T) {
-	container, err := Run(context.Background())
-	assert.NoError(t, err)
-
-	chainIO, err := container.NewChainIO("../.babylon")
-	assert.NoError(t, err)
+	container := Run(context.Background())
+	chainIO := container.NewChainIO("../.babylon")
 
 	status, err := chainIO.QueryNodeStatus(context.Background())
 	assert.NoError(t, err)

--- a/modules/babylond/wallet.go
+++ b/modules/babylond/wallet.go
@@ -1,0 +1,92 @@
+package babylond
+
+import (
+	"context"
+	"encoding/hex"
+
+	"cosmossdk.io/math"
+	coretypes "github.com/cometbft/cometbft/rpc/core/types"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+)
+
+func (c *BabylonContainer) GenerateAddress(uid string) sdk.AccAddress {
+	record, err := c.ClientCtx.Keyring.Key(uid)
+	if record == nil {
+		privKey := secp256k1.GenPrivKey()
+		err := c.ClientCtx.Keyring.ImportPrivKeyHex(uid, hex.EncodeToString(privKey.Bytes()), "secp256k1")
+		if err != nil {
+			panic(err)
+		}
+
+		record, err = c.ClientCtx.Keyring.Key(uid)
+		if record == nil {
+			panic(err)
+		}
+	} else {
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	address, err := record.GetAddress()
+	if err != nil {
+		panic(err)
+	}
+	return address
+}
+
+func (c *BabylonContainer) FundAddress(address string, coin sdk.Coin) *coretypes.ResultBroadcastTxCommit {
+	ctx := context.Background()
+
+	from, err := sdk.AccAddressFromBech32("bbn1lmnc4gcvcu5dexa8p6vv2e6qkas5lu2r2nwlnv")
+	if err != nil {
+		panic(err)
+	}
+	to, err := sdk.AccAddressFromBech32(address)
+	if err != nil {
+		panic(err)
+	}
+
+	clientCtx := c.ClientCtx.WithFromName("genesis").WithFromAddress(from)
+	txf, err := c.TxFactory.Prepare(clientCtx)
+	if err != nil {
+		panic(err)
+	}
+
+	txBuilder := clientCtx.TxConfig.NewTxBuilder()
+	txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("ubbn", math.NewInt(1000))))
+	txBuilder.SetGasLimit(200000)
+	msg := banktypes.NewMsgSend(from, to, sdk.NewCoins(coin))
+	err = txBuilder.SetMsgs(msg)
+	if err != nil {
+		panic(err)
+	}
+
+	err = tx.Sign(ctx, txf, clientCtx.FromName, txBuilder, true)
+	if err != nil {
+		panic(err)
+	}
+
+	txBytes, err := clientCtx.TxConfig.TxEncoder()(txBuilder.GetTx())
+	if err != nil {
+		panic(err)
+	}
+
+	node, err := clientCtx.GetNode()
+	if err != nil {
+		panic(err)
+	}
+	result, err := node.BroadcastTxCommit(context.Background(), txBytes)
+	if err != nil {
+		panic(err)
+	}
+
+	return result
+}
+
+func (c *BabylonContainer) FundAddressUbbn(address string, amount int64) *coretypes.ResultBroadcastTxCommit {
+	return c.FundAddress(address, sdk.NewCoin("ubbn", math.NewInt(amount)))
+}

--- a/modules/babylond/wallet_test.go
+++ b/modules/babylond/wallet_test.go
@@ -1,0 +1,145 @@
+package babylond
+
+import (
+	"context"
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"cosmossdk.io/math"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/bech32"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/stretchr/testify/suite"
+)
+
+type WalletTestSuite struct {
+	suite.Suite
+	Container *BabylonContainer
+}
+
+func (s *WalletTestSuite) SetupSuite() {
+	s.Container = Run(context.Background())
+}
+
+func (s *WalletTestSuite) TearDownSuite() {
+	s.Require().NoError(s.Container.Container.Terminate(context.Background()))
+}
+
+func TestWallet(t *testing.T) {
+	suite.Run(t, new(WalletTestSuite))
+}
+
+func (s *WalletTestSuite) TestGenesisBalance() {
+	clientCtx := s.Container.ClientCtx
+	queryClient := banktypes.NewQueryClient(clientCtx)
+	req := banktypes.QueryBalanceRequest{
+		Address: "bbn1lmnc4gcvcu5dexa8p6vv2e6qkas5lu2r2nwlnv",
+		Denom:   "ubbn",
+	}
+
+	res, err := queryClient.Balance(context.Background(), &req)
+	s.NoError(err)
+	// Greater than 10^16, because the genesis balance is 10^17, concurrently running tests may have spent some
+	s.Greater(res.Balance.Amount.Int64(), int64(1e16))
+}
+
+func (s *WalletTestSuite) TestSendCoinsManually() {
+	clientCtx := s.Container.ClientCtx
+
+	var receiver sdk.AccAddress
+	sender, err := sdk.AccAddressFromBech32("bbn1lmnc4gcvcu5dexa8p6vv2e6qkas5lu2r2nwlnv")
+	s.NoError(err)
+	privKeyBytes, err := hex.DecodeString("230FAE50A4FFB19125F89D8F321996A46F805E7BCF0CDAC5D102E7A42741887A")
+	s.NoError(err)
+	privKey := secp256k1.PrivKey{Key: privKeyBytes}
+
+	{
+		privateKey := secp256k1.GenPrivKey()
+		address, err := bech32.ConvertAndEncode("bbn", privateKey.PubKey().Address())
+		s.NoError(err)
+
+		receiver, err = sdk.AccAddressFromBech32(address)
+		s.NoError(err)
+	}
+
+	txBuilder := clientCtx.TxConfig.NewTxBuilder()
+	txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("ubbn", math.NewInt(1000))))
+	txBuilder.SetGasLimit(200000)
+
+	msg := banktypes.NewMsgSend(sender, receiver, sdk.NewCoins(sdk.NewCoin("ubbn", math.NewInt(10))))
+	err = txBuilder.SetMsgs(msg)
+	s.NoError(err)
+
+	account, err := clientCtx.AccountRetriever.GetAccount(clientCtx, sender)
+	s.NoError(err)
+
+	signMode := signing.SignMode(clientCtx.TxConfig.SignModeHandler().DefaultMode())
+
+	emptySig := signing.SignatureV2{
+		PubKey: privKey.PubKey(),
+		Data: &signing.SingleSignatureData{
+			SignMode:  signMode,
+			Signature: nil,
+		},
+		Sequence: account.GetSequence(),
+	}
+	err = txBuilder.SetSignatures(emptySig)
+	s.NoError(err)
+
+	signerData := authsigning.SignerData{
+		ChainID:       clientCtx.ChainID,
+		AccountNumber: account.GetAccountNumber(),
+		Sequence:      account.GetSequence(),
+	}
+
+	signV2, err := tx.SignWithPrivKey(
+		context.Background(),
+		signMode,
+		signerData,
+		txBuilder,
+		&privKey,
+		clientCtx.TxConfig,
+		account.GetSequence(),
+	)
+	s.NoError(err)
+
+	err = txBuilder.SetSignatures(signV2)
+	s.NoError(err)
+
+	txBytes, err := clientCtx.TxConfig.TxEncoder()(txBuilder.GetTx())
+	s.NoError(err)
+
+	res, err := clientCtx.BroadcastTx(txBytes)
+	s.NoError(err)
+	s.Equal("", res.RawLog)
+	s.Equal(uint32(0), res.Code)
+	s.Regexp("^[0-9A-F]{64}$", res.TxHash)
+
+	time.Sleep(2 * time.Second)
+
+	queryClient := banktypes.NewQueryClient(clientCtx)
+	balRes, err := queryClient.Balance(context.Background(), &banktypes.QueryBalanceRequest{
+		Address: receiver.String(),
+		Denom:   "ubbn",
+	})
+	s.NoError(err)
+	s.Equal("10ubbn", balRes.Balance.String())
+}
+
+func (s *WalletTestSuite) TestFundAddress() {
+	res := s.Container.FundAddressUbbn("bbn1whhg5wce9g9nn6frehnagh526f6thc7y380jhl", 10000)
+	s.Equal(uint32(0), res.TxResult.Code)
+
+	queryClient := banktypes.NewQueryClient(s.Container.ClientCtx)
+	balRes, err := queryClient.Balance(context.Background(), &banktypes.QueryBalanceRequest{
+		Address: "bbn1whhg5wce9g9nn6frehnagh526f6thc7y380jhl",
+		Denom:   "ubbn",
+	})
+	s.NoError(err)
+	s.Equal("10000ubbn", balRes.Balance.String())
+}

--- a/modules/babylond/wasm.go
+++ b/modules/babylond/wasm.go
@@ -11,8 +11,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
-	bvscw "github.com/satlayer/satlayer-bvs/bvs-cw"
 )
 
 type DeployedWasmContract struct {
@@ -20,16 +18,7 @@ type DeployedWasmContract struct {
 	Address string
 }
 
-func (c *BabylonContainer) DeployCrate(crate string, initMsg []byte, label, from string) (*DeployedWasmContract, error) {
-	wasmByteCode, err := bvscw.ReadWasmFile(crate)
-	if err != nil {
-		panic(err)
-	}
-
-	return c.DeployWasmCode(wasmByteCode, initMsg, label, from)
-}
-
-func (c *BabylonContainer) DeployWasmCode(wasmByteCode []byte, initMsg []byte, label, from string) (*DeployedWasmContract, error) {
+func (c *BabylonContainer) StoreAndInitWasm(wasmByteCode []byte, initMsg []byte, label, from string) (*DeployedWasmContract, error) {
 	res, err := c.StoreWasmCode(wasmByteCode, from)
 	if err != nil {
 		panic(err)

--- a/modules/babylond/wasm_test.go
+++ b/modules/babylond/wasm_test.go
@@ -14,9 +14,7 @@ type WasmTestSuite struct {
 }
 
 func (s *WasmTestSuite) SetupSuite() {
-	container, err := Run(context.Background())
-	s.Require().NoError(err)
-	s.Container = container
+	s.Container = Run(context.Background())
 }
 
 func (s *WasmTestSuite) TearDownSuite() {

--- a/modules/bvs-api/tests/e2e/statebank_test.go
+++ b/modules/bvs-api/tests/e2e/statebank_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/satlayer/satlayer-bvs/babylond"
 	"github.com/satlayer/satlayer-bvs/bvs-api/chainio/api"
 	"github.com/satlayer/satlayer-bvs/bvs-api/chainio/io"
-	statebank "github.com/satlayer/satlayer-bvs/bvs-cw/state-bank"
 )
 
 type stateBankTestSuite struct {
@@ -23,24 +22,12 @@ type stateBankTestSuite struct {
 }
 
 func (suite *stateBankTestSuite) SetupTest() {
-	container, err := babylond.Run(context.Background())
-	suite.Require().NoError(err)
+	container := babylond.Run(context.Background())
+	container.FundAddressUbbn("bbn1dcpzdejnywqc4x8j5tyafv7y4pdmj7p9fmredf", 1e8)
 
-	owner := container.GenerateAddress("initial_owner").String()
-	initMsg := statebank.InstantiateMsg{InitialOwner: owner}
-	initBytes, err := initMsg.Marshal()
-	suite.Require().NoError(err)
-	contract, err := container.DeployCrate("bvs-state-bank", initBytes, "BVS State Bank", "genesis")
-	suite.Require().NoError(err)
-
-	suite.contrAddr = contract.Address
+	suite.contrAddr = container.DeployStateBank().Address
 	suite.callerAddr = "bbn1dcpzdejnywqc4x8j5tyafv7y4pdmj7p9fmredf"
-	_, err = container.FundAccountUbbn("bbn1dcpzdejnywqc4x8j5tyafv7y4pdmj7p9fmredf", 1e8)
-	suite.Require().NoError(err)
-
-	chainIO, err := container.NewChainIO("../.babylon")
-	suite.Require().NoError(err)
-	suite.chainIO = chainIO
+	suite.chainIO = container.NewChainIO("../.babylon")
 }
 
 func (suite *stateBankTestSuite) Test_ExecuteStateBank() {


### PR DESCRIPTION
#### What this PR does / why we need it:

Make it easier to set up a test suite—because we're going to write a lot of tests in `./modules`.
Code in `babylond` will panic (fail early) instead of returning an erroring. Less `suite.Require().NoError(err)` to write.

```go
func (suite *stateBankTestSuite) SetupTest() {
    container := babylond.Run(context.Background())
    container.FundAddressUbbn("bbn1dcpzdejnywqc4x8j5tyafv7y4pdmj7p9fmredf", 1e8)

    suite.contrAddr = container.DeployStateBank().Address
    suite.callerAddr = "bbn1dcpzdejnywqc4x8j5tyafv7y4pdmj7p9fmredf"
    suite.chainIO = container.NewChainIO("../.babylon")
}
```