### PR TITLE
draft: fix satl-19 prevent private key exposure by using native Sign method

### DIFF
--- a/modules/bvs-api/signer/signer.go
+++ b/modules/bvs-api/signer/signer.go
@@ -2,18 +2,11 @@ package signer
 
 import (
 	"encoding/base64"
-	"errors"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/tx"
-	"github.com/cosmos/cosmos-sdk/crypto"
-	sdksecp256k1 "github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
-	dcrdsecp256k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
-	"github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
-
-	"github.com/satlayer/satlayer-bvs/bvs-api/utils"
 )
 
 type Signer struct {
@@ -99,51 +92,27 @@ func (s *Signer) checkMsg(msgs ...sdktypes.Msg) ([]sdktypes.Msg, error) {
 }
 
 func (s *Signer) Sign(msgHash []byte) (string, error) {
-	decryptPrivKeyPwd, err := utils.GenerateRandomString(16)
+	signature, _, err := s.ClientCtx.Keyring.Sign(
+		s.ClientCtx.FromName,
+		msgHash,
+		signing.SignMode_SIGN_MODE_DIRECT,
+	)
 	if err != nil {
 		return "", err
 	}
-	armor, err := s.ClientCtx.Keyring.ExportPrivKeyArmor(s.ClientCtx.FromName, decryptPrivKeyPwd)
-	if err != nil {
-		return "", err
-	}
-	// decrypt private key
-	privKey, _, err := crypto.UnarmorDecryptPrivKey(armor, decryptPrivKeyPwd)
-	if err != nil {
-		return "", err
-	}
-	// convert the private key to secp256k1.PrivKey type
-	secp256k1PrivKey, ok := privKey.(*sdksecp256k1.PrivKey)
-	if !ok {
-		return "", errors.New("invalid secp256k1 privkey")
-	}
-	var secKey = dcrdsecp256k1.PrivKeyFromBytes(secp256k1PrivKey.Bytes())
-	signature := ecdsa.SignCompact(secKey, msgHash, false)
-	// remove the recovery bit and convert signature to base64 string
-	return base64.StdEncoding.EncodeToString(signature[1:]), nil
+
+	return base64.StdEncoding.EncodeToString(signature), nil
 }
 
 func (s *Signer) SignByKeyName(msgHash []byte, keyName string) (string, error) {
-	decryptPrivKeyPwd, err := utils.GenerateRandomString(16)
+	signature, _, err := s.ClientCtx.Keyring.Sign(
+		keyName,
+		msgHash,
+		signing.SignMode_SIGN_MODE_DIRECT,
+	)
 	if err != nil {
 		return "", err
 	}
-	armor, err := s.ClientCtx.Keyring.ExportPrivKeyArmor(keyName, decryptPrivKeyPwd)
-	if err != nil {
-		return "", err
-	}
-	// decrypt private key
-	privKey, _, err := crypto.UnarmorDecryptPrivKey(armor, decryptPrivKeyPwd)
-	if err != nil {
-		return "", err
-	}
-	// convert the private key to secp256k1.PrivKey type
-	secp256k1PrivKey, ok := privKey.(*sdksecp256k1.PrivKey)
-	if !ok {
-		return "", errors.New("invalid secp256k1 privkey")
-	}
-	var secKey = dcrdsecp256k1.PrivKeyFromBytes(secp256k1PrivKey.Bytes())
-	signature := ecdsa.SignCompact(secKey, msgHash, false)
-	// remove the recovery bit and convert signature to base64 string
-	return base64.StdEncoding.EncodeToString(signature[1:]), nil
+
+	return base64.StdEncoding.EncodeToString(signature), nil
 }

--- a/modules/bvs-api/signer/verify_sign.go
+++ b/modules/bvs-api/signer/verify_sign.go
@@ -2,40 +2,16 @@ package signer
 
 import (
 	"encoding/base64"
-	"errors"
+	"fmt"
 
-	sdksecp256k1 "github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
-	dcrdsecp256k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
-	"github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
 )
 
 // VerifySignature Function to verify signature
 func VerifySignature(pubKey cryptotypes.PubKey, msgHash []byte, signatureBase64 string) (bool, error) {
-	// Decode base64 encoded signature into bytes
 	signatureBytes, err := base64.StdEncoding.DecodeString(signatureBase64)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to decode signature: %w", err)
 	}
-	// Check that the signature length is correct (should be 64 bytes since the recovery bit was removed)
-	if len(signatureBytes) != 64 {
-		return false, errors.New("invalid signature length")
-	}
-	// Convert the Cosmos SDK's public key to the public key format of the dcrdsecp256k1 library
-	cosmosSecp256k1PubKey, ok := pubKey.(*sdksecp256k1.PubKey)
-	if !ok {
-		return false, errors.New("invalid public key type")
-	}
-	dcrdPubKey, err := dcrdsecp256k1.ParsePubKey(cosmosSecp256k1PubKey.Bytes())
-	if err != nil {
-		return false, err
-	}
-	// Create ecdsa.Signature from signature bytes
-	r := new(dcrdsecp256k1.ModNScalar)
-	s := new(dcrdsecp256k1.ModNScalar)
-	r.SetByteSlice(signatureBytes[:32])
-	s.SetByteSlice(signatureBytes[32:])
-	signature := ecdsa.NewSignature(r, s)
-	// Verify signature
-	return signature.Verify(msgHash, dcrdPubKey), nil
+	return pubKey.VerifySignature(msgHash, signatureBytes), nil
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
fix SATL-19
Refactor the custom sign method by using the Keyring.Sign method to avoid private key export and decryption, ensuring a simpler and more secure signing process.

Closes SL-203