### PR TITLE
fix: SATL-11 enqueued withdrawal wait time

### DIFF
--- a/crates/bvs-delegation-manager/src/state.rs
+++ b/crates/bvs-delegation-manager/src/state.rs
@@ -17,6 +17,7 @@ pub const OPERATOR_SHARES: Map<(&Addr, &Addr), Uint128> = Map::new("operator_sha
 pub const PENDING_WITHDRAWALS: Map<&[u8], bool> = Map::new("pending_withdrawals");
 pub const STRATEGY_WITHDRAWAL_DELAY_BLOCKS: Map<&Addr, u64> =
     Map::new("strategy_withdrawal_delay_blocks");
+pub const WITHDRAWAL_DELAYS: Map<&[u8], Vec<u64>> = Map::new("withdrawal_delays");
 pub const MIN_WITHDRAWAL_DELAY_BLOCKS: Item<u64> = Item::new("min_withdrawal_delay_blocks");
 pub const CUMULATIVE_WITHDRAWALS_QUEUED: Map<&Addr, Uint128> =
     Map::new("cumulative_withdrawals_queued");


### PR DESCRIPTION
#### What this PR does / why we need it:

This fix is to resolve: Stakers with enqueued withdrawals can be forced to wait more than expected.

Closes SL-93
