### PR TITLE
chore: automate release-labeling and release-drafting

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,34 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+categories:
+  - title: "Babylon Contracts (cosmos)"
+    labels: ["a/crates"]
+
+  - title: "@modules/babylond"
+    labels: ["a/modules/babylond"]
+
+  - title: "@modules/bvs-api"
+    labels: ["a/modules/bvs-api"]
+
+  - title: "@modules/bvs-cli"
+    labels: ["a/modules/bvs-cli"]
+
+  - title: "@modules/bvs-cw"
+    labels: ["a/modules/bvs-cw"]
+
+  - title: "@examples"
+    collapse-after: 5
+    labels: ["a/examples"]
+
+  - title: "Documentation"
+    collapse-after: 5
+    labels: ["a/docs"]
+sort-by: title
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+change-title-escapes: '\<*_&'
+version-resolver:
+  minor:
+    labels: ["s/feat"]
+  default: patch
+template: |
+  $CHANGES

--- a/.github/release-labeling.yml
+++ b/.github/release-labeling.yml
@@ -1,0 +1,63 @@
+version: v1
+
+labels:
+  - label: s/feat
+    sync: true
+    matcher:
+      title: "^feat: .+"
+
+  - label: s/fix
+    sync: true
+    matcher:
+      title: "^fix: .+"
+
+  - label: s/chore
+    sync: true
+    matcher:
+      title: "^chore(\\(.+\\))?: .+"
+
+  - label: a/crates
+    sync: true
+    matcher:
+      files: "crates/**"
+
+  - label: a/docs
+    sync: true
+    matcher:
+      files: "docs/**"
+
+  - label: a/examples
+    sync: true
+    matcher:
+      files: "examples/**"
+
+  - label: a/modules/babylond
+    sync: true
+    matcher:
+      files: "modules/babylond/**"
+
+  - label: a/modules/bvs-api
+    sync: true
+    matcher:
+      files: "modules/bvs-api/**"
+
+  - label: a/modules/bvs-cli
+    sync: true
+    matcher:
+      files: "modules/bvs-cli/**"
+
+  - label: a/modules/bvs-cw
+    sync: true
+    matcher:
+      files: "modules/bvs-cw/**"
+
+checks:
+  - context: "Semantic Pull Request"
+    description:
+      success: Ready for review & merge.
+      failure: "Missing semantic title [feat/fix/chore(optional): what's change]"
+    labels:
+      any:
+        - s/feat
+        - s/fix
+        - s/chore

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,21 @@
+name: Release Drafter
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+          disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-labeling.yml
+++ b/.github/workflows/release-labeling.yml
@@ -1,0 +1,21 @@
+name: Release Labeling
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  statuses: write
+  checks: write
+
+jobs:
+  main:
+    name: Labeler
+    runs-on: ubuntu-latest
+    steps:
+      - uses: fuxingloh/multi-labeler@v4
+        with:
+          config-path: .github/labeling.yml


### PR DESCRIPTION
#### What this PR does / why we need it:

Set up an automated release-labeling system via semantic title and changed files.
This will automate release-drafting based on the labeled PRs.

Closes SL-47