### PR TITLE
chore: use SetupSuite instead of SetupTest

### DIFF
--- a/modules/bvs-api/tests/e2e/strategy_base_test.go
+++ b/modules/bvs-api/tests/e2e/strategy_base_test.go
@@ -23,7 +23,7 @@ type strategyBaseTestSuite struct {
 	container       *babylond.BabylonContainer
 }
 
-func (suite *strategyBaseTestSuite) SetupTest() {
+func (suite *strategyBaseTestSuite) SetupSuite() {
 	container := babylond.Run(context.Background())
 	suite.chainIO = container.NewChainIO("../.babylon")
 	suite.container = container


### PR DESCRIPTION
#### What this PR does / why we need it:

For faster test.

Closes SL-174