### PR TITLE
fix: remove unused strategy in GetDeposits

### DIFF
--- a/modules/bvs-api/chainio/api/strategy_manager.go
+++ b/modules/bvs-api/chainio/api/strategy_manager.go
@@ -323,12 +323,10 @@ func (r *StrategyManager) query(msg any) (*wasmtypes.QuerySmartContractStateResp
 	return r.io.QueryContract(*r.queryOptions)
 }
 
-func (r *StrategyManager) GetDeposits(staker string, strategy string) (*wasmtypes.QuerySmartContractStateResponse, error) {
+func (r *StrategyManager) GetDeposits(staker string) (*wasmtypes.QuerySmartContractStateResponse, error) {
 	msg := strategymanager.QueryMsg{
 		GetDeposits: &strategymanager.GetDeposits{
 			Staker: staker,
-			// TODO: what happen to strategy field is not present on the Rust side
-			// Strategy: strategy,
 		},
 	}
 

--- a/modules/bvs-api/tests/e2e/strategy_manager_test.go
+++ b/modules/bvs-api/tests/e2e/strategy_manager_test.go
@@ -287,7 +287,7 @@ func (suite *strategyManagerTestSuite) test_QueryStrategyManager() {
 	strategyManager := api.NewStrategyManager(chainIO)
 	strategyManager.BindClient(managerAddr)
 
-	resp, err := strategyManager.GetDeposits(stakerAddr, strategyAddr)
+	resp, err := strategyManager.GetDeposits(stakerAddr)
 	assert.NoError(t, err, "GetDeposits")
 	assert.NotNil(t, resp, "response nil")
 	t.Logf("GetDeposits resp:%+v", resp)

--- a/modules/bvs-cli/cmd/strategy.go
+++ b/modules/bvs-cli/cmd/strategy.go
@@ -163,11 +163,11 @@ func strategyCmd() *cobra.Command {
 		},
 	}
 	getDepositsCmd := &cobra.Command{
-		Use:   "get-deposits <stakerAddress> <strategyAddress>",
+		Use:   "get-deposits <stakerAddress>",
 		Short: "To get the deposits.",
-		Args:  cobra.ExactArgs(2),
+		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			strategy.GetDeposits(args[0], args[1])
+			strategy.GetDeposits(args[0])
 		},
 	}
 

--- a/modules/bvs-cli/commands/strategy/query.go
+++ b/modules/bvs-cli/commands/strategy/query.go
@@ -2,9 +2,9 @@ package strategy
 
 import "fmt"
 
-func GetDeposits(stakerAddress, strategyAddress string) {
+func GetDeposits(stakerAddress string) {
 	s := NewService()
-	resp, err := s.Strategy.GetDeposits(stakerAddress, strategyAddress)
+	resp, err := s.Strategy.GetDeposits(stakerAddress)
 	if err != nil {
 		panic(err)
 	}

--- a/modules/bvs-cli/tests/e2e/strategy_test.go
+++ b/modules/bvs-cli/tests/e2e/strategy_test.go
@@ -8,8 +8,7 @@ import (
 
 func Test_GetDeposits(t *testing.T) {
 	stakerAddress := "bbn1yph32eys4tdzv47dymfmn4el9x3k5rvpgjnphk"
-	strategyAddress := "bbn102zy555uul67xct4f29plgt6wq63wacmjp93csxpz8z538jrzcdqmj993a"
-	strategy.GetDeposits(stakerAddress, strategyAddress)
+	strategy.GetDeposits(stakerAddress)
 }
 
 func Test_GetStakerStrategyListLength(t *testing.T) {


### PR DESCRIPTION
#### What this PR does / why we need it:

The field is not present in rust; it should be removed to prevent confusion. We can add it back when it's implemented.

Closes SL-189