### PR TITLE
chore: rename bvs-strategy-manager CONTRACT_NAME

### DIFF
--- a/crates/bvs-strategy-manager/src/contract.rs
+++ b/crates/bvs-strategy-manager/src/contract.rs
@@ -32,7 +32,7 @@ use bvs_base::delegation::ExecuteMsg as DelegationManagerExecuteMsg;
 use bvs_base::pausable::{only_when_not_paused, pause, unpause, PAUSED_STATE};
 use bvs_base::roles::{check_pauser, check_unpauser, set_pauser, set_unpauser};
 
-const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
+const CONTRACT_NAME: &str = "BVS Strategy Manager";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 const PAUSED_DEPOSITS: u8 = 0;


### PR DESCRIPTION
#### What this PR does / why we need it:

This was supposed to be addressed in #232, but somehow I left it out.
