### PR TITLE
chore: missing suite.container during teardown

### DIFF
--- a/modules/bvs-api/tests/e2e/chainio_test.go
+++ b/modules/bvs-api/tests/e2e/chainio_test.go
@@ -24,6 +24,7 @@ type ioTestSuite struct {
 
 func (suite *ioTestSuite) SetupSuite() {
 	container := babylond.Run(context.Background())
+	suite.container = container
 	suite.chainIO = container.NewChainIO("../.babylon")
 	container.FundAddressUbbn("bbn1dcpzdejnywqc4x8j5tyafv7y4pdmj7p9fmredf", 1e8)
 

--- a/modules/bvs-api/tests/e2e/slash_manager_test.go
+++ b/modules/bvs-api/tests/e2e/slash_manager_test.go
@@ -26,6 +26,7 @@ type slashManagerTestSuite struct {
 
 func (suite *slashManagerTestSuite) SetupSuite() {
 	container := babylond.Run(context.Background())
+	suite.container = container
 	suite.chainIO = container.NewChainIO("../.babylon")
 
 	// Import And Fund Caller

--- a/modules/bvs-api/tests/e2e/strategy_base_tvl_limits_test.go
+++ b/modules/bvs-api/tests/e2e/strategy_base_tvl_limits_test.go
@@ -26,6 +26,7 @@ type strategyBaseTVLLimitsTestSuite struct {
 func (suite *strategyBaseTVLLimitsTestSuite) SetupSuite() {
 	container := babylond.Run(context.Background())
 	suite.chainIO = container.NewChainIO("../.babylon")
+	suite.container = container
 	container.FundAddressUbbn("bbn1dcpzdejnywqc4x8j5tyafv7y4pdmj7p9fmredf", 1e8)
 
 	deployer := &bvs.Deployer{BabylonContainer: container}


### PR DESCRIPTION
#### What this PR does / why we need it:

Add missing `suite.container`.