### PR TITLE
fix: SATL-09 add `earner_tree_depth` and `token_tree_depth` parameters

### DIFF
--- a/examples/squaring/modules/uploader/uploader/rpc.go
+++ b/examples/squaring/modules/uploader/uploader/rpc.go
@@ -135,9 +135,9 @@ func (u *Uploader) rpcUnderlyingToken(strategy string) (string, error) {
 // timestamp that is one hour ago from the current time.
 //
 // The method returns an error if the transaction fails.
-func (u *Uploader) rpcSubmitHashRoot(rootHash string) error {
+func (u *Uploader) rpcSubmitHashRoot(rootHash string, earnerTreeDepth, tokenTreeDepth uint8) error {
 	timestamp := time.Now().Unix() - 3600
-	rsp, err := u.rewardsCoordinator.SubmitRoot(context.Background(), rootHash, timestamp)
+	rsp, err := u.rewardsCoordinator.SubmitRoot(context.Background(), rootHash, timestamp, earnerTreeDepth, tokenTreeDepth)
 	if err != nil {
 		fmt.Println("SubmitRootHash err: ", err)
 		return err

--- a/examples/squaring/modules/uploader/uploader/uploader.go
+++ b/examples/squaring/modules/uploader/uploader/uploader.go
@@ -256,7 +256,15 @@ func (u *Uploader) calcReward(ctx context.Context, taskId string, operators stri
 	}
 	fmt.Printf("root Hash: %s\n", rootHash)
 
-	if err := u.rpcSubmitHashRoot(rootHash); err != nil {
+	totalTokens := 0
+	for _, earner := range totalEarners {
+		totalTokens += len(earner.Tokens)
+	}
+	tokenTreeDepth := uint8(math.Ceil(math.Log2(float64(totalTokens))))
+	earnerTreeDepth := uint8(math.Ceil(math.Log2(float64(len(totalEarners)))))
+	fmt.Printf("earnerTreeDepth: %d, tokenTreeDepth: %d\n", earnerTreeDepth, tokenTreeDepth)
+
+	if err := u.rpcSubmitHashRoot(rootHash, earnerTreeDepth, tokenTreeDepth); err != nil {
 		fmt.Println("rpc root hash err: ", err)
 		return
 	}

--- a/modules/bvs-api/chainio/api/rewards_coordinator.go
+++ b/modules/bvs-api/chainio/api/rewards_coordinator.go
@@ -94,11 +94,13 @@ func (r *RewardsCoordinator) ProcessClaim(ctx context.Context, claim rewardscoor
 	return r.io.SendTransaction(ctx, executeOptions)
 }
 
-func (r *RewardsCoordinator) SubmitRoot(ctx context.Context, root string, rewardsCalculationEndTimestamp int64) (*coretypes.ResultTx, error) {
+func (r *RewardsCoordinator) SubmitRoot(ctx context.Context, root string, rewardsCalculationEndTimestamp int64, earnerTreeDepth, tokenTreeDepth uint8) (*coretypes.ResultTx, error) {
 	msg := rewardscoordinator.ExecuteMsg{
 		SubmitRoot: &rewardscoordinator.SubmitRoot{
-			Root:                           root,
 			RewardsCalculationEndTimestamp: rewardsCalculationEndTimestamp,
+			Root:                           root,
+			EarnerTreeDepth:                earnerTreeDepth,
+			TokenTreeDepth:                 tokenTreeDepth,
 		},
 	}
 

--- a/modules/bvs-api/tests/e2e/rewards_coordinator_test.go
+++ b/modules/bvs-api/tests/e2e/rewards_coordinator_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -256,11 +257,13 @@ func (suite *rewardsTestSuite) Test_SubmitRoot() {
 
 	earnerLeaf1, tokenRootHash1, _ := suite.calculateEarnerLeaf(rewardsCoordinator, t)
 	t.Logf("earner leaf1:%+v", bytesToString(earnerLeaf1))
-
-	resp, err := rewardsCoordinator.MerkleizeLeaves([]string{
+	earnerLeafArr := []string{
 		base64.StdEncoding.EncodeToString(earnerLeaf),
 		base64.StdEncoding.EncodeToString(earnerLeaf1),
-	})
+	}
+	tokenTreeDepth := uint8(math.Ceil(math.Log2(float64(len(earnerLeafArr) * 2))))
+	earnerTreeDepth := uint8(math.Ceil(math.Log2(float64(len(earnerLeafArr)))))
+	resp, err := rewardsCoordinator.MerkleizeLeaves(earnerLeafArr)
 	assert.NoError(t, err, "execute contract")
 	assert.NotNil(t, resp, "response nil")
 	t.Logf("resp:%+v, %+v, %+v, %+v", resp, tokenRootHash, leafB, tokenRootHash1)
@@ -273,7 +276,7 @@ func (suite *rewardsTestSuite) Test_SubmitRoot() {
 	t.Logf("root hash:%+v", rootHash)
 
 	timestamp := time.Now().Unix() - 3600
-	res, err := rewardsCoordinator.SubmitRoot(context.Background(), base64.StdEncoding.EncodeToString(rootHash), timestamp)
+	res, err := rewardsCoordinator.SubmitRoot(context.Background(), base64.StdEncoding.EncodeToString(rootHash), timestamp, earnerTreeDepth, tokenTreeDepth)
 	assert.NoError(t, err, "execute contract")
 	assert.NotNil(t, res, "response nil")
 	t.Logf("resp:%+v", res)

--- a/modules/bvs-cw/rewards-coordinator/schema.go
+++ b/modules/bvs-cw/rewards-coordinator/schema.go
@@ -306,6 +306,8 @@ type SetUnpauser struct {
 type SubmitRoot struct {
 	RewardsCalculationEndTimestamp int64  `json:"rewards_calculation_end_timestamp"`
 	Root                           string `json:"root"`
+	EarnerTreeDepth                uint8  `json:"earner_tree_depth"`
+	TokenTreeDepth                 uint8  `json:"token_tree_depth"`
 }
 
 type TransferOwnership struct {


### PR DESCRIPTION
#### What this PR does / why we need it:

contract required updates

fix: SATL-09
add earner_tree_depth and token_tree_depth parameters to submit_root in RewardsCoordinator contract

<!-- remove if not applicable -->
Fixes [SL-91](https://linear.app/satlayer/issue/SL-91)
Closes SATL-09