### PR TITLE
chore: disable failing cli tests

### DIFF
--- a/modules/bvs-cli/tests/e2e/slash_test.go
+++ b/modules/bvs-cli/tests/e2e/slash_test.go
@@ -8,7 +8,8 @@ import (
 
 var slashKeyName = "caller"
 
-func Test_GetSlashDetails(t *testing.T) {
+// TODO: Disable failing test, to be fixed in SL-182
+func test_GetSlashDetails(t *testing.T) {
 	slashHash := "8644527532e4230b12809aade8cf2aa018b24e7c1f1051562d653744cc49bcab"
 	slash.GetSlashDetails(slashHash)
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

Disable failing CLI crates unnecessary noise. To be tackled in SL-182