### PR TITLE
feat: make  public and consistent

### DIFF
--- a/modules/bvs-api/chainio/api/delegation_manager.go
+++ b/modules/bvs-api/chainio/api/delegation_manager.go
@@ -20,7 +20,7 @@ const zeroValueAddr = "0"
 
 type DelegationManager struct {
 	io            io.ChainIO
-	contractAddr  string
+	ContractAddr  string
 	gasAdjustment float64
 	gasPrice      sdktypes.DecCoin
 	gasLimit      uint64
@@ -29,7 +29,7 @@ type DelegationManager struct {
 func NewDelegationManager(chainIO io.ChainIO, contractAddr string) *DelegationManager {
 	return &DelegationManager{
 		io:            chainIO,
-		contractAddr:  contractAddr,
+		ContractAddr:  contractAddr,
 		gasAdjustment: 1.2,
 		gasPrice:      sdktypes.NewInt64DecCoin("ubbn", 1),
 		gasLimit:      700000,
@@ -74,7 +74,7 @@ func (r *DelegationManager) RegisterAsOperator(
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.contractAddr, executeMsgBytes, "RegisterAsOperator")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "RegisterAsOperator")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
@@ -97,7 +97,7 @@ func (r *DelegationManager) ModifyOperatorDetails(
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.contractAddr, executeMsgBytes, "ModifyOperatorDetails")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "ModifyOperatorDetails")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
@@ -110,7 +110,7 @@ func (r *DelegationManager) UpdateOperatorMetadataURI(ctx context.Context, metad
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.contractAddr, executeMsgBytes, "UpdateOperatorMetadataURI")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "UpdateOperatorMetadataURI")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
@@ -144,7 +144,7 @@ func (r *DelegationManager) DelegateTo(ctx context.Context, operator, approver, 
 			ApproverPublicKey: base64.StdEncoding.EncodeToString(approverPublicKey.Bytes()),
 			ApproverSalt:      base64.StdEncoding.EncodeToString([]byte(salt)),
 			Expiry:            expiry,
-			ContractAddr:      r.contractAddr,
+			ContractAddr:      r.ContractAddr,
 		}
 		hashBytes, err := r.DelegationApprovalDigestHash(digestHashParams)
 		if err != nil {
@@ -168,7 +168,7 @@ func (r *DelegationManager) DelegateTo(ctx context.Context, operator, approver, 
 		return nil, err
 	}
 
-	executeOptions := r.newExecuteOptions(r.contractAddr, executeMsgBytes, "DelegateTo")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "DelegateTo")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
@@ -193,7 +193,7 @@ func (r *DelegationManager) DelegateToBySignature(
 		Operator:        operator,
 		StakerPublicKey: base64.StdEncoding.EncodeToString(stakerPublicKey.Bytes()),
 		Expiry:          expiry,
-		ContractAddr:    r.contractAddr,
+		ContractAddr:    r.ContractAddr,
 	}
 	stakerHashBytes, err := r.StakerDelegationDigestHash(digestHashParams)
 	if err != nil {
@@ -231,7 +231,7 @@ func (r *DelegationManager) DelegateToBySignature(
 			ApproverPublicKey: base64.StdEncoding.EncodeToString(approverPublicKey.Bytes()),
 			ApproverSalt:      base64.StdEncoding.EncodeToString([]byte(salt)),
 			Expiry:            expiry,
-			ContractAddr:      r.contractAddr,
+			ContractAddr:      r.ContractAddr,
 		}
 		approverHashBytes, err := r.DelegationApprovalDigestHash(approverDigestHashReq)
 		if err != nil {
@@ -253,7 +253,7 @@ func (r *DelegationManager) DelegateToBySignature(
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.contractAddr, executeMsgBytes, "DelegateToBySignature")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "DelegateToBySignature")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
@@ -266,7 +266,7 @@ func (r *DelegationManager) UnDelegate(ctx context.Context, staker string) (*cor
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.contractAddr, executeMsgBytes, "UnDelegate")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "UnDelegate")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
@@ -281,7 +281,7 @@ func (r *DelegationManager) QueueWithdrawals(ctx context.Context, withdrawalPara
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.contractAddr, executeMsgBytes, "QueueWithdrawals")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "QueueWithdrawals")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
@@ -305,7 +305,7 @@ func (r *DelegationManager) CompleteQueuedWithdrawal(
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.contractAddr, executeMsgBytes, "CompleteQueuedWithdrawal")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "CompleteQueuedWithdrawal")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
@@ -329,7 +329,7 @@ func (r *DelegationManager) CompleteQueuedWithdrawals(
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.contractAddr, executeMsgBytes, "CompleteQueuedWithdrawals")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "CompleteQueuedWithdrawals")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
@@ -346,7 +346,7 @@ func (r *DelegationManager) IncreaseDelegatedShares(ctx context.Context, staker,
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.contractAddr, executeMsgBytes, "IncreaseDelegatedShares")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "IncreaseDelegatedShares")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
@@ -363,7 +363,7 @@ func (r *DelegationManager) DecreaseDelegatedShares(ctx context.Context, staker,
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.contractAddr, executeMsgBytes, "DecreaseDelegatedShares")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "DecreaseDelegatedShares")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
@@ -378,7 +378,7 @@ func (r *DelegationManager) SetMinWithdrawalDelayBlocks(ctx context.Context, new
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.contractAddr, executeMsgBytes, "SetMinWithdrawalDelayBlocks")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "SetMinWithdrawalDelayBlocks")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
@@ -394,7 +394,7 @@ func (r *DelegationManager) SetStrategyWithdrawalDelayBlocks(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.contractAddr, executeMsgBytes, "SetStrategyWithdrawalDelayBlocks")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "SetStrategyWithdrawalDelayBlocks")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
@@ -407,7 +407,7 @@ func (r *DelegationManager) TransferOwnership(ctx context.Context, newOwner stri
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.contractAddr, executeMsgBytes, "TransferOwnership")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "TransferOwnership")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
@@ -420,7 +420,7 @@ func (r *DelegationManager) Pause(ctx context.Context) (*coretypes.ResultTx, err
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.contractAddr, executeMsgBytes, "Pause")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "Pause")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
@@ -433,7 +433,7 @@ func (r *DelegationManager) Unpause(ctx context.Context) (*coretypes.ResultTx, e
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.contractAddr, executeMsgBytes, "Unpause")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "Unpause")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
@@ -446,7 +446,7 @@ func (r *DelegationManager) SetPauser(ctx context.Context, newPauser string) (*c
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.contractAddr, executeMsgBytes, "SetPauser")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "SetPauser")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
@@ -459,7 +459,7 @@ func (r *DelegationManager) SetUnpauser(ctx context.Context, newUnpauser string)
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.contractAddr, executeMsgBytes, "SetUnpauser")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "SetUnpauser")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
@@ -472,7 +472,7 @@ func (r *DelegationManager) SetSlashManager(ctx context.Context, newSlashManager
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.contractAddr, executeMsgBytes, "SetSlashManager")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "SetSlashManager")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
@@ -486,7 +486,7 @@ func (r *DelegationManager) IsDelegated(staker string) (*delegationmanager.Deleg
 	if err != nil {
 		return nil, err
 	}
-	queryOptions := r.newQueryOptions(r.contractAddr, queryMsgBytes)
+	queryOptions := r.newQueryOptions(r.ContractAddr, queryMsgBytes)
 	resp, err := r.io.QueryContract(queryOptions)
 	if err != nil {
 		return nil, err
@@ -506,7 +506,7 @@ func (r *DelegationManager) IsOperator(operator string) (*delegationmanager.Oper
 	if err != nil {
 		return nil, err
 	}
-	queryOptions := r.newQueryOptions(r.contractAddr, queryMsgBytes)
+	queryOptions := r.newQueryOptions(r.ContractAddr, queryMsgBytes)
 	resp, err := r.io.QueryContract(queryOptions)
 	if err != nil {
 		return nil, err
@@ -526,7 +526,7 @@ func (r *DelegationManager) OperatorDetails(operator string) (*delegationmanager
 	if err != nil {
 		return nil, err
 	}
-	queryOptions := r.newQueryOptions(r.contractAddr, queryMsgBytes)
+	queryOptions := r.newQueryOptions(r.ContractAddr, queryMsgBytes)
 	resp, err := r.io.QueryContract(queryOptions)
 	if err != nil {
 		return nil, err
@@ -546,7 +546,7 @@ func (r *DelegationManager) DelegationApprover(operator string) (*delegationmana
 	if err != nil {
 		return nil, err
 	}
-	queryOptions := r.newQueryOptions(r.contractAddr, queryMsgBytes)
+	queryOptions := r.newQueryOptions(r.ContractAddr, queryMsgBytes)
 	resp, err := r.io.QueryContract(queryOptions)
 	if err != nil {
 		return nil, err
@@ -566,7 +566,7 @@ func (r *DelegationManager) StakerOptOutWindowBlocks(operator string) (*delegati
 	if err != nil {
 		return nil, err
 	}
-	queryOptions := r.newQueryOptions(r.contractAddr, queryMsgBytes)
+	queryOptions := r.newQueryOptions(r.ContractAddr, queryMsgBytes)
 	resp, err := r.io.QueryContract(queryOptions)
 	if err != nil {
 		return nil, err
@@ -589,7 +589,7 @@ func (r *DelegationManager) GetOperatorShares(operator string, strategies []stri
 	if err != nil {
 		return nil, err
 	}
-	queryOptions := r.newQueryOptions(r.contractAddr, queryMsgBytes)
+	queryOptions := r.newQueryOptions(r.ContractAddr, queryMsgBytes)
 	resp, err := r.io.QueryContract(queryOptions)
 	if err != nil {
 		return nil, err
@@ -609,7 +609,7 @@ func (r *DelegationManager) GetOperatorStakers(operator string) (*delegationmana
 	if err != nil {
 		return nil, err
 	}
-	queryOptions := r.newQueryOptions(r.contractAddr, queryMsgBytes)
+	queryOptions := r.newQueryOptions(r.ContractAddr, queryMsgBytes)
 	resp, err := r.io.QueryContract(queryOptions)
 	if err != nil {
 		return nil, err
@@ -629,7 +629,7 @@ func (r *DelegationManager) GetDelegatableShares(staker string) (*delegationmana
 	if err != nil {
 		return nil, err
 	}
-	queryOptions := r.newQueryOptions(r.contractAddr, queryMsgBytes)
+	queryOptions := r.newQueryOptions(r.ContractAddr, queryMsgBytes)
 	resp, err := r.io.QueryContract(queryOptions)
 	if err != nil {
 		return nil, err
@@ -649,7 +649,7 @@ func (r *DelegationManager) GetWithdrawalDelay(strategies []string) (*delegation
 	if err != nil {
 		return nil, err
 	}
-	queryOptions := r.newQueryOptions(r.contractAddr, queryMsgBytes)
+	queryOptions := r.newQueryOptions(r.ContractAddr, queryMsgBytes)
 	resp, err := r.io.QueryContract(queryOptions)
 	if err != nil {
 		return nil, err
@@ -669,7 +669,7 @@ func (r *DelegationManager) CalculateWithdrawalRoot(withdrawal delegationmanager
 	if err != nil {
 		return nil, err
 	}
-	queryOptions := r.newQueryOptions(r.contractAddr, queryMsgBytes)
+	queryOptions := r.newQueryOptions(r.ContractAddr, queryMsgBytes)
 	resp, err := r.io.QueryContract(queryOptions)
 	if err != nil {
 		return nil, err
@@ -691,7 +691,7 @@ func (r *DelegationManager) CalculateCurrentStakerDelegationDigestHash(stakerDig
 	if err != nil {
 		return nil, err
 	}
-	queryOptions := r.newQueryOptions(r.contractAddr, queryMsgBytes)
+	queryOptions := r.newQueryOptions(r.ContractAddr, queryMsgBytes)
 	resp, err := r.io.QueryContract(queryOptions)
 	if err != nil {
 		return nil, err
@@ -713,7 +713,7 @@ func (r *DelegationManager) StakerDelegationDigestHash(stakerDigestHashParams de
 	if err != nil {
 		return nil, err
 	}
-	queryOptions := r.newQueryOptions(r.contractAddr, queryMsgBytes)
+	queryOptions := r.newQueryOptions(r.ContractAddr, queryMsgBytes)
 	resp, err := r.io.QueryContract(queryOptions)
 	if err != nil {
 		return nil, err
@@ -735,7 +735,7 @@ func (r *DelegationManager) DelegationApprovalDigestHash(digestHashParams delega
 	if err != nil {
 		return nil, err
 	}
-	queryOptions := r.newQueryOptions(r.contractAddr, queryMsgBytes)
+	queryOptions := r.newQueryOptions(r.ContractAddr, queryMsgBytes)
 	resp, err := r.io.QueryContract(queryOptions)
 	if err != nil {
 		return nil, err
@@ -755,7 +755,7 @@ func (r *DelegationManager) GetStakerNonce(staker string) (*delegationmanager.St
 	if err != nil {
 		return nil, err
 	}
-	queryOptions := r.newQueryOptions(r.contractAddr, queryMsgBytes)
+	queryOptions := r.newQueryOptions(r.ContractAddr, queryMsgBytes)
 	resp, err := r.io.QueryContract(queryOptions)
 	if err != nil {
 		return nil, err
@@ -775,7 +775,7 @@ func (r *DelegationManager) GetCumulativeWithdrawalsQueuedNonce(staker string) (
 	if err != nil {
 		return nil, err
 	}
-	queryOptions := r.newQueryOptions(r.contractAddr, queryMsgBytes)
+	queryOptions := r.newQueryOptions(r.ContractAddr, queryMsgBytes)
 	resp, err := r.io.QueryContract(queryOptions)
 	if err != nil {
 		return nil, err

--- a/modules/bvs-api/chainio/api/directory.go
+++ b/modules/bvs-api/chainio/api/directory.go
@@ -17,7 +17,7 @@ import (
 
 type Directory struct {
 	io            io.ChainIO
-	contractAddr  string
+	ContractAddr  string
 	gasAdjustment float64
 	gasPrice      sdktypes.DecCoin
 	gasLimit      uint64
@@ -26,7 +26,7 @@ type Directory struct {
 func NewDirectory(chainIO io.ChainIO, contractAddr string) *Directory {
 	return &Directory{
 		io:            chainIO,
-		contractAddr:  contractAddr,
+		ContractAddr:  contractAddr,
 		gasAdjustment: 1.2,
 		gasPrice:      sdktypes.NewInt64DecCoin("ubbn", 1),
 		gasLimit:      700000,
@@ -56,7 +56,7 @@ func (r *Directory) RegisterBvs(ctx context.Context, bvsContract string) (*coret
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.contractAddr, executeMsgBytes, "RegisterBvs")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "RegisterBvs")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
@@ -89,7 +89,7 @@ func (r *Directory) RegisterOperator(ctx context.Context, operator string, publi
 	executeMsg := directory.ExecuteMsg{RegisterOperatorToBvs: &directory.RegisterOperatorToBvs{
 		Operator:     operator,
 		PublicKey:    base64.StdEncoding.EncodeToString(publicKey.Bytes()),
-		ContractAddr: r.contractAddr,
+		ContractAddr: r.ContractAddr,
 		SignatureWithSaltAndExpiry: directory.ExecuteSignatureWithSaltAndExpiry{
 			Signature: sig,
 			Salt:      base64.StdEncoding.EncodeToString([]byte(salt)),
@@ -100,7 +100,7 @@ func (r *Directory) RegisterOperator(ctx context.Context, operator string, publi
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.contractAddr, executeMsgBytes, "RegisterOperator")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "RegisterOperator")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
@@ -111,7 +111,7 @@ func (r *Directory) DeregisterOperator(ctx context.Context, operator string) (*c
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.contractAddr, executeMsgBytes, "DeregisterOperator")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "DeregisterOperator")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
@@ -122,7 +122,7 @@ func (r *Directory) UpdateMetadataURI(ctx context.Context, metadataURI string) (
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.contractAddr, executeMsgBytes, "UpdateMetadataURI")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "UpdateMetadataURI")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
@@ -133,7 +133,7 @@ func (r *Directory) CancelSalt(ctx context.Context, salt string) (*coretypes.Res
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.contractAddr, executeMsgBytes, "CancelSalt")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "CancelSalt")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
@@ -144,7 +144,7 @@ func (r *Directory) TransferOwnership(ctx context.Context, newOwner string) (*co
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.contractAddr, executeMsgBytes, "TransferOwnership")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "TransferOwnership")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
@@ -155,7 +155,7 @@ func (r *Directory) Pause(ctx context.Context) (*coretypes.ResultTx, error) {
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.contractAddr, executeMsgBytes, "Pause")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "Pause")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
@@ -166,7 +166,7 @@ func (r *Directory) Unpause(ctx context.Context) (*coretypes.ResultTx, error) {
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.contractAddr, executeMsgBytes, "Unpause")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "Unpause")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
@@ -177,7 +177,7 @@ func (r *Directory) SetPauser(ctx context.Context, newPauser string) (*coretypes
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.contractAddr, executeMsgBytes, "SetPauser")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "SetPauser")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
@@ -188,7 +188,7 @@ func (r *Directory) SetUnpauser(ctx context.Context, newUnpauser string) (*coret
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.contractAddr, executeMsgBytes, "SetUnpauser")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "SetUnpauser")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
@@ -199,7 +199,7 @@ func (r *Directory) SetDelegationManager(ctx context.Context, delegationManager 
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.contractAddr, executeMsgBytes, "SetDelegationManager")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "SetDelegationManager")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
@@ -214,7 +214,7 @@ func (r *Directory) QueryOperator(bvs, operator string) (*directory.OperatorStat
 	if err != nil {
 		return nil, err
 	}
-	queryOptions := r.newQueryOptions(r.contractAddr, queryMsgBytes)
+	queryOptions := r.newQueryOptions(r.ContractAddr, queryMsgBytes)
 	resp, err := r.io.QueryContract(queryOptions)
 	if err != nil {
 		return nil, err
@@ -232,13 +232,13 @@ func (r *Directory) CalculateDigestHash(operatorPublicKey cryptotypes.PubKey, bv
 		Bvs:               bvs,
 		Salt:              base64.StdEncoding.EncodeToString([]byte(salt)),
 		Expiry:            expiry,
-		ContractAddr:      r.contractAddr,
+		ContractAddr:      r.ContractAddr,
 	}}
 	queryMsgBytes, err := json.Marshal(queryMsg)
 	if err != nil {
 		return nil, err
 	}
-	queryOptions := r.newQueryOptions(r.contractAddr, queryMsgBytes)
+	queryOptions := r.newQueryOptions(r.ContractAddr, queryMsgBytes)
 	resp, err := r.io.QueryContract(queryOptions)
 	if err != nil {
 		return nil, err
@@ -259,7 +259,7 @@ func (r *Directory) IsSaltSpent(operator, salt string) (*directory.SaltResponse,
 	if err != nil {
 		return nil, err
 	}
-	queryOptions := r.newQueryOptions(r.contractAddr, queryMsgBytes)
+	queryOptions := r.newQueryOptions(r.ContractAddr, queryMsgBytes)
 	resp, err := r.io.QueryContract(queryOptions)
 	if err != nil {
 		return nil, err
@@ -279,7 +279,7 @@ func (r *Directory) GetDelegationManager() (*directory.DelegationResponse, error
 	if err != nil {
 		return nil, err
 	}
-	queryOptions := r.newQueryOptions(r.contractAddr, queryMsgBytes)
+	queryOptions := r.newQueryOptions(r.ContractAddr, queryMsgBytes)
 	resp, err := r.io.QueryContract(queryOptions)
 	if err != nil {
 		return nil, err
@@ -299,7 +299,7 @@ func (r *Directory) GetOwner() (*directory.OwnerResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	queryOptions := r.newQueryOptions(r.contractAddr, queryMsgBytes)
+	queryOptions := r.newQueryOptions(r.ContractAddr, queryMsgBytes)
 	resp, err := r.io.QueryContract(queryOptions)
 	if err != nil {
 		return nil, err
@@ -319,7 +319,7 @@ func (r *Directory) GetOperatorBvsRegistrationTypeHash() (*directory.Registratio
 	if err != nil {
 		return nil, err
 	}
-	queryOptions := r.newQueryOptions(r.contractAddr, queryMsgBytes)
+	queryOptions := r.newQueryOptions(r.ContractAddr, queryMsgBytes)
 	resp, err := r.io.QueryContract(queryOptions)
 	if err != nil {
 		return nil, err
@@ -339,7 +339,7 @@ func (r *Directory) GetDomainTypeHash() (*directory.DomainTypeHashResponse, erro
 	if err != nil {
 		return nil, err
 	}
-	queryOptions := r.newQueryOptions(r.contractAddr, queryMsgBytes)
+	queryOptions := r.newQueryOptions(r.ContractAddr, queryMsgBytes)
 	resp, err := r.io.QueryContract(queryOptions)
 	if err != nil {
 		return nil, err
@@ -359,7 +359,7 @@ func (r *Directory) GetDomainName() (*directory.DomainNameResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	queryOptions := r.newQueryOptions(r.contractAddr, queryMsgBytes)
+	queryOptions := r.newQueryOptions(r.ContractAddr, queryMsgBytes)
 	resp, err := r.io.QueryContract(queryOptions)
 	if err != nil {
 		return nil, err
@@ -377,7 +377,7 @@ func (r *Directory) GetBvsInfo(bvsHash string) (*directory.BvsInfoResponse, erro
 	if err != nil {
 		return nil, err
 	}
-	queryOptions := r.newQueryOptions(r.contractAddr, queryMsgBytes)
+	queryOptions := r.newQueryOptions(r.ContractAddr, queryMsgBytes)
 	resp, err := r.io.QueryContract(queryOptions)
 	if err != nil {
 		return nil, err

--- a/modules/bvs-api/chainio/api/driver.go
+++ b/modules/bvs-api/chainio/api/driver.go
@@ -15,7 +15,7 @@ import (
 type Driver struct {
 	registeredBVSContract string
 	io                    io.ChainIO
-	contractAddr          string
+	ContractAddr          string
 	gasAdjustment         float64
 	gasPrice              sdktypes.DecCoin
 	gasLimit              uint64
@@ -46,12 +46,12 @@ func (r *Driver) WithGasLimit(gasLimit uint64) *Driver {
 }
 
 func (r *Driver) BindClient(contractAddress string) {
-	r.contractAddr = contractAddress
+	r.ContractAddr = contractAddress
 }
 
 func (r *Driver) newExecuteOptions(executeMsg []byte, memo string) types.ExecuteOptions {
 	return types.ExecuteOptions{
-		ContractAddr:  r.contractAddr,
+		ContractAddr:  r.ContractAddr,
 		ExecuteMsg:    executeMsg,
 		Funds:         "",
 		GasAdjustment: r.gasAdjustment,

--- a/modules/bvs-api/chainio/api/rewards_coordinator.go
+++ b/modules/bvs-api/chainio/api/rewards_coordinator.go
@@ -15,6 +15,7 @@ import (
 
 type RewardsCoordinator struct {
 	io             io.ChainIO
+	ContractAddr   string
 	executeOptions *types.ExecuteOptions
 	queryOptions   *types.QueryOptions
 	gasAdjustment  float64
@@ -62,6 +63,8 @@ func (r *RewardsCoordinator) BindClient(contractAddress string) {
 		ContractAddr: contractAddress,
 		QueryMsg:     []byte{},
 	}
+
+	r.ContractAddr = contractAddress
 }
 
 func (r *RewardsCoordinator) CreateBVSRewardsSubmission(ctx context.Context, submissions []rewardscoordinator.RewardsSubmission) (*coretypes.ResultTx, error) {

--- a/modules/bvs-api/chainio/api/slash_manager.go
+++ b/modules/bvs-api/chainio/api/slash_manager.go
@@ -17,6 +17,7 @@ import (
 
 type SlashManager struct {
 	io             io.ChainIO
+	ContractAddr   string
 	executeOptions *types.ExecuteOptions
 	queryOptions   *types.QueryOptions
 	gasAdjustment  float64
@@ -25,7 +26,7 @@ type SlashManager struct {
 }
 
 func NewSlashManager(chainIO io.ChainIO) *SlashManager {
-	// TODO(fuxingloh): unused contractAddr
+	// TODO(fuxingloh): unused ContractAddr
 	return &SlashManager{
 		io:            chainIO,
 		gasAdjustment: 1.2,
@@ -65,6 +66,8 @@ func (r *SlashManager) BindClient(contractAddress string) {
 		ContractAddr: contractAddress,
 		QueryMsg:     []byte{},
 	}
+
+	r.ContractAddr = contractAddress
 }
 
 func (r *SlashManager) SubmitSlashRequest(ctx context.Context, slashDetails slashmanager.SubmitSlashRequestSlashDetails, validatorsPublicKeys []cryptotypes.PubKey) (*coretypes.ResultTx, error) {

--- a/modules/bvs-api/chainio/api/state_bank.go
+++ b/modules/bvs-api/chainio/api/state_bank.go
@@ -22,7 +22,7 @@ var wasmUpdateState sync.Map
 type StateBank struct {
 	registeredBVSContract string
 	io                    io.ChainIO
-	contractAddr          string
+	ContractAddr          string
 	gasAdjustment         float64
 	gasPrice              sdktypes.DecCoin
 	gasLimit              uint64
@@ -53,7 +53,7 @@ func (r *StateBank) WithGasLimit(gasLimit uint64) *StateBank {
 }
 
 func (r *StateBank) BindClient(contractAddress string) {
-	r.contractAddr = contractAddress
+	r.ContractAddr = contractAddress
 }
 
 func (r *StateBank) GetWasmUpdateState(key string) (string, error) {
@@ -94,7 +94,7 @@ func (r *StateBank) EventHandler(ch chan *indexer.Event) {
 
 func (r *StateBank) newExecuteOptions(executeMsg []byte, memo string) types.ExecuteOptions {
 	return types.ExecuteOptions{
-		ContractAddr:  r.contractAddr,
+		ContractAddr:  r.ContractAddr,
 		ExecuteMsg:    executeMsg,
 		Funds:         "",
 		GasAdjustment: r.gasAdjustment,

--- a/modules/bvs-api/chainio/api/strategy_base.go
+++ b/modules/bvs-api/chainio/api/strategy_base.go
@@ -16,6 +16,7 @@ import (
 
 type StrategyBase struct {
 	io             io.ChainIO
+	ContractAddr   string
 	executeOptions *types.ExecuteOptions
 	queryOptions   *types.QueryOptions
 	gasAdjustment  float64
@@ -63,6 +64,8 @@ func (r *StrategyBase) BindClient(contractAddress string) {
 		ContractAddr: contractAddress,
 		QueryMsg:     []byte{},
 	}
+
+	r.ContractAddr = contractAddress
 }
 
 func (r *StrategyBase) execute(ctx context.Context, msg any) (*coretypes.ResultTx, error) {

--- a/modules/bvs-api/chainio/api/strategy_base_tvl_limits.go
+++ b/modules/bvs-api/chainio/api/strategy_base_tvl_limits.go
@@ -16,6 +16,7 @@ import (
 
 type StrategyBaseTvlLimits struct {
 	io             io.ChainIO
+	ContractAddr   string
 	executeOptions *types.ExecuteOptions
 	queryOptions   *types.QueryOptions
 	gasAdjustment  float64
@@ -63,6 +64,8 @@ func (r *StrategyBaseTvlLimits) BindClient(contractAddress string) {
 		ContractAddr: contractAddress,
 		QueryMsg:     []byte{},
 	}
+
+	r.ContractAddr = contractAddress
 }
 
 func (r *StrategyBaseTvlLimits) execute(ctx context.Context, msg any) (*coretypes.ResultTx, error) {

--- a/modules/bvs-api/chainio/api/strategy_factory.go
+++ b/modules/bvs-api/chainio/api/strategy_factory.go
@@ -15,6 +15,7 @@ import (
 
 type StrategyFactory struct {
 	io             io.ChainIO
+	ContractAddr   string
 	executeOptions *types.ExecuteOptions
 	queryOptions   *types.QueryOptions
 	gasAdjustment  float64
@@ -62,6 +63,8 @@ func (r *StrategyFactory) BindClient(contractAddress string) {
 		ContractAddr: contractAddress,
 		QueryMsg:     []byte{},
 	}
+
+	r.ContractAddr = contractAddress
 }
 
 func (r *StrategyFactory) execute(ctx context.Context, msg any) (*coretypes.ResultTx, error) {

--- a/modules/bvs-api/chainio/api/strategy_manager.go
+++ b/modules/bvs-api/chainio/api/strategy_manager.go
@@ -18,6 +18,7 @@ import (
 
 type StrategyManager struct {
 	io             io.ChainIO
+	ContractAddr   string
 	executeOptions *types.ExecuteOptions
 	queryOptions   *types.QueryOptions
 	gasAdjustment  float64
@@ -65,6 +66,8 @@ func (r *StrategyManager) BindClient(contractAddress string) {
 		ContractAddr: contractAddress,
 		QueryMsg:     []byte{},
 	}
+
+	r.ContractAddr = contractAddress
 }
 
 func (r *StrategyManager) AddStrategiesToWhitelist(ctx context.Context, strategies []string, thirdPartyTransfersForbiddenValues []bool) (*coretypes.ResultTx, error) {


### PR DESCRIPTION
#### What this PR does / why we need it:

make `ContractAddress` from api public and add it to other apis that does not have it.

This is so that consumer can instantiate contract once, create the contract api reference and use it to execute, query and also get contract address. Without this, consumer will need to separately store each contract address.

<!-- remove if not applicable -->
Closes SL-206
