### PR TITLE
fix: Q8 Address token association

### DIFF
--- a/crates/bvs-strategy-factory/src/error.rs
+++ b/crates/bvs-strategy-factory/src/error.rs
@@ -32,4 +32,7 @@ pub enum ContractError {
 
     #[error("StrategyFactory.acceptOwnership: no pending owner")]
     NoPendingOwner {},
+
+    #[error("ReplyError: {msg}")]
+    ReplyError { msg: String },
 }

--- a/crates/bvs-strategy-factory/src/msg.rs
+++ b/crates/bvs-strategy-factory/src/msg.rs
@@ -65,6 +65,7 @@ pub enum ExecuteMsg {
 pub enum QueryMsg {
     #[returns(StrategyResponse)]
     GetStrategy { token: String },
+
     #[returns(BlacklistStatusResponse)]
     IsTokenBlacklisted { token: String },
 }

--- a/crates/bvs-strategy-factory/src/state.rs
+++ b/crates/bvs-strategy-factory/src/state.rs
@@ -6,6 +6,8 @@ pub const CONFIG: Item<Config> = Item::new("config");
 pub const PENDING_OWNER: Item<Option<Addr>> = Item::new("pending_owner");
 pub const DEPLOYED_STRATEGIES: Map<&Addr, Addr> = Map::new("strategies");
 pub const IS_BLACKLISTED: Map<&Addr, bool> = Map::new("is_blacklisted");
+pub const NEXT_DEPLOY_ID: Item<u64> = Item::new("next_deploy_id");
+pub const PENDING_TOKENS: Map<u64, Addr> = Map::new("pending_tokens");
 
 #[cw_serde]
 pub struct Config {


### PR DESCRIPTION
#### What this PR does / why we need it:

This fix is to resolve:  the address may be obtained incorrectly through the reply() method when deploying a new strategy, and the token may be stuck

Closes SL-214

