### PR TITLE
chore: dependabot reduce noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,13 +10,22 @@ updates:
     schedule:
       interval: "daily"
     groups:
-      dev:
-        dependency-type: development
+      eslint:
         update-types:
           - "minor"
           - "patch"
-        exclude-patterns:
-          - "typescript"
+        include:
+          - "eslint"
+          - "husky"
+          - "lint-staged"
+          - "@eslint/*"
+          - "eslint-*"
+          - "globals"
+          - "*-eslint-*"
+      prettier:
+        include:
+          - "prettier"
+          - "prettier-plugin-*"
 
   - package-ecosystem: cargo
     directory: "/crates"


### PR DESCRIPTION
#### What this PR does / why we need it:

Too much updates, reducing to focused groups.