### PR TITLE
fix: incompatibility and add granularity for pausing specific fields

### DIFF
--- a/modules/bvs-api/chainio/api/delegation_manager.go
+++ b/modules/bvs-api/chainio/api/delegation_manager.go
@@ -411,28 +411,46 @@ func (r *DelegationManager) TransferOwnership(ctx context.Context, newOwner stri
 	return r.io.SendTransaction(ctx, executeOptions)
 }
 
-func (r *DelegationManager) Pause(ctx context.Context) (*coretypes.ResultTx, error) {
-	executeMsg := delegationmanager.ExecuteMsg{
-		Pause: &delegationmanager.Pause{},
-	}
+func (r *DelegationManager) PauseAll(ctx context.Context) (*coretypes.ResultTx, error) {
+	executeMsg := delegationmanager.ExecuteMsg{PauseAll: &delegationmanager.PauseAll{}}
 	executeMsgBytes, err := json.Marshal(executeMsg)
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "Pause")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "PauseAll")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
 
-func (r *DelegationManager) Unpause(ctx context.Context) (*coretypes.ResultTx, error) {
-	executeMsg := delegationmanager.ExecuteMsg{
-		Unpause: &delegationmanager.Unpause{},
-	}
+func (r *DelegationManager) UnpauseAll(ctx context.Context) (*coretypes.ResultTx, error) {
+	executeMsg := delegationmanager.ExecuteMsg{UnpauseAll: &delegationmanager.UnpauseAll{}}
 	executeMsgBytes, err := json.Marshal(executeMsg)
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "Unpause")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "UnpauseAll")
+
+	return r.io.SendTransaction(ctx, executeOptions)
+}
+
+func (r *DelegationManager) PauseBit(ctx context.Context, index uint8) (*coretypes.ResultTx, error) {
+	executeMsg := delegationmanager.ExecuteMsg{PauseBit: &delegationmanager.PauseBit{Index: index}}
+	executeMsgBytes, err := json.Marshal(executeMsg)
+	if err != nil {
+		return nil, err
+	}
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "PauseBit")
+
+	return r.io.SendTransaction(ctx, executeOptions)
+}
+
+func (r *DelegationManager) UnpauseBit(ctx context.Context, index uint8) (*coretypes.ResultTx, error) {
+	executeMsg := delegationmanager.ExecuteMsg{UnpauseBit: &delegationmanager.UnpauseBit{Index: index}}
+	executeMsgBytes, err := json.Marshal(executeMsg)
+	if err != nil {
+		return nil, err
+	}
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "UnpauseBit")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }

--- a/modules/bvs-api/chainio/api/directory.go
+++ b/modules/bvs-api/chainio/api/directory.go
@@ -149,24 +149,46 @@ func (r *Directory) TransferOwnership(ctx context.Context, newOwner string) (*co
 	return r.io.SendTransaction(ctx, executeOptions)
 }
 
-func (r *Directory) Pause(ctx context.Context) (*coretypes.ResultTx, error) {
-	executeMsg := directory.ExecuteMsg{Pause: &directory.Pause{}}
+func (r *Directory) PauseAll(ctx context.Context) (*coretypes.ResultTx, error) {
+	executeMsg := directory.ExecuteMsg{PauseAll: &directory.PauseAll{}}
 	executeMsgBytes, err := json.Marshal(executeMsg)
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "Pause")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "PauseAll")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
 
-func (r *Directory) Unpause(ctx context.Context) (*coretypes.ResultTx, error) {
-	executeMsg := directory.ExecuteMsg{Unpause: &directory.Unpause{}}
+func (r *Directory) UnpauseAll(ctx context.Context) (*coretypes.ResultTx, error) {
+	executeMsg := directory.ExecuteMsg{UnpauseAll: &directory.UnpauseAll{}}
 	executeMsgBytes, err := json.Marshal(executeMsg)
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "Unpause")
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "UnpauseAll")
+
+	return r.io.SendTransaction(ctx, executeOptions)
+}
+
+func (r *Directory) PauseBit(ctx context.Context, index uint8) (*coretypes.ResultTx, error) {
+	executeMsg := directory.ExecuteMsg{PauseBit: &directory.PauseBit{Index: index}}
+	executeMsgBytes, err := json.Marshal(executeMsg)
+	if err != nil {
+		return nil, err
+	}
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "PauseBit")
+
+	return r.io.SendTransaction(ctx, executeOptions)
+}
+
+func (r *Directory) UnpauseBit(ctx context.Context, index uint8) (*coretypes.ResultTx, error) {
+	executeMsg := directory.ExecuteMsg{UnpauseBit: &directory.UnpauseBit{Index: index}}
+	executeMsgBytes, err := json.Marshal(executeMsg)
+	if err != nil {
+		return nil, err
+	}
+	executeOptions := r.newExecuteOptions(r.ContractAddr, executeMsgBytes, "UnpauseBit")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }

--- a/modules/bvs-api/chainio/api/rewards_coordinator.go
+++ b/modules/bvs-api/chainio/api/rewards_coordinator.go
@@ -175,29 +175,46 @@ func (r *RewardsCoordinator) SetGlobalOperatorCommission(ctx context.Context, ne
 	return r.io.SendTransaction(ctx, executeOptions)
 }
 
-func (r *RewardsCoordinator) Pause(ctx context.Context) (*coretypes.ResultTx, error) {
-	msg := rewardscoordinator.ExecuteMsg{
-		Pause: &rewardscoordinator.Pause{},
-	}
-
-	executeMsgBytes, err := json.Marshal(msg)
+func (r *RewardsCoordinator) PauseAll(ctx context.Context) (*coretypes.ResultTx, error) {
+	executeMsg := rewardscoordinator.ExecuteMsg{PauseAll: &rewardscoordinator.PauseAll{}}
+	executeMsgBytes, err := json.Marshal(executeMsg)
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(executeMsgBytes, "Pause")
+	executeOptions := r.newExecuteOptions(executeMsgBytes, "PauseAll")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
 
-func (r *RewardsCoordinator) Unpause(ctx context.Context) (*coretypes.ResultTx, error) {
-	msg := rewardscoordinator.ExecuteMsg{
-		Unpause: &rewardscoordinator.Unpause{},
-	}
-	executeMsgBytes, err := json.Marshal(msg)
+func (r *RewardsCoordinator) UnpauseAll(ctx context.Context) (*coretypes.ResultTx, error) {
+	executeMsg := rewardscoordinator.ExecuteMsg{UnpauseAll: &rewardscoordinator.UnpauseAll{}}
+	executeMsgBytes, err := json.Marshal(executeMsg)
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(executeMsgBytes, "Unpause")
+	executeOptions := r.newExecuteOptions(executeMsgBytes, "UnpauseAll")
+
+	return r.io.SendTransaction(ctx, executeOptions)
+}
+
+func (r *RewardsCoordinator) PauseBit(ctx context.Context, index uint8) (*coretypes.ResultTx, error) {
+	executeMsg := rewardscoordinator.ExecuteMsg{PauseBit: &rewardscoordinator.PauseBit{Index: index}}
+	executeMsgBytes, err := json.Marshal(executeMsg)
+	if err != nil {
+		return nil, err
+	}
+	executeOptions := r.newExecuteOptions(executeMsgBytes, "PauseBit")
+
+	return r.io.SendTransaction(ctx, executeOptions)
+}
+
+func (r *RewardsCoordinator) UnpauseBit(ctx context.Context, index uint8) (*coretypes.ResultTx, error) {
+	executeMsg := rewardscoordinator.ExecuteMsg{UnpauseBit: &rewardscoordinator.UnpauseBit{Index: index}}
+	executeMsgBytes, err := json.Marshal(executeMsg)
+	if err != nil {
+		return nil, err
+	}
+	executeOptions := r.newExecuteOptions(executeMsgBytes, "UnpauseBit")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }

--- a/modules/bvs-api/chainio/api/slash_manager.go
+++ b/modules/bvs-api/chainio/api/slash_manager.go
@@ -223,30 +223,46 @@ func (r *SlashManager) SetDelegationManager(ctx context.Context, newDelegationMa
 	return r.io.SendTransaction(ctx, executeOptions)
 }
 
-func (r *SlashManager) Pause(ctx context.Context) (*coretypes.ResultTx, error) {
-	executeMsg := slashmanager.ExecuteMsg{
-		Pause: &slashmanager.Pause{},
-	}
-
+func (r *SlashManager) PauseAll(ctx context.Context) (*coretypes.ResultTx, error) {
+	executeMsg := slashmanager.ExecuteMsg{PauseAll: &slashmanager.PauseAll{}}
 	executeMsgBytes, err := json.Marshal(executeMsg)
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(executeMsgBytes, "Pause")
+	executeOptions := r.newExecuteOptions(executeMsgBytes, "PauseAll")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
 
-func (r *SlashManager) Unpause(ctx context.Context) (*coretypes.ResultTx, error) {
-	executeMsg := slashmanager.ExecuteMsg{
-		Unpause: &slashmanager.Unpause{},
-	}
-
+func (r *SlashManager) UnpauseAll(ctx context.Context) (*coretypes.ResultTx, error) {
+	executeMsg := slashmanager.ExecuteMsg{UnpauseAll: &slashmanager.UnpauseAll{}}
 	executeMsgBytes, err := json.Marshal(executeMsg)
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(executeMsgBytes, "Unpause")
+	executeOptions := r.newExecuteOptions(executeMsgBytes, "UnpauseAll")
+
+	return r.io.SendTransaction(ctx, executeOptions)
+}
+
+func (r *SlashManager) PauseBit(ctx context.Context, index uint8) (*coretypes.ResultTx, error) {
+	executeMsg := slashmanager.ExecuteMsg{PauseBit: &slashmanager.PauseBit{Index: index}}
+	executeMsgBytes, err := json.Marshal(executeMsg)
+	if err != nil {
+		return nil, err
+	}
+	executeOptions := r.newExecuteOptions(executeMsgBytes, "PauseBit")
+
+	return r.io.SendTransaction(ctx, executeOptions)
+}
+
+func (r *SlashManager) UnpauseBit(ctx context.Context, index uint8) (*coretypes.ResultTx, error) {
+	executeMsg := slashmanager.ExecuteMsg{UnpauseBit: &slashmanager.UnpauseBit{Index: index}}
+	executeMsgBytes, err := json.Marshal(executeMsg)
+	if err != nil {
+		return nil, err
+	}
+	executeOptions := r.newExecuteOptions(executeMsgBytes, "UnpauseBit")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }

--- a/modules/bvs-api/chainio/api/strategy_base.go
+++ b/modules/bvs-api/chainio/api/strategy_base.go
@@ -80,30 +80,46 @@ func (r *StrategyBase) Withdraw(ctx context.Context, recipient string, amountSha
 	return r.io.SendTransaction(ctx, executeOptions)
 }
 
-func (r *StrategyBase) Pause(ctx context.Context) (*coretypes.ResultTx, error) {
-	msg := strategybase.ExecuteMsg{
-		Pause: &strategybase.Pause{},
-	}
-
-	executeMsgBytes, err := json.Marshal(msg)
+func (r *StrategyBase) PauseAll(ctx context.Context) (*coretypes.ResultTx, error) {
+	executeMsg := strategybase.ExecuteMsg{PauseAll: &strategybase.PauseAll{}}
+	executeMsgBytes, err := json.Marshal(executeMsg)
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(executeMsgBytes, "Pause")
+	executeOptions := r.newExecuteOptions(executeMsgBytes, "PauseAll")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
 
-func (r *StrategyBase) Unpause(ctx context.Context) (*coretypes.ResultTx, error) {
-	msg := strategybase.ExecuteMsg{
-		Unpause: &strategybase.Unpause{},
-	}
-
-	executeMsgBytes, err := json.Marshal(msg)
+func (r *StrategyBase) UnpauseAll(ctx context.Context) (*coretypes.ResultTx, error) {
+	executeMsg := strategybase.ExecuteMsg{UnpauseAll: &strategybase.UnpauseAll{}}
+	executeMsgBytes, err := json.Marshal(executeMsg)
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(executeMsgBytes, "Unpause")
+	executeOptions := r.newExecuteOptions(executeMsgBytes, "UnpauseAll")
+
+	return r.io.SendTransaction(ctx, executeOptions)
+}
+
+func (r *StrategyBase) PauseBit(ctx context.Context, index uint8) (*coretypes.ResultTx, error) {
+	executeMsg := strategybase.ExecuteMsg{PauseBit: &strategybase.PauseBit{Index: index}}
+	executeMsgBytes, err := json.Marshal(executeMsg)
+	if err != nil {
+		return nil, err
+	}
+	executeOptions := r.newExecuteOptions(executeMsgBytes, "PauseBit")
+
+	return r.io.SendTransaction(ctx, executeOptions)
+}
+
+func (r *StrategyBase) UnpauseBit(ctx context.Context, index uint8) (*coretypes.ResultTx, error) {
+	executeMsg := strategybase.ExecuteMsg{UnpauseBit: &strategybase.UnpauseBit{Index: index}}
+	executeMsgBytes, err := json.Marshal(executeMsg)
+	if err != nil {
+		return nil, err
+	}
+	executeOptions := r.newExecuteOptions(executeMsgBytes, "UnpauseBit")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }

--- a/modules/bvs-api/chainio/api/strategy_base_tvl_limits.go
+++ b/modules/bvs-api/chainio/api/strategy_base_tvl_limits.go
@@ -80,30 +80,46 @@ func (r *StrategyBaseTvlLimits) Withdraw(ctx context.Context, recipient string, 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
 
-func (r *StrategyBaseTvlLimits) Pause(ctx context.Context) (*coretypes.ResultTx, error) {
-	msg := strategybasetvllimits.ExecuteMsg{
-		Pause: &strategybasetvllimits.Pause{},
-	}
-
-	executeMsgBytes, err := json.Marshal(msg)
+func (r *StrategyBaseTvlLimits) PauseAll(ctx context.Context) (*coretypes.ResultTx, error) {
+	executeMsg := strategybasetvllimits.ExecuteMsg{PauseAll: &strategybasetvllimits.PauseAll{}}
+	executeMsgBytes, err := json.Marshal(executeMsg)
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(executeMsgBytes, "Pause")
+	executeOptions := r.newExecuteOptions(executeMsgBytes, "PauseAll")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
 
-func (r *StrategyBaseTvlLimits) Unpause(ctx context.Context) (*coretypes.ResultTx, error) {
-	msg := strategybasetvllimits.ExecuteMsg{
-		Unpause: &strategybasetvllimits.Unpause{},
-	}
-
-	executeMsgBytes, err := json.Marshal(msg)
+func (r *StrategyBaseTvlLimits) UnpauseAll(ctx context.Context) (*coretypes.ResultTx, error) {
+	executeMsg := strategybasetvllimits.ExecuteMsg{UnpauseAll: &strategybasetvllimits.UnpauseAll{}}
+	executeMsgBytes, err := json.Marshal(executeMsg)
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(executeMsgBytes, "Unpause")
+	executeOptions := r.newExecuteOptions(executeMsgBytes, "UnpauseAll")
+
+	return r.io.SendTransaction(ctx, executeOptions)
+}
+
+func (r *StrategyBaseTvlLimits) PauseBit(ctx context.Context, index uint8) (*coretypes.ResultTx, error) {
+	executeMsg := strategybasetvllimits.ExecuteMsg{PauseBit: &strategybasetvllimits.PauseBit{Index: index}}
+	executeMsgBytes, err := json.Marshal(executeMsg)
+	if err != nil {
+		return nil, err
+	}
+	executeOptions := r.newExecuteOptions(executeMsgBytes, "PauseBit")
+
+	return r.io.SendTransaction(ctx, executeOptions)
+}
+
+func (r *StrategyBaseTvlLimits) UnpauseBit(ctx context.Context, index uint8) (*coretypes.ResultTx, error) {
+	executeMsg := strategybasetvllimits.ExecuteMsg{UnpauseBit: &strategybasetvllimits.UnpauseBit{Index: index}}
+	executeMsgBytes, err := json.Marshal(executeMsg)
+	if err != nil {
+		return nil, err
+	}
+	executeOptions := r.newExecuteOptions(executeMsgBytes, "UnpauseBit")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }

--- a/modules/bvs-api/chainio/api/strategy_factory.go
+++ b/modules/bvs-api/chainio/api/strategy_factory.go
@@ -180,30 +180,46 @@ func (r *StrategyFactory) TransferOwnership(ctx context.Context, newOwner string
 	return r.io.SendTransaction(ctx, executeOptions)
 }
 
-func (r *StrategyFactory) Pause(ctx context.Context) (*coretypes.ResultTx, error) {
-	executeMsg := strategyfactory.ExecuteMsg{
-		Pause: &strategyfactory.Pause{},
-	}
-
+func (r *StrategyFactory) PauseAll(ctx context.Context) (*coretypes.ResultTx, error) {
+	executeMsg := strategyfactory.ExecuteMsg{PauseAll: &strategyfactory.PauseAll{}}
 	executeMsgBytes, err := json.Marshal(executeMsg)
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(executeMsgBytes, "Pause")
+	executeOptions := r.newExecuteOptions(executeMsgBytes, "PauseAll")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
 
-func (r *StrategyFactory) Unpause(ctx context.Context) (*coretypes.ResultTx, error) {
-	executeMsg := strategyfactory.ExecuteMsg{
-		Unpause: &strategyfactory.Unpause{},
-	}
-
+func (r *StrategyFactory) UnpauseAll(ctx context.Context) (*coretypes.ResultTx, error) {
+	executeMsg := strategyfactory.ExecuteMsg{UnpauseAll: &strategyfactory.UnpauseAll{}}
 	executeMsgBytes, err := json.Marshal(executeMsg)
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(executeMsgBytes, "Unpause")
+	executeOptions := r.newExecuteOptions(executeMsgBytes, "UnpauseAll")
+
+	return r.io.SendTransaction(ctx, executeOptions)
+}
+
+func (r *StrategyFactory) PauseBit(ctx context.Context, index uint8) (*coretypes.ResultTx, error) {
+	executeMsg := strategyfactory.ExecuteMsg{PauseBit: &strategyfactory.PauseBit{Index: index}}
+	executeMsgBytes, err := json.Marshal(executeMsg)
+	if err != nil {
+		return nil, err
+	}
+	executeOptions := r.newExecuteOptions(executeMsgBytes, "PauseBit")
+
+	return r.io.SendTransaction(ctx, executeOptions)
+}
+
+func (r *StrategyFactory) UnpauseBit(ctx context.Context, index uint8) (*coretypes.ResultTx, error) {
+	executeMsg := strategyfactory.ExecuteMsg{UnpauseBit: &strategyfactory.UnpauseBit{Index: index}}
+	executeMsgBytes, err := json.Marshal(executeMsg)
+	if err != nil {
+		return nil, err
+	}
+	executeOptions := r.newExecuteOptions(executeMsgBytes, "UnpauseBit")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }

--- a/modules/bvs-api/chainio/api/strategy_manager.go
+++ b/modules/bvs-api/chainio/api/strategy_manager.go
@@ -283,30 +283,46 @@ func (r *StrategyManager) SetDelegationManager(ctx context.Context, newDelegatio
 	return r.io.SendTransaction(ctx, executeOptions)
 }
 
-func (r *StrategyManager) Pause(ctx context.Context) (*coretypes.ResultTx, error) {
-	msg := strategymanager.ExecuteMsg{
-		Pause: &strategymanager.Pause{},
-	}
-
-	executeMsgBytes, err := json.Marshal(msg)
+func (r *StrategyManager) PauseAll(ctx context.Context) (*coretypes.ResultTx, error) {
+	executeMsg := strategymanager.ExecuteMsg{PauseAll: &strategymanager.PauseAll{}}
+	executeMsgBytes, err := json.Marshal(executeMsg)
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(executeMsgBytes, "Pause")
+	executeOptions := r.newExecuteOptions(executeMsgBytes, "PauseAll")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }
 
-func (r *StrategyManager) Unpause(ctx context.Context) (*coretypes.ResultTx, error) {
-	msg := strategymanager.ExecuteMsg{
-		Unpause: &strategymanager.Unpause{},
-	}
-
-	executeMsgBytes, err := json.Marshal(msg)
+func (r *StrategyManager) UnpauseAll(ctx context.Context) (*coretypes.ResultTx, error) {
+	executeMsg := strategymanager.ExecuteMsg{UnpauseAll: &strategymanager.UnpauseAll{}}
+	executeMsgBytes, err := json.Marshal(executeMsg)
 	if err != nil {
 		return nil, err
 	}
-	executeOptions := r.newExecuteOptions(executeMsgBytes, "Unpause")
+	executeOptions := r.newExecuteOptions(executeMsgBytes, "UnpauseAll")
+
+	return r.io.SendTransaction(ctx, executeOptions)
+}
+
+func (r *StrategyManager) PauseBit(ctx context.Context, index uint8) (*coretypes.ResultTx, error) {
+	executeMsg := strategymanager.ExecuteMsg{PauseBit: &strategymanager.PauseBit{Index: index}}
+	executeMsgBytes, err := json.Marshal(executeMsg)
+	if err != nil {
+		return nil, err
+	}
+	executeOptions := r.newExecuteOptions(executeMsgBytes, "PauseBit")
+
+	return r.io.SendTransaction(ctx, executeOptions)
+}
+
+func (r *StrategyManager) UnpauseBit(ctx context.Context, index uint8) (*coretypes.ResultTx, error) {
+	executeMsg := strategymanager.ExecuteMsg{UnpauseBit: &strategymanager.UnpauseBit{Index: index}}
+	executeMsgBytes, err := json.Marshal(executeMsg)
+	if err != nil {
+		return nil, err
+	}
+	executeOptions := r.newExecuteOptions(executeMsgBytes, "UnpauseBit")
 
 	return r.io.SendTransaction(ctx, executeOptions)
 }

--- a/modules/bvs-api/tests/e2e/delegation_manager_test.go
+++ b/modules/bvs-api/tests/e2e/delegation_manager_test.go
@@ -378,12 +378,12 @@ func (suite *delegationTestSuite) Test_DelegationPause() {
 	chainIO, err := suite.chainIO.SetupKeyring(keyName, "test")
 	assert.NoError(t, err)
 
-	txResp, err := api.NewDelegationManager(chainIO, suite.contrAddr).Pause(context.Background())
+	txResp, err := api.NewDelegationManager(chainIO, suite.contrAddr).PauseAll(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, txResp, "response nil")
 	t.Logf("txResp:%+v", txResp)
 
-	recoverResp, err := api.NewDelegationManager(chainIO, suite.contrAddr).Unpause(context.Background())
+	recoverResp, err := api.NewDelegationManager(chainIO, suite.contrAddr).UnpauseAll(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, recoverResp, "response nil")
 	t.Logf("txResp:%+v", recoverResp)

--- a/modules/bvs-api/tests/e2e/directory_test.go
+++ b/modules/bvs-api/tests/e2e/directory_test.go
@@ -186,12 +186,12 @@ func (s *DirectoryTestSuite) Test_Pause() {
 		s.Require().NoError(err)
 	}
 
-	txResp, err := bvsDirectory.Pause(context.Background())
+	txResp, err := bvsDirectory.PauseAll(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, txResp, "response nil")
 	t.Logf("txResp:%+v", txResp)
 
-	recoverResp, err := bvsDirectory.Unpause(context.Background())
+	recoverResp, err := bvsDirectory.UnpauseAll(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, recoverResp, "response nil")
 	t.Logf("txResp:%+v", recoverResp)

--- a/modules/bvs-api/tests/e2e/slash_manager_test.go
+++ b/modules/bvs-api/tests/e2e/slash_manager_test.go
@@ -160,7 +160,7 @@ func (suite *slashManagerTestSuite) Test_Pause() {
 		suite.Require().NoError(err)
 	}
 
-	txResp, err := slashApi.Pause(context.Background())
+	txResp, err := slashApi.PauseAll(context.Background())
 	assert.NoError(t, err, "Pause failed")
 	assert.NotNil(t, txResp, "response nil")
 	t.Logf("txResp:%+v", txResp)
@@ -180,7 +180,7 @@ func (suite *slashManagerTestSuite) Test_Unpause() {
 		suite.Require().NoError(err)
 	}
 
-	txResp, err := slashApi.Unpause(context.Background())
+	txResp, err := slashApi.UnpauseAll(context.Background())
 	assert.NoError(t, err, "Unpause failed")
 	assert.NotNil(t, txResp, "response nil")
 	t.Logf("txResp:%+v", txResp)

--- a/modules/bvs-api/tests/e2e/strategy_factory_test.go
+++ b/modules/bvs-api/tests/e2e/strategy_factory_test.go
@@ -209,7 +209,7 @@ func (suite *strategyFactoryTestSuite) Test_Pause() {
 		suite.Require().NoError(err)
 	}
 
-	txResp, err := factoryApi.Pause(context.Background())
+	txResp, err := factoryApi.PauseAll(context.Background())
 	assert.NoError(t, err, "Pause failed")
 	assert.NotNil(t, txResp, "response nil")
 	t.Logf("txResp:%+v", txResp)
@@ -246,7 +246,7 @@ func (suite *strategyFactoryTestSuite) Test_Unpause() {
 		suite.Require().NoError(err)
 	}
 
-	txResp, err := factoryApi.Unpause(context.Background())
+	txResp, err := factoryApi.UnpauseAll(context.Background())
 	assert.NoError(t, err, "Unpause failed")
 	assert.NotNil(t, txResp, "response nil")
 	t.Logf("txResp:%+v", txResp)

--- a/modules/bvs-cli/commands/delegation/exec.go
+++ b/modules/bvs-cli/commands/delegation/exec.go
@@ -173,7 +173,7 @@ func TransferOwnership(userKeyName, newOwner string) {
 func Pause(userKeyName string) {
 	ctx := context.Background()
 	delegation, _ := newService(userKeyName)
-	txResp, err := delegation.Pause(ctx)
+	txResp, err := delegation.PauseAll(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -183,7 +183,7 @@ func Pause(userKeyName string) {
 func Unpause(userKeyName string) {
 	ctx := context.Background()
 	delegation, _ := newService(userKeyName)
-	txResp, err := delegation.Unpause(ctx)
+	txResp, err := delegation.UnpauseAll(ctx)
 	if err != nil {
 		panic(err)
 	}

--- a/modules/bvs-cli/commands/directory/exec.go
+++ b/modules/bvs-cli/commands/directory/exec.go
@@ -106,7 +106,7 @@ func TransferOwner(userKeyName, newOwner string) {
 func Pause(userKeyName string) {
 	ctx := context.Background()
 	directory, _ := newService(userKeyName)
-	txn, err := directory.Pause(ctx)
+	txn, err := directory.PauseAll(ctx)
 	if err != nil {
 		fmt.Printf("Pause error! %v\n", err)
 		return
@@ -117,7 +117,7 @@ func Pause(userKeyName string) {
 func Unpause(userKeyName string) {
 	ctx := context.Background()
 	directory, _ := newService(userKeyName)
-	txn, err := directory.Unpause(ctx)
+	txn, err := directory.UnpauseAll(ctx)
 	if err != nil {
 		fmt.Printf("Unpause error! %v\n", err)
 		return

--- a/modules/bvs-cli/commands/reward/exec.go
+++ b/modules/bvs-cli/commands/reward/exec.go
@@ -63,7 +63,7 @@ func SetRewardUpdater(userKeyName, rewardUpdater string) {
 func Pause(userKeyName string) {
 	ctx := context.Background()
 	reward, _ := newService(userKeyName)
-	resp, err := reward.Pause(ctx)
+	resp, err := reward.PauseAll(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -73,7 +73,7 @@ func Pause(userKeyName string) {
 func Unpause(userKeyName string) {
 	ctx := context.Background()
 	reward, _ := newService(userKeyName)
-	resp, err := reward.Unpause(ctx)
+	resp, err := reward.UnpauseAll(ctx)
 	if err != nil {
 		panic(err)
 	}

--- a/modules/bvs-cli/commands/slash/exec.go
+++ b/modules/bvs-cli/commands/slash/exec.go
@@ -85,7 +85,7 @@ func SetSlasherValidator(userKeyName string, validators []string, values []bool)
 func Pause(userKeyName string) {
 	ctx := context.Background()
 	slash, _ := newService(userKeyName)
-	txResp, err := slash.Pause(ctx)
+	txResp, err := slash.PauseAll(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -95,7 +95,7 @@ func Pause(userKeyName string) {
 func Unpause(userKeyName string) {
 	ctx := context.Background()
 	slash, _ := newService(userKeyName)
-	txResp, err := slash.Unpause(ctx)
+	txResp, err := slash.UnpauseAll(ctx)
 	if err != nil {
 		panic(err)
 	}

--- a/modules/bvs-cli/commands/strategy/exec.go
+++ b/modules/bvs-cli/commands/strategy/exec.go
@@ -91,7 +91,7 @@ func DepositStrategy(userKeyName, strategyAddress, tokenAddress string, amount u
 func Pause(userKeyName string) {
 	ctx := context.Background()
 	strategy, _ := newService(userKeyName)
-	txResp, err := strategy.Pause(ctx)
+	txResp, err := strategy.PauseAll(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -101,7 +101,7 @@ func Pause(userKeyName string) {
 func Unpause(userKeyName string) {
 	ctx := context.Background()
 	strategy, _ := newService(userKeyName)
-	txResp, err := strategy.Unpause(ctx)
+	txResp, err := strategy.UnpauseAll(ctx)
 	if err != nil {
 		panic(err)
 	}

--- a/modules/bvs-cli/commands/strategybase/exec.go
+++ b/modules/bvs-cli/commands/strategybase/exec.go
@@ -40,7 +40,7 @@ func Withdraw(userKeyName, recipient string, amount uint64) {
 
 func Pause(uerKeyName string) {
 	strategyBase, _ := newService(uerKeyName)
-	resp, err := strategyBase.Pause(context.Background())
+	resp, err := strategyBase.PauseAll(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -49,7 +49,7 @@ func Pause(uerKeyName string) {
 
 func Unpause(userKeyName string) {
 	strategyBase, _ := newService(userKeyName)
-	resp, err := strategyBase.Unpause(context.Background())
+	resp, err := strategyBase.UnpauseAll(context.Background())
 	if err != nil {
 		panic(err)
 	}

--- a/modules/bvs-cli/commands/strategybasetvl/exec.go
+++ b/modules/bvs-cli/commands/strategybasetvl/exec.go
@@ -39,7 +39,7 @@ func Withdraw(userKeyName, recipient string, amount uint64) {
 
 func Pause(userKeyName string) {
 	StrategyBaseTVL, _ := newService(userKeyName)
-	resp, err := StrategyBaseTVL.Pause(context.Background())
+	resp, err := StrategyBaseTVL.PauseAll(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -48,7 +48,7 @@ func Pause(userKeyName string) {
 
 func Unpause(userKeyName string) {
 	StrategyBaseTVL, _ := newService(userKeyName)
-	resp, err := StrategyBaseTVL.Unpause(context.Background())
+	resp, err := StrategyBaseTVL.UnpauseAll(context.Background())
 	if err != nil {
 		panic(err)
 	}

--- a/modules/bvs-cli/commands/strategyfactory/exec.go
+++ b/modules/bvs-cli/commands/strategyfactory/exec.go
@@ -40,7 +40,7 @@ func UpdateConfig(userKeyName, newOwner string, strategyCodeId int64) {
 
 func Pause(userKeyName string) {
 	strategyFactory, _ := newService(userKeyName)
-	resp, err := strategyFactory.Pause(context.Background())
+	resp, err := strategyFactory.PauseAll(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -49,7 +49,7 @@ func Pause(userKeyName string) {
 
 func Unpause(userKeyName string) {
 	strategyFactory, _ := newService(userKeyName)
-	resp, err := strategyFactory.Unpause(context.Background())
+	resp, err := strategyFactory.UnpauseAll(context.Background())
 	if err != nil {
 		panic(err)
 	}

--- a/modules/bvs-cw/delegation-manager/schema.go
+++ b/modules/bvs-cw/delegation-manager/schema.go
@@ -267,8 +267,10 @@ type ExecuteMsg struct {
 	SetSlashManager                  *SetSlashManager                  `json:"set_slash_manager,omitempty"`
 	SetStrategyWithdrawalDelayBlocks *SetStrategyWithdrawalDelayBlocks `json:"set_strategy_withdrawal_delay_blocks,omitempty"`
 	TransferOwnership                *TransferOwnership                `json:"transfer_ownership,omitempty"`
-	Pause                            *Pause                            `json:"pause,omitempty"`
-	Unpause                          *Unpause                          `json:"unpause,omitempty"`
+	PauseAll                         *PauseAll                         `json:"pause_all,omitempty"`
+	UnpauseAll                       *UnpauseAll                       `json:"unpause_all,omitempty"`
+	PauseBit                         *PauseBit                         `json:"pause_bit,omitempty"`
+	UnpauseBit                       *UnpauseBit                       `json:"unpause_bit,omitempty"`
 	SetPauser                        *SetPauser                        `json:"set_pauser,omitempty"`
 	SetUnpauser                      *SetUnpauser                      `json:"set_unpauser,omitempty"`
 }
@@ -343,7 +345,18 @@ type ExecuteOperatorDetails struct {
 	StakerOptOutWindowBlocks   int64  `json:"staker_opt_out_window_blocks"`
 }
 
-type Pause struct {
+type PauseAll struct {
+}
+
+type UnpauseAll struct {
+}
+
+type PauseBit struct {
+	Index uint8 `json:"index"`
+}
+
+type UnpauseBit struct {
+	Index uint8 `json:"index"`
 }
 
 type QueueWithdrawals struct {
@@ -389,9 +402,6 @@ type TransferOwnership struct {
 
 type Undelegate struct {
 	Staker string `json:"staker"`
-}
-
-type Unpause struct {
 }
 
 type UpdateOperatorMetadataURI struct {

--- a/modules/bvs-cw/directory/schema.go
+++ b/modules/bvs-cw/directory/schema.go
@@ -177,8 +177,10 @@ type ExecuteMsg struct {
 	SetDelegationManager      *SetDelegationManager      `json:"set_delegation_manager,omitempty"`
 	CancelSalt                *CancelSalt                `json:"cancel_salt,omitempty"`
 	TransferOwnership         *TransferOwnership         `json:"transfer_ownership,omitempty"`
-	Pause                     *Pause                     `json:"pause,omitempty"`
-	Unpause                   *Unpause                   `json:"unpause,omitempty"`
+	PauseAll                  *PauseAll                  `json:"pause_all,omitempty"`
+	UnpauseAll                *UnpauseAll                `json:"unpause_all,omitempty"`
+	PauseBit                  *PauseBit                  `json:"pause_bit,omitempty"`
+	UnpauseBit                *UnpauseBit                `json:"unpause_bit,omitempty"`
 	SetPauser                 *SetPauser                 `json:"set_pauser,omitempty"`
 	SetUnpauser               *SetUnpauser               `json:"set_unpauser,omitempty"`
 }
@@ -191,7 +193,18 @@ type DeregisterOperatorFromBvs struct {
 	Operator string `json:"operator"`
 }
 
-type Pause struct {
+type PauseAll struct {
+}
+
+type UnpauseAll struct {
+}
+
+type PauseBit struct {
+	Index uint8 `json:"index"`
+}
+
+type UnpauseBit struct {
+	Index uint8 `json:"index"`
 }
 
 type RegisterBvs struct {
@@ -225,9 +238,6 @@ type SetUnpauser struct {
 
 type TransferOwnership struct {
 	NewOwner string `json:"new_owner"`
-}
-
-type Unpause struct {
 }
 
 type UpdateBvsMetadataURI struct {

--- a/modules/bvs-cw/rewards-coordinator/schema.go
+++ b/modules/bvs-cw/rewards-coordinator/schema.go
@@ -215,8 +215,10 @@ type ExecuteMsg struct {
 	SetRewardsForAllSubmitter     *SetRewardsForAllSubmitter     `json:"set_rewards_for_all_submitter,omitempty"`
 	SetGlobalOperatorCommission   *SetGlobalOperatorCommission   `json:"set_global_operator_commission,omitempty"`
 	TransferOwnership             *TransferOwnership             `json:"transfer_ownership,omitempty"`
-	Pause                         *Pause                         `json:"pause,omitempty"`
-	Unpause                       *Unpause                       `json:"unpause,omitempty"`
+	PauseAll                      *PauseAll                      `json:"pause_all,omitempty"`
+	UnpauseAll                    *UnpauseAll                    `json:"unpause_all,omitempty"`
+	PauseBit                      *PauseBit                      `json:"pause_bit,omitempty"`
+	UnpauseBit                    *UnpauseBit                    `json:"unpause_bit,omitempty"`
 	SetPauser                     *SetPauser                     `json:"set_pauser,omitempty"`
 	SetUnpauser                   *SetUnpauser                   `json:"set_unpauser,omitempty"`
 }
@@ -246,7 +248,18 @@ type DisableRoot struct {
 	RootIndex int64 `json:"root_index"`
 }
 
-type Pause struct {
+type PauseAll struct {
+}
+
+type UnpauseAll struct {
+}
+
+type PauseBit struct {
+	Index uint8 `json:"index"`
+}
+
+type UnpauseBit struct {
+	Index uint8 `json:"index"`
 }
 
 type ProcessClaim struct {
@@ -310,9 +323,6 @@ type SubmitRoot struct {
 
 type TransferOwnership struct {
 	NewOwner string `json:"new_owner"`
-}
-
-type Unpause struct {
 }
 
 type QueryMsg struct {

--- a/modules/bvs-cw/slash-manager/schema.go
+++ b/modules/bvs-cw/slash-manager/schema.go
@@ -115,8 +115,10 @@ type ExecuteMsg struct {
 	SetDelegationManager     *SetDelegationManager     `json:"set_delegation_manager,omitempty"`
 	SetStrategyManager       *SetStrategyManager       `json:"set_strategy_manager,omitempty"`
 	TransferOwnership        *TransferOwnership        `json:"transfer_ownership,omitempty"`
-	Pause                    *Pause                    `json:"pause,omitempty"`
-	Unpause                  *Unpause                  `json:"unpause,omitempty"`
+	PauseAll                 *PauseAll                 `json:"pause_all,omitempty"`
+	UnpauseAll               *UnpauseAll               `json:"unpause_all,omitempty"`
+	PauseBit                 *PauseBit                 `json:"pause_bit,omitempty"`
+	UnpauseBit               *UnpauseBit               `json:"unpause_bit,omitempty"`
 	SetPauser                *SetPauser                `json:"set_pauser,omitempty"`
 	SetUnpauser              *SetUnpauser              `json:"set_unpauser,omitempty"`
 }
@@ -131,7 +133,18 @@ type ExecuteSlashRequest struct {
 	ValidatorsPublicKeys []string `json:"validators_public_keys"`
 }
 
-type Pause struct {
+type PauseAll struct {
+}
+
+type UnpauseAll struct {
+}
+
+type PauseBit struct {
+	Index uint8 `json:"index"`
+}
+
+type UnpauseBit struct {
+	Index uint8 `json:"index"`
 }
 
 type SetDelegationManager struct {
@@ -183,9 +196,6 @@ type SubmitSlashRequestSlashDetails struct {
 
 type TransferOwnership struct {
 	NewOwner string `json:"new_owner"`
-}
-
-type Unpause struct {
 }
 
 type QueryMsg struct {

--- a/modules/bvs-cw/strategy-base-tvl-limits/schema.go
+++ b/modules/bvs-cw/strategy-base-tvl-limits/schema.go
@@ -203,8 +203,10 @@ type ExecuteMsg struct {
 	Withdraw           *Withdraw           `json:"withdraw,omitempty"`
 	SetStrategyManager *SetStrategyManager `json:"set_strategy_manager,omitempty"`
 	TransferOwnership  *TransferOwnership  `json:"transfer_ownership,omitempty"`
-	Pause              *Pause              `json:"pause,omitempty"`
-	Unpause            *Unpause            `json:"unpause,omitempty"`
+	PauseAll           *PauseAll           `json:"pause_all,omitempty"`
+	UnpauseAll         *UnpauseAll         `json:"unpause_all,omitempty"`
+	PauseBit           *PauseBit           `json:"pause_bit,omitempty"`
+	UnpauseBit         *UnpauseBit         `json:"unpause_bit,omitempty"`
 	SetPauser          *SetPauser          `json:"set_pauser,omitempty"`
 	SetUnpauser        *SetUnpauser        `json:"set_unpauser,omitempty"`
 	SetTvlLimits       *SetTvlLimits       `json:"set_tvl_limits,omitempty"`
@@ -214,7 +216,18 @@ type Deposit struct {
 	Amount string `json:"amount"`
 }
 
-type Pause struct {
+type PauseAll struct {
+}
+
+type UnpauseAll struct {
+}
+
+type PauseBit struct {
+	Index uint8 `json:"index"`
+}
+
+type UnpauseBit struct {
+	Index uint8 `json:"index"`
 }
 
 type SetPauser struct {
@@ -236,9 +249,6 @@ type SetUnpauser struct {
 
 type TransferOwnership struct {
 	NewOwner string `json:"new_owner"`
-}
-
-type Unpause struct {
 }
 
 type Withdraw struct {

--- a/modules/bvs-cw/strategy-base/schema.go
+++ b/modules/bvs-cw/strategy-base/schema.go
@@ -188,8 +188,10 @@ type ExecuteMsg struct {
 	Withdraw           *Withdraw           `json:"withdraw,omitempty"`
 	SetStrategyManager *SetStrategyManager `json:"set_strategy_manager,omitempty"`
 	TransferOwnership  *TransferOwnership  `json:"transfer_ownership,omitempty"`
-	Pause              *Pause              `json:"pause,omitempty"`
-	Unpause            *Unpause            `json:"unpause,omitempty"`
+	PauseAll           *PauseAll           `json:"pause_all,omitempty"`
+	UnpauseAll         *UnpauseAll         `json:"unpause_all,omitempty"`
+	PauseBit           *PauseBit           `json:"pause_bit,omitempty"`
+	UnpauseBit         *UnpauseBit         `json:"unpause_bit,omitempty"`
 	SetPauser          *SetPauser          `json:"set_pauser,omitempty"`
 	SetUnpauser        *SetUnpauser        `json:"set_unpauser,omitempty"`
 }
@@ -198,7 +200,18 @@ type Deposit struct {
 	Amount string `json:"amount"`
 }
 
-type Pause struct {
+type PauseAll struct {
+}
+
+type UnpauseAll struct {
+}
+
+type PauseBit struct {
+	Index uint8 `json:"index"`
+}
+
+type UnpauseBit struct {
+	Index uint8 `json:"index"`
 }
 
 type SetPauser struct {
@@ -215,9 +228,6 @@ type SetUnpauser struct {
 
 type TransferOwnership struct {
 	NewOwner string `json:"new_owner"`
-}
-
-type Unpause struct {
 }
 
 type Withdraw struct {

--- a/modules/bvs-cw/strategy-factory/schema.go
+++ b/modules/bvs-cw/strategy-factory/schema.go
@@ -88,8 +88,10 @@ type ExecuteMsg struct {
 	WhitelistStrategies             *WhitelistStrategies             `json:"whitelist_strategies,omitempty"`
 	SetStrategyManager              *SetStrategyManager              `json:"set_strategy_manager,omitempty"`
 	TransferOwnership               *TransferOwnership               `json:"transfer_ownership,omitempty"`
-	Pause                           *Pause                           `json:"pause,omitempty"`
-	Unpause                         *Unpause                         `json:"unpause,omitempty"`
+	PauseAll                        *PauseAll                        `json:"pause_all,omitempty"`
+	UnpauseAll                      *UnpauseAll                      `json:"unpause_all,omitempty"`
+	PauseBit                        *PauseBit                        `json:"pause_bit,omitempty"`
+	UnpauseBit                      *UnpauseBit                      `json:"unpause_bit,omitempty"`
 	SetPauser                       *SetPauser                       `json:"set_pauser,omitempty"`
 	SetUnpauser                     *SetUnpauser                     `json:"set_unpauser,omitempty"`
 }
@@ -104,7 +106,18 @@ type DeployNewStrategy struct {
 	Unpauser string `json:"unpauser"`
 }
 
-type Pause struct {
+type PauseAll struct {
+}
+
+type UnpauseAll struct {
+}
+
+type PauseBit struct {
+	Index uint8 `json:"index"`
+}
+
+type UnpauseBit struct {
+	Index uint8 `json:"index"`
 }
 
 type RemoveStrategiesFromWhitelist struct {
@@ -130,9 +143,6 @@ type SetUnpauser struct {
 
 type TransferOwnership struct {
 	NewOwner string `json:"new_owner"`
-}
-
-type Unpause struct {
 }
 
 type UpdateConfig struct {

--- a/modules/bvs-cw/strategy-manager/schema.go
+++ b/modules/bvs-cw/strategy-manager/schema.go
@@ -264,8 +264,10 @@ type ExecuteMsg struct {
 	SetSlashManager                  *SetSlashManager                  `json:"set_slash_manager,omitempty"`
 	SetStrategyFactory               *SetStrategyFactory               `json:"set_strategy_factory,omitempty"`
 	TransferOwnership                *TransferOwnership                `json:"transfer_ownership,omitempty"`
-	Pause                            *Pause                            `json:"pause,omitempty"`
-	Unpause                          *Unpause                          `json:"unpause,omitempty"`
+	PauseAll                         *PauseAll                         `json:"pause_all,omitempty"`
+	UnpauseAll                       *UnpauseAll                       `json:"unpause_all,omitempty"`
+	PauseBit                         *PauseBit                         `json:"pause_bit,omitempty"`
+	UnpauseBit                       *UnpauseBit                       `json:"unpause_bit,omitempty"`
 	SetPauser                        *SetPauser                        `json:"set_pauser,omitempty"`
 	SetUnpauser                      *SetUnpauser                      `json:"set_unpauser,omitempty"`
 }
@@ -298,7 +300,18 @@ type DepositIntoStrategyWithSignature struct {
 	Token     string `json:"token"`
 }
 
-type Pause struct {
+type PauseAll struct {
+}
+
+type UnpauseAll struct {
+}
+
+type PauseBit struct {
+	Index uint8 `json:"index"`
+}
+
+type UnpauseBit struct {
+	Index uint8 `json:"index"`
 }
 
 type RemoveShares struct {
@@ -342,9 +355,6 @@ type SetUnpauser struct {
 
 type TransferOwnership struct {
 	NewOwner string `json:"new_owner"`
-}
-
-type Unpause struct {
 }
 
 type WithdrawSharesAsTokens struct {


### PR DESCRIPTION
#### What this PR does / why we need it:

contract required updates

fix: q7
resolve incompatibility of only_when_not_paused modifier with standard pause/unpause mechanisms and add granularity for pausing specific fields

<!-- remove if not applicable -->
Closes [SL-213](https://linear.app/satlayer/issue/SL-213)
Fixes Q7