### PR TITLE
chore: examples missing bvs-cli dependency

### DIFF
--- a/examples/squaring/modules/package.json
+++ b/examples/squaring/modules/package.json
@@ -11,6 +11,7 @@
     "test": "gotestsum"
   },
   "dependencies": {
+    "@modules/bvs-api": "workspace:*",
     "@modules/bvs-cli": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
 
   examples/squaring/modules:
     dependencies:
+      '@modules/bvs-api':
+        specifier: workspace:*
+        version: link:../../../modules/bvs-api
       '@modules/bvs-cli':
         specifier: workspace:*
         version: link:../../../modules/bvs-cli


### PR DESCRIPTION
#### What this PR does / why we need it:

`@modules/bvs-cli` was missing in example project, this cause `turbo test` not to automatically re-run tests when sources were updated. Also, separate `build:*` steps into their own scripts.

```json
"dependencies": {
  "@modules/bvs-cli": "workspace:*"
}
```