### PR TITLE
fix: Q6 TVL limit enforcement

### DIFF
--- a/crates/bvs-strategy-base-tvl-limits/src/contract.rs
+++ b/crates/bvs-strategy-base-tvl-limits/src/contract.rs
@@ -164,16 +164,15 @@ pub fn deposit(
         return Err(ContractError::MaxPerDepositExceeded {});
     }
 
+    // This is the balance of after the deposit
     let balance = token_balance(
         &deps.querier,
         &state.underlying_token,
         &env.contract.address,
     )?;
 
-    let before_balance = balance - amount;
-
     let max_total_deposits = MAX_TOTAL_DEPOSITS.load(deps.storage)?;
-    if before_balance + amount > max_total_deposits {
+    if balance > max_total_deposits {
         return Err(ContractError::MaxTotalDepositsExceeded {});
     }
 


### PR DESCRIPTION
What this PR does / why we need it:

This fix is to resolve: Remove unnecessary calculations and obtain the current balance. The actual tokens have been transferred to the contract.

Fixes SL-212
