### PR TITLE
chore: use gotestsum for bvs-cli

### DIFF
--- a/modules/bvs-cli/commands/chain/query.go
+++ b/modules/bvs-cli/commands/chain/query.go
@@ -32,7 +32,7 @@ func QueryTxn(txnHash string) {
 		fmt.Printf("Query Txn Failed. Error msg: %s", err)
 		return
 	}
-	fmt.Printf("===TxnInfo===\n1. Index: %d\n2. TxHash: %s\n3. Height: %d\n4. Events: %s\n", resp.Index, resp.Hash.String(), resp.Height, resp.TxResult.Events)
+	fmt.Printf("===TxnInfo===\n1. Index: %d\n2. TxHash: %s\n3. Height: %d\n4. Events: %+v\n", resp.Index, resp.Hash.String(), resp.Height, resp.TxResult.Events)
 }
 
 func QueryAccount(account string) {

--- a/modules/bvs-cli/package.json
+++ b/modules/bvs-cli/package.json
@@ -2,8 +2,7 @@
   "name": "@modules/bvs-cli",
   "private": true,
   "scripts": {
-    "build": "go build -o ${PWD}/dist/bvs-cli .",
-    "test": "export SATLAYER_CONFIG=${PWD}/tests/config.toml && go test -v ${PWD}/tests/...",
-    "test:e2e": "export SATLAYER_CONFIG=${PWD}/tests/config.toml && go test -v ${PWD}/tests/e2e/..."
+    "build": "go build -o ./dist/bvs-cli .",
+    "test": "export SATLAYER_CONFIG=${PWD}/tests/config.toml && gotestsum"
   }
 }

--- a/modules/bvs-cli/turbo.json
+++ b/modules/bvs-cli/turbo.json
@@ -6,10 +6,6 @@
       "inputs": ["**.go"],
       "dependsOn": ["@modules/bvs-cw#generate:schema"]
     },
-    "test:e2e": {
-      "inputs": ["**.go"],
-      "dependsOn": ["@modules/bvs-cw#generate:schema"]
-    },
     "build": {
       "inputs": ["**.go"],
       "outputs": ["dist"],

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
     "build": "turbo run build",
     "format": "prettier --write .",
     "prepare": "husky",
-    "test": "turbo run test",
-    "test:e2e": "turbo run test:e2e"
+    "test": "turbo run test"
   },
   "lint-staged": {
     "*": [

--- a/turbo.json
+++ b/turbo.json
@@ -24,10 +24,6 @@
       "dependsOn": ["^build"],
       "env": ["GOTESTSUM_JUNITFILE"]
     },
-    "test:e2e": {
-      "inputs": ["tsconfig.json", "tsconfig.build.json", "src/**"],
-      "dependsOn": ["^build"]
-    },
     "eslint": {
       "cache": false,
       "outputLogs": "errors-only"


### PR DESCRIPTION
#### What this PR does / why we need it:

Use `gotestsum` for `bvs-cli`. 

This PR also fixes an obvious error.

Closes SL-155