### PR TITLE
fix: SATL-07 prevent hijacking of operator signatures

### DIFF
--- a/examples/squaring/modules/initprogram/main.go
+++ b/examples/squaring/modules/initprogram/main.go
@@ -117,7 +117,7 @@ func registerOperators(approverAddress string) {
 			fmt.Println("registerAsOperator to delegation success:", txResp)
 		}
 		// register operator to bvsDirectory
-		txResp, err = api.NewDirectory(chainIO, core.C.Contract.DirectoryAddr).RegisterOperator(context.Background(), address, pubKey)
+		txResp, err = api.NewDirectory(chainIO, core.C.Contract.DirectoryAddr).RegisterOperator(context.Background(), address, address, pubKey)
 		if err != nil {
 			fmt.Println("Err: registerOperators to bvsDirectory failed: ", err)
 			return

--- a/modules/bvs-api/chainio/api/directory.go
+++ b/modules/bvs-api/chainio/api/directory.go
@@ -61,7 +61,7 @@ func (r *Directory) RegisterBvs(ctx context.Context, bvsContract string) (*coret
 	return r.io.SendTransaction(ctx, executeOptions)
 }
 
-func (r *Directory) RegisterOperator(ctx context.Context, operator string, publicKey cryptotypes.PubKey) (*coretypes.ResultTx, error) {
+func (r *Directory) RegisterOperator(ctx context.Context, bvs, operator string, publicKey cryptotypes.PubKey) (*coretypes.ResultTx, error) {
 	nodeStatus, err := r.io.QueryNodeStatus(context.Background())
 	if err != nil {
 		return nil, err
@@ -74,7 +74,7 @@ func (r *Directory) RegisterOperator(ctx context.Context, operator string, publi
 	}
 	salt := "salt" + randomStr
 
-	msgHashResp, err := r.CalculateDigestHash(publicKey, operator, salt, expiry)
+	msgHashResp, err := r.CalculateDigestHash(publicKey, bvs, operator, salt, expiry)
 	if err != nil {
 		return nil, err
 	}
@@ -225,11 +225,12 @@ func (r *Directory) QueryOperator(bvs, operator string) (*directory.OperatorStat
 	return result, nil
 }
 
-func (r *Directory) CalculateDigestHash(operatorPublicKey cryptotypes.PubKey, bvs, salt string, expiry int64) (*directory.CalculateDigestHashResponse, error) {
+func (r *Directory) CalculateDigestHash(operatorPublicKey cryptotypes.PubKey, bvs, operator, salt string, expiry int64) (*directory.CalculateDigestHashResponse, error) {
 	result := new(directory.CalculateDigestHashResponse)
 	queryMsg := &directory.QueryMsg{CalculateDigestHash: &directory.CalculateDigestHash{
 		OperatorPublicKey: base64.StdEncoding.EncodeToString(operatorPublicKey.Bytes()),
 		Bvs:               bvs,
+		Operator:          operator,
 		Salt:              base64.StdEncoding.EncodeToString([]byte(salt)),
 		Expiry:            expiry,
 		ContractAddr:      r.ContractAddr,

--- a/modules/bvs-api/tests/e2e/directory_test.go
+++ b/modules/bvs-api/tests/e2e/directory_test.go
@@ -107,13 +107,13 @@ func (s *DirectoryTestSuite) Test_RegisterOperatorAndDeregisterOperator() {
 
 	bvsApi := api.NewDirectory(chainIO, s.contrAddr)
 	bvsApi.WithGasLimit(500000)
-	registerResp, err := bvsApi.RegisterOperator(context.Background(), operatorAddr.String(), operatorPubKey)
+	registerResp, err := bvsApi.RegisterOperator(context.Background(), operatorAddr.String(), operatorAddr.String(), operatorPubKey)
 	assert.NoError(t, err, "register operator")
 	assert.NotNil(t, registerResp, "response nil")
 	t.Logf("registerResp:%+v", registerResp)
 
 	// repeat register operator failed
-	registerResp, err = bvsApi.RegisterOperator(context.Background(), operatorAddr.String(), operatorPubKey)
+	registerResp, err = bvsApi.RegisterOperator(context.Background(), operatorAddr.String(), operatorAddr.String(), operatorPubKey)
 	assert.Error(t, err, "register operator not failed")
 	assert.Nil(t, registerResp, "response not nil")
 
@@ -259,6 +259,7 @@ func (s *DirectoryTestSuite) Test_CalculateDigestHash() {
 	assert.NoError(t, err, "get account")
 	msgHashResp, err := api.NewDirectory(chainIO, s.contrAddr).CalculateDigestHash(
 		pubKey,
+		"bbn1rt6v30zxvhtwet040xpdnhz4pqt8p2za7y430x",
 		"bbn1rt6v30zxvhtwet040xpdnhz4pqt8p2za7y430x",
 		salt,
 		expiry,

--- a/modules/bvs-cli/commands/directory/exec.go
+++ b/modules/bvs-cli/commands/directory/exec.go
@@ -49,7 +49,7 @@ func RegOperator(operatorKeyName string) {
 	directory, newChainIO := newService(operatorKeyName)
 	pubKey := newChainIO.GetCurrentAccountPubKey()
 	address := sdk.AccAddress(pubKey.Address()).String()
-	txn, err := directory.RegisterOperator(ctx, address, pubKey)
+	txn, err := directory.RegisterOperator(ctx, address, address, pubKey)
 	if err != nil {
 		fmt.Printf("Register operator error! %v\n", err)
 		return

--- a/modules/bvs-cli/commands/directory/query.go
+++ b/modules/bvs-cli/commands/directory/query.go
@@ -28,7 +28,7 @@ func CalcDigestHash(userKeyName, salt string, expire int64) {
 	}
 	pubKey := newChainIO.GetCurrentAccountPubKey()
 	address := sdk.AccAddress(pubKey.Address()).String()
-	resp, err := s.Directory.CalculateDigestHash(pubKey, address, salt, expire)
+	resp, err := s.Directory.CalculateDigestHash(pubKey, address, address, salt, expire)
 	if err != nil {
 		fmt.Printf("Calculate digest hash error! %+v\n", err)
 		return

--- a/modules/bvs-cw/directory/schema.go
+++ b/modules/bvs-cw/directory/schema.go
@@ -252,6 +252,7 @@ type BvsInfo struct {
 
 type CalculateDigestHash struct {
 	Bvs               string `json:"bvs"`
+	Operator          string `json:"operator"`
 	ContractAddr      string `json:"contract_addr"`
 	Expiry            int64  `json:"expiry"`
 	OperatorPublicKey string `json:"operator_public_key"`


### PR DESCRIPTION
#### What this PR does / why we need it:

contract required updates

fix: SATL-07
include operator and BVS in hash to prevent signature hijacking and replay attacks

<!-- remove if not applicable -->
Closes SL-89
Fixes SATL-07