### PR TITLE
fix: Q4B fix execute set and add set bvs-directory interface

### DIFF
--- a/crates/bvs-state-bank/src/msg.rs
+++ b/crates/bvs-state-bank/src/msg.rs
@@ -11,6 +11,7 @@ pub struct InstantiateMsg {
 pub enum ExecuteMsg {
     Set { key: String, value: String },
     AddRegisteredBvsContract { address: String },
+    SetBVSDirectory { new_directory: String },
     TwoStepTransferOwnership { new_owner: String },
     AcceptOwnership {},
     CancelOwnershipTransfer {},


### PR DESCRIPTION
What this PR does / why we need it:

This fix is to resolve: use bvs contract and key to correspond to value and realize multiplexing, and add set bvs-directory address func.