### PR TITLE
draft: fix satl-20 make delegation signature expiry configurable

### DIFF
--- a/examples/squaring/modules/initprogram/main.go
+++ b/examples/squaring/modules/initprogram/main.go
@@ -195,15 +195,21 @@ func registerStakers(approverAddress string) {
 			panic(err)
 		}
 
+		nodeStatus, err := chainIO.QueryNodeStatus(context.Background())
+		if err != nil {
+			panic(err)
+		}
+		expiry := nodeStatus.SyncInfo.LatestBlockTime.Unix() + 1000
+
 		pubKey := oClient.GetCurrentAccountPubKey()
 		address := sdktypes.AccAddress(pubKey.Address()).String()
-
 		txResp, err := delegation.DelegateTo(
 			context.Background(),
 			address,
 			approverAddress,
 			core.C.Account.ApproverKeyName,
 			pubKey,
+			expiry,
 		)
 		if err != nil {
 			fmt.Println("Err: ", err)

--- a/modules/bvs-api/chainio/api/delegation_manager.go
+++ b/modules/bvs-api/chainio/api/delegation_manager.go
@@ -114,7 +114,12 @@ func (r *DelegationManager) UpdateOperatorMetadataURI(ctx context.Context, metad
 	return r.io.SendTransaction(ctx, executeOptions)
 }
 
-func (r *DelegationManager) DelegateTo(ctx context.Context, operator, approver, approverKeyName string, approverPublicKey cryptotypes.PubKey) (*coretypes.ResultTx, error) {
+func (r *DelegationManager) DelegateTo(
+	ctx context.Context,
+	operator, approver, approverKeyName string,
+	approverPublicKey cryptotypes.PubKey,
+	expiry int64,
+) (*coretypes.ResultTx, error) {
 	stakerAccount, err := r.io.GetCurrentAccount()
 	if err != nil {
 		return nil, err
@@ -126,11 +131,6 @@ func (r *DelegationManager) DelegateTo(ctx context.Context, operator, approver, 
 		},
 	}}
 	if approver != zeroValueAddr && approverKeyName != "" && approverPublicKey != nil {
-		nodeStatus, err := r.io.QueryNodeStatus(context.Background())
-		if err != nil {
-			return nil, err
-		}
-		expiry := nodeStatus.SyncInfo.LatestBlockTime.Unix() + 1000
 		randomStr, err := utils.GenerateRandomString(16)
 		if err != nil {
 			return nil, err
@@ -176,16 +176,12 @@ func (r *DelegationManager) DelegateToBySignature(
 	ctx context.Context,
 	operator, staker, stakerKeyName, approver, approverKeyName string,
 	stakerPublicKey, approverPublicKey cryptotypes.PubKey,
+	expiry int64,
 ) (*coretypes.ResultTx, error) {
-	nodeStatus, err := r.io.QueryNodeStatus(context.Background())
-	if err != nil {
-		return nil, err
-	}
 	stakerNonceResp, err := r.GetStakerNonce(staker)
 	if err != nil {
 		return nil, err
 	}
-	expiry := nodeStatus.SyncInfo.LatestBlockTime.Unix() + 1000
 	digestHashParams := delegationmanager.QueryStakerDigestHashParams{
 		Staker:          staker,
 		StakerNonce:     stakerNonceResp.Nonce,

--- a/modules/bvs-api/tests/e2e/delegation_manager_test.go
+++ b/modules/bvs-api/tests/e2e/delegation_manager_test.go
@@ -164,12 +164,17 @@ func (suite *delegationTestSuite) Test_DelegateToAndUnDelegate() {
 	approverAccount, err := chainIO.QueryAccount("bbn1yh5vdtu8n55f2e4fjea8gh0dw9gkzv7uxt8jrv")
 	assert.NoError(t, err, "get account")
 
+	nodeStatus, err := chainIO.QueryNodeStatus(context.Background())
+	assert.NoError(t, err, "query node status")
+	expiry := nodeStatus.SyncInfo.LatestBlockTime.Unix() + 1000
+
 	txResp, err := delegation.DelegateTo(
 		context.Background(),
 		"bbn1rt6v30zxvhtwet040xpdnhz4pqt8p2za7y430x",
 		approverAccount.GetAddress().String(),
 		"aggregator",
 		approverAccount.GetPubKey(),
+		expiry,
 	)
 	assert.NoError(t, err, "delegate to")
 	t.Logf("txResp: %v", txResp)
@@ -181,6 +186,7 @@ func (suite *delegationTestSuite) Test_DelegateToAndUnDelegate() {
 		approverAccount.GetAddress().String(),
 		"aggregator",
 		approverAccount.GetPubKey(),
+		expiry,
 	)
 	assert.Error(t, err, "delegate to no error")
 	t.Logf("txResp: %v", txResp)
@@ -204,6 +210,10 @@ func (suite *delegationTestSuite) Test_DelegateToBySignatureAndUnDelegate() {
 	approverAccountPubKey := GetPubKeyFromKeychainByAddress(chainIO, "bbn1yh5vdtu8n55f2e4fjea8gh0dw9gkzv7uxt8jrv")
 	assert.NoError(t, err, "get account")
 
+	nodeStatus, err := chainIO.QueryNodeStatus(context.Background())
+	assert.NoError(t, err, "query node status")
+	expiry := nodeStatus.SyncInfo.LatestBlockTime.Unix() + 1000
+
 	txResp, err := delegation.DelegateToBySignature(
 		context.Background(),
 		"bbn1rt6v30zxvhtwet040xpdnhz4pqt8p2za7y430x",
@@ -213,6 +223,7 @@ func (suite *delegationTestSuite) Test_DelegateToBySignatureAndUnDelegate() {
 		"aggregator",
 		stakerAccountPubKey,
 		approverAccountPubKey,
+		expiry,
 	)
 	assert.NoError(t, err, "delegate to by signature")
 	t.Logf("txResp: %v", txResp)

--- a/modules/bvs-cli/commands/delegation/exec.go
+++ b/modules/bvs-cli/commands/delegation/exec.go
@@ -79,6 +79,14 @@ func DelegateTo(stakerKeyName, operatorAddress, approverKeyName string) {
 		approverAddress = sdk.AccAddress(approverPubKey.Address()).String()
 	}
 	newChainIO, err := s.ChainIO.SetupKeyring(stakerKeyName, conf.C.Account.KeyringBackend)
+	if err != nil {
+		panic(err)
+	}
+	nodeStatus, err := newChainIO.QueryNodeStatus(context.Background())
+	if err != nil {
+		panic(err)
+	}
+	expiry := nodeStatus.SyncInfo.LatestBlockTime.Unix() + 1000
 	delegation := api.NewDelegationManager(newChainIO, conf.C.Contract.Delegation).WithGasLimit(400000)
 	txResp, err := delegation.DelegateTo(
 		ctx,
@@ -86,6 +94,7 @@ func DelegateTo(stakerKeyName, operatorAddress, approverKeyName string) {
 		approverAddress,
 		approverKeyName,
 		approverPubKey,
+		expiry,
 	)
 	if err != nil {
 		panic(err)
@@ -121,6 +130,12 @@ func DelegateBySignature(stakerKeyName, operatorAddress, approverKeyName string)
 	if err != nil {
 		panic(err)
 	}
+	nodeStatus, err := newChainIO.QueryNodeStatus(context.Background())
+	if err != nil {
+		panic(err)
+	}
+	expiry := nodeStatus.SyncInfo.LatestBlockTime.Unix() + 1000
+
 	stakerPubKey := newChainIO.GetCurrentAccountPubKey()
 	stakerAddress := sdk.AccAddress(stakerPubKey.Address()).String()
 	delegation := api.NewDelegationManager(newChainIO, conf.C.Contract.Delegation).WithGasLimit(400000)
@@ -133,6 +148,7 @@ func DelegateBySignature(stakerKeyName, operatorAddress, approverKeyName string)
 		approverKeyName,
 		stakerPubKey,
 		approverPubKey,
+		expiry,
 	)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
#### What this PR does:
SATL-20 To enhance flexibility and security, the signature expiration time should be configurable by the user as needed.

#### why we need it:
The signature expiration time is fixed and set to 1000 seconds. Certain delegations may pose financial risks after a specific time, so it is necessary to prevent delegation operations.

<!-- remove if not applicable -->
Closes SL-248
Fixes SATL-20