### PR TITLE
feat: move controller init logic to SetController

### DIFF
--- a/crates/bvs-rewards-coordinator/src/contract.rs
+++ b/crates/bvs-rewards-coordinator/src/contract.rs
@@ -2,6 +2,7 @@
 use cosmwasm_std::entry_point;
 
 use crate::{
+    controller,
     error::ContractError,
     msg::{DistributionRoot, ExecuteMsg, InstantiateMsg, QueryMsg},
     query::{
@@ -12,10 +13,9 @@ use crate::{
     },
     state::{
         ACTIVATION_DELAY, CALCULATION_INTERVAL_SECONDS, CLAIMER_FOR, CUMULATIVE_CLAIMED,
-        CURR_REWARDS_CALCULATION_END_TIMESTAMP, DELEGATION_MANAGER, DISTRIBUTION_ROOTS,
-        DISTRIBUTION_ROOTS_COUNT, GENESIS_REWARDS_TIMESTAMP, GLOBAL_OPERATOR_COMMISSION_BIPS,
-        IS_BVS_REWARDS_SUBMISSION_HASH, MAX_FUTURE_LENGTH, MAX_RETROACTIVE_LENGTH,
-        MAX_REWARDS_DURATION, OWNER, REWARDS_FOR_ALL_SUBMITTER, REWARDS_UPDATER, STRATEGY_MANAGER,
+        CURR_REWARDS_CALCULATION_END_TIMESTAMP, DISTRIBUTION_ROOTS, DISTRIBUTION_ROOTS_COUNT,
+        GENESIS_REWARDS_TIMESTAMP, GLOBAL_OPERATOR_COMMISSION_BIPS, IS_BVS_REWARDS_SUBMISSION_HASH,
+        MAX_FUTURE_LENGTH, MAX_RETROACTIVE_LENGTH, MAX_REWARDS_DURATION, REWARDS_FOR_ALL_SUBMITTER,
         SUBMISSION_NONCE,
     },
     utils::{
@@ -59,30 +59,20 @@ pub fn instantiate(
         return Err(ContractError::InvalidCalculationInterval {});
     }
 
-    let initial_owner = deps.api.addr_validate(&msg.initial_owner)?;
-
-    let strategy_manager = deps.api.addr_validate(&msg.strategy_manager)?;
-    let delegation_manager = deps.api.addr_validate(&msg.delegation_manager)?;
-
-    let rewards_updater = deps.api.addr_validate(&msg.rewards_updater)?;
-
-    OWNER.save(deps.storage, &initial_owner)?;
+    let owner = deps.api.addr_validate(&msg.owner)?;
+    controller::OWNER.save(deps.storage, &owner)?;
 
     CALCULATION_INTERVAL_SECONDS.save(deps.storage, &msg.calculation_interval_seconds)?;
     MAX_REWARDS_DURATION.save(deps.storage, &msg.max_rewards_duration)?;
     MAX_RETROACTIVE_LENGTH.save(deps.storage, &msg.max_retroactive_length)?;
     MAX_FUTURE_LENGTH.save(deps.storage, &msg.max_future_length)?;
     GENESIS_REWARDS_TIMESTAMP.save(deps.storage, &msg.genesis_rewards_timestamp)?;
-    DELEGATION_MANAGER.save(deps.storage, &delegation_manager)?;
-    STRATEGY_MANAGER.save(deps.storage, &strategy_manager)?;
 
-    set_rewards_updater_internal(deps.branch(), rewards_updater.clone())?;
     set_activation_delay_internal(deps.branch(), msg.activation_delay)?;
 
     Ok(Response::new()
         .add_attribute("method", "instantiate")
-        .add_attribute("owner", initial_owner.to_string())
-        .add_attribute("rewards_updater", msg.rewards_updater.to_string())
+        .add_attribute("owner", owner.to_string())
         .add_attribute("activation_delay", msg.activation_delay.to_string()))
 }
 
@@ -141,10 +131,6 @@ pub fn execute(
         ExecuteMsg::SetActivationDelay {
             new_activation_delay,
         } => set_activation_delay(deps, info, new_activation_delay),
-        ExecuteMsg::SetRewardsUpdater { new_updater } => {
-            let new_updater = deps.api.addr_validate(&new_updater)?;
-            set_rewards_updater(deps, info, new_updater)
-        }
         ExecuteMsg::SetRewardsForAllSubmitter {
             submitter,
             new_value,
@@ -155,9 +141,25 @@ pub fn execute(
         ExecuteMsg::SetGlobalOperatorCommission {
             new_commission_bips,
         } => set_global_operator_commission(deps, info, new_commission_bips),
-        ExecuteMsg::TransferOwnership { new_owner } => {
-            let new_owner = deps.api.addr_validate(&new_owner)?;
-            transfer_ownership(deps, info, new_owner)
+        ExecuteMsg::SetController {
+            owner,
+            rewards_updater,
+            delegation_manager,
+            strategy_manager,
+        } => {
+            let owner = deps.api.addr_validate(&owner)?;
+            let rewards_updater = deps.api.addr_validate(&rewards_updater)?;
+            let delegation_manager = deps.api.addr_validate(&delegation_manager)?;
+            let strategy_manager = deps.api.addr_validate(&strategy_manager)?;
+
+            controller::set_controller(
+                deps,
+                &info,
+                owner,
+                rewards_updater,
+                delegation_manager,
+                strategy_manager,
+            )
         }
     }
 }
@@ -356,7 +358,7 @@ pub fn submit_root(
     root: Binary,
     rewards_calculation_end_timestamp: u64,
 ) -> Result<Response, ContractError> {
-    only_rewards_updater(deps.as_ref(), &info)?;
+    controller::only_rewards_updater(deps.as_ref(), &info)?;
 
     let curr_rewards_calculation_end_timestamp = CURR_REWARDS_CALCULATION_END_TIMESTAMP
         .may_load(deps.storage)?
@@ -413,7 +415,7 @@ pub fn disable_root(
     info: MessageInfo,
     root_index: u64,
 ) -> Result<Response, ContractError> {
-    only_rewards_updater(deps.as_ref(), &info)?;
+    controller::only_rewards_updater(deps.as_ref(), &info)?;
 
     let roots_length = DISTRIBUTION_ROOTS_COUNT.load(deps.storage)?;
     if root_index >= roots_length {
@@ -475,20 +477,9 @@ pub fn set_activation_delay(
     info: MessageInfo,
     new_activation_delay: u32,
 ) -> Result<Response, ContractError> {
-    only_owner(deps.as_ref(), &info)?;
+    controller::only_owner(deps.as_ref(), &info)?;
 
     let res = set_activation_delay_internal(deps, new_activation_delay)?;
-    Ok(res)
-}
-
-pub fn set_rewards_updater(
-    deps: DepsMut,
-    info: MessageInfo,
-    new_updater: Addr,
-) -> Result<Response, ContractError> {
-    only_owner(deps.as_ref(), &info)?;
-
-    let res = set_rewards_updater_internal(deps, new_updater)?;
     Ok(res)
 }
 
@@ -498,7 +489,7 @@ pub fn set_rewards_for_all_submitter(
     submitter: Addr,
     new_value: bool,
 ) -> Result<Response, ContractError> {
-    only_owner(deps.as_ref(), &info)?;
+    controller::only_owner(deps.as_ref(), &info)?;
 
     let prev_value = REWARDS_FOR_ALL_SUBMITTER
         .may_load(deps.storage, submitter.clone())?
@@ -517,30 +508,10 @@ pub fn set_global_operator_commission(
     info: MessageInfo,
     new_commission_bips: u16,
 ) -> Result<Response, ContractError> {
-    only_owner(deps.as_ref(), &info)?;
+    controller::only_owner(deps.as_ref(), &info)?;
 
     let res = set_global_operator_commission_internal(deps, new_commission_bips)?;
     Ok(res)
-}
-
-pub fn transfer_ownership(
-    deps: DepsMut,
-    info: MessageInfo,
-    new_owner: Addr,
-) -> Result<Response, ContractError> {
-    let current_owner = OWNER.load(deps.storage)?;
-
-    if current_owner != info.sender {
-        return Err(ContractError::Unauthorized {});
-    }
-
-    OWNER.save(deps.storage, &new_owner)?;
-
-    let event = Event::new("TransferOwnership")
-        .add_attribute("method", "transfer_ownership")
-        .add_attribute("new_owner", new_owner.to_string());
-
-    Ok(Response::new().add_event(event))
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
@@ -767,29 +738,12 @@ pub fn query_check_claim(
     Ok(CheckClaimResponse { check_claim })
 }
 
-fn only_rewards_updater(deps: Deps, info: &MessageInfo) -> Result<(), ContractError> {
-    let rewards_updater = REWARDS_UPDATER.load(deps.storage)?;
-
-    if info.sender != rewards_updater {
-        return Err(ContractError::NotRewardsUpdater {});
-    }
-    Ok(())
-}
-
 fn only_rewards_for_all_submitter(deps: Deps, info: &MessageInfo) -> Result<(), ContractError> {
     let is_submitter = REWARDS_FOR_ALL_SUBMITTER
         .may_load(deps.storage, info.sender.clone())?
         .unwrap_or(false);
     if !is_submitter {
         return Err(ContractError::ValidCreateRewardsForAllSubmission {});
-    }
-    Ok(())
-}
-
-fn only_owner(deps: Deps, info: &MessageInfo) -> Result<(), ContractError> {
-    let owner = OWNER.load(deps.storage)?;
-    if info.sender != owner {
-        return Err(ContractError::Unauthorized {});
     }
     Ok(())
 }
@@ -838,7 +792,7 @@ fn validate_rewards_submission(
 
     let mut current_address = Addr::unchecked("");
 
-    let strategy_manager = STRATEGY_MANAGER.load(deps.storage)?;
+    let strategy_manager = controller::STRATEGY_MANAGER.load(deps.storage)?;
 
     for strategy_multiplier in &submission.strategies_and_multipliers {
         let strategy = &strategy_multiplier.strategy;
@@ -989,19 +943,6 @@ fn set_global_operator_commission_internal(
     Ok(Response::new().add_event(event))
 }
 
-fn set_rewards_updater_internal(
-    deps: DepsMut,
-    new_updater: Addr,
-) -> Result<Response, ContractError> {
-    REWARDS_UPDATER.save(deps.storage, &new_updater)?;
-
-    let event = Event::new("SetRewardsUpdater")
-        .add_attribute("method", "set_rewards_updater")
-        .add_attribute("new_updater", new_updater.to_string());
-
-    Ok(Response::new().add_event(event))
-}
-
 fn token_balance(querier: &QuerierWrapper, token: &Addr, account: &Addr) -> StdResult<Uint128> {
     let res: Cw20BalanceResponse = querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
         contract_addr: token.to_string(),
@@ -1015,6 +956,7 @@ fn token_balance(querier: &QuerierWrapper, token: &Addr, account: &Addr) -> StdR
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::controller::set_controller;
     use crate::msg::DistributionRoot;
     use crate::utils::{
         sha256, ExecuteEarnerTreeMerkleLeaf, ExecuteRewardsMerkleClaim, StrategyAndMultiplier,
@@ -1038,40 +980,32 @@ mod tests {
         let env = mock_env();
         let info = message_info(&Addr::unchecked("creator"), &[]);
 
-        let delegation_manager = deps.api.addr_make("delegation_manager").to_string();
-        let strategy_manager = deps.api.addr_make("strategy_manager").to_string();
-        let initial_owner = deps.api.addr_make("initial_owner").to_string();
-        let rewards_updater = deps.api.addr_make("rewards_updater").to_string();
+        let owner = deps.api.addr_make("owner").to_string();
         let registry = deps.api.addr_make("registry").to_string();
 
         let msg = InstantiateMsg {
-            initial_owner: initial_owner.clone(),
+            owner: owner.clone(),
             calculation_interval_seconds: 86_400, // 1 day
             max_rewards_duration: 30 * 86_400,    // 30 days
             max_retroactive_length: 5 * 86_400,   // 5 days
             max_future_length: 10 * 86_400,       // 10 days
             genesis_rewards_timestamp: env.block.time.seconds() / 86_400 * 86_400,
-            delegation_manager: delegation_manager.clone(),
-            strategy_manager: strategy_manager.clone(),
-            rewards_updater: rewards_updater.clone(),
             activation_delay: 60,
             registry,
         };
 
         let res = instantiate(deps.as_mut(), env.clone(), info.clone(), msg.clone()).unwrap();
 
-        assert_eq!(res.attributes.len(), 4);
+        assert_eq!(res.attributes.len(), 3);
         assert_eq!(res.attributes[0].key, "method");
         assert_eq!(res.attributes[0].value, "instantiate");
         assert_eq!(res.attributes[1].key, "owner");
-        assert_eq!(res.attributes[1].value, initial_owner.to_string());
-        assert_eq!(res.attributes[2].key, "rewards_updater");
-        assert_eq!(res.attributes[2].value, rewards_updater.to_string());
-        assert_eq!(res.attributes[3].key, "activation_delay");
-        assert_eq!(res.attributes[3].value, "60");
+        assert_eq!(res.attributes[1].value, owner.to_string());
+        assert_eq!(res.attributes[2].key, "activation_delay");
+        assert_eq!(res.attributes[2].value, "60");
 
-        let stored_owner = OWNER.load(&deps.storage).unwrap();
-        assert_eq!(stored_owner, Addr::unchecked(initial_owner));
+        let stored_owner = controller::OWNER.load(&deps.storage).unwrap();
+        assert_eq!(stored_owner, Addr::unchecked(owner));
 
         let stored_calculation_interval = CALCULATION_INTERVAL_SECONDS.load(&deps.storage).unwrap();
         assert_eq!(stored_calculation_interval, 86_400);
@@ -1091,21 +1025,6 @@ mod tests {
             stored_genesis_rewards_timestamp,
             msg.genesis_rewards_timestamp
         );
-
-        let stored_delegation_manager = DELEGATION_MANAGER.load(&deps.storage).unwrap();
-        assert_eq!(
-            stored_delegation_manager,
-            Addr::unchecked(delegation_manager)
-        );
-
-        let stored_strategy_manager = STRATEGY_MANAGER.load(&deps.storage).unwrap();
-        assert_eq!(stored_strategy_manager, Addr::unchecked(strategy_manager));
-
-        let stored_activation_delay = ACTIVATION_DELAY.load(&deps.storage).unwrap();
-        assert_eq!(stored_activation_delay, 60);
-
-        let stored_rewards_updater = REWARDS_UPDATER.load(&deps.storage).unwrap();
-        assert_eq!(stored_rewards_updater, Addr::unchecked(rewards_updater));
     }
 
     fn instantiate_contract() -> (
@@ -1121,32 +1040,30 @@ mod tests {
         let mut deps = mock_dependencies();
         let env = mock_env();
 
-        let initial_owner = deps.api.addr_make("initial_owner").to_string();
+        let owner = deps.api.addr_make("owner").to_string();
+        let registry = deps.api.addr_make("registry").to_string();
+
         let delegation_manager = deps.api.addr_make("delegation_manager").to_string();
         let strategy_manager = deps.api.addr_make("strategy_manager").to_string();
         let pauser = deps.api.addr_make("pauser").to_string();
         let unpauser = deps.api.addr_make("unpauser").to_string();
         let rewards_updater = deps.api.addr_make("rewards_updater").to_string();
 
-        let owner_info = message_info(&Addr::unchecked(initial_owner.clone()), &[]);
+        let owner_info = message_info(&Addr::unchecked(owner.clone()), &[]);
         let pauser_info = message_info(&Addr::unchecked(pauser.clone()), &[]);
         let unpauser_info = message_info(&Addr::unchecked(unpauser.clone()), &[]);
         let strategy_manager_info = message_info(&Addr::unchecked(strategy_manager.clone()), &[]);
         let delegation_manager_info =
             message_info(&Addr::unchecked(delegation_manager.clone()), &[]);
         let rewards_updater_info = message_info(&Addr::unchecked(rewards_updater.clone()), &[]);
-        let registry = deps.api.addr_make("registry").to_string();
 
         let msg = InstantiateMsg {
-            initial_owner: initial_owner.clone(),
+            owner: owner.clone(),
             calculation_interval_seconds: 86_400, // 1 day
             max_rewards_duration: 30 * 86_400,    // 30 days
             max_retroactive_length: 5 * 86_400,   // 5 days
             max_future_length: 10 * 86_400,       // 10 days
             genesis_rewards_timestamp: env.block.time.seconds() / 86_400 * 86_400,
-            delegation_manager: delegation_manager.clone(),
-            strategy_manager: strategy_manager.clone(),
-            rewards_updater: rewards_updater.clone(),
             activation_delay: 60, // 1 minute
             registry,
         };
@@ -1163,56 +1080,6 @@ mod tests {
             delegation_manager_info,
             rewards_updater_info,
         )
-    }
-
-    #[test]
-    fn test_only_rewards_updater_success() {
-        let (
-            mut deps,
-            _env,
-            _owner_info,
-            _pauser_info,
-            _unpauser_info,
-            _strategy_manager_info,
-            _delegation_manager_info,
-            _rewards_updater_info,
-        ) = instantiate_contract();
-
-        let rewards_updater_addr = deps.api.addr_make("rewards_updater");
-
-        REWARDS_UPDATER
-            .save(&mut deps.storage, &(rewards_updater_addr))
-            .unwrap();
-
-        let info = message_info(&Addr::unchecked(rewards_updater_addr), &[]);
-        let result = only_rewards_updater(deps.as_ref(), &info);
-
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_only_rewards_updater_failure() {
-        let (
-            mut deps,
-            _env,
-            _owner_info,
-            _pauser_info,
-            _unpauser_info,
-            _strategy_manager_info,
-            _delegation_manager_info,
-            _rewards_updater_info,
-        ) = instantiate_contract();
-
-        let rewards_updater_addr = deps.api.addr_make("rewards_updater");
-
-        REWARDS_UPDATER
-            .save(&mut deps.storage, &rewards_updater_addr)
-            .unwrap();
-
-        let info = message_info(&Addr::unchecked("not_rewards_updater"), &[]);
-        let result = only_rewards_updater(deps.as_ref(), &info);
-
-        assert_eq!(result, Err(ContractError::NotRewardsUpdater {}));
     }
 
     #[test]
@@ -1258,27 +1125,6 @@ mod tests {
     }
 
     #[test]
-    fn test_only_owner() {
-        let (
-            deps,
-            _env,
-            owner_info,
-            _pauser_info,
-            _unpauser_info,
-            _strategy_manager_info,
-            _delegation_manager_info,
-            _rewards_updater_info,
-        ) = instantiate_contract();
-
-        let result = only_owner(deps.as_ref(), &owner_info);
-        assert!(result.is_ok());
-
-        let info = message_info(&Addr::unchecked("not_owner"), &[]);
-        let result = only_owner(deps.as_ref(), &info);
-        assert_eq!(result, Err(ContractError::Unauthorized {}));
-    }
-
-    #[test]
     fn test_validate_rewards_submission() {
         let (
             mut deps,
@@ -1309,6 +1155,10 @@ mod tests {
             token: deps.api.addr_make("token"),
         };
 
+        let strategy_manager = deps.api.addr_make("strategy_manager");
+        controller::STRATEGY_MANAGER
+            .save(&mut deps.storage, &strategy_manager)
+            .unwrap();
         deps.querier.update_wasm(move |query| match query {
             WasmQuery::Smart { contract_addr, msg }
                 if Addr::unchecked(contract_addr) == deps.api.addr_make("strategy_manager") =>
@@ -1406,6 +1256,8 @@ mod tests {
             _rewards_updater_info,
         ) = instantiate_contract();
 
+        let owner = deps.api.addr_make("initial_owner");
+        let owner_info = message_info(&owner, &[]);
         let calc_interval = 86_400; // 1 day
 
         let block_time = mock_env().block.time.seconds();
@@ -1424,9 +1276,14 @@ mod tests {
             token: deps.api.addr_make("token"),
         }];
 
+        let strategy_manager = deps.api.addr_make("strategy_manager");
+        controller::STRATEGY_MANAGER
+            .save(&mut deps.storage, &strategy_manager)
+            .unwrap();
+
         deps.querier.update_wasm(move |query| match query {
             WasmQuery::Smart { contract_addr, msg }
-                if Addr::unchecked(contract_addr) == deps.api.addr_make("strategy_manager") =>
+                if Addr::unchecked(contract_addr) == &strategy_manager =>
             {
                 let msg: StrategyManagerQueryMsg = from_json(msg).unwrap();
                 match msg {
@@ -1521,9 +1378,13 @@ mod tests {
             token: deps.api.addr_make("token"),
         }];
 
+        let strategy_manager = deps.api.addr_make("strategy_manager");
+        controller::STRATEGY_MANAGER
+            .save(&mut deps.storage, &strategy_manager)
+            .unwrap();
         deps.querier.update_wasm(move |query| match query {
             WasmQuery::Smart { contract_addr, msg }
-                if Addr::unchecked(contract_addr) == deps.api.addr_make("strategy_manager") =>
+                if Addr::unchecked(contract_addr) == &strategy_manager =>
             {
                 let msg: StrategyManagerQueryMsg = from_json(msg).unwrap();
                 match msg {
@@ -1602,7 +1463,7 @@ mod tests {
     }
 
     #[test]
-    fn test_transfer_ownership() {
+    fn test_set_controller() {
         let (
             mut deps,
             _env,
@@ -1615,35 +1476,54 @@ mod tests {
         ) = instantiate_contract();
 
         let new_owner = deps.api.addr_make("new_owner");
+        let new_rewards_updater = deps.api.addr_make("new_rewards_updater");
+        let new_delegation_manager = deps.api.addr_make("new_delegation_manager");
+        let new_strategy_manager = deps.api.addr_make("new_strategy_manager");
 
-        let result = transfer_ownership(deps.as_mut(), owner_info, new_owner.clone());
+        let result = set_controller(
+            deps.as_mut(),
+            &owner_info,
+            new_owner.clone(),
+            new_rewards_updater.clone(),
+            new_delegation_manager.clone(),
+            new_strategy_manager.clone(),
+        );
 
         assert!(result.is_ok());
 
         let response = result.unwrap();
         assert_eq!(response.events.len(), 1);
 
-        let event = response.events.first().unwrap();
-        assert_eq!(event.ty, "TransferOwnership");
-        assert_eq!(event.attributes.len(), 2);
-        assert_eq!(event.attributes[0].key, "method");
-        assert_eq!(event.attributes[0].value, "transfer_ownership");
-        assert_eq!(event.attributes[1].key, "new_owner");
-        assert_eq!(event.attributes[1].value, new_owner.to_string());
+        assert_eq!(
+            response.events[0],
+            Event::new("SetController")
+                .add_attribute("owner", new_owner.to_string())
+                .add_attribute("rewards_updater", new_rewards_updater.to_string())
+                .add_attribute("delegation_manager", new_delegation_manager.to_string())
+                .add_attribute("strategy_manager", new_strategy_manager.to_string())
+        );
 
-        let stored_owner = OWNER.load(&deps.storage).unwrap();
+        let stored_owner = controller::OWNER.load(&deps.storage).unwrap();
         assert_eq!(stored_owner, new_owner);
 
         let info_unauthorized = message_info(&Addr::unchecked("unauthorized_caller"), &[]);
 
-        let result = transfer_ownership(deps.as_mut(), info_unauthorized, new_owner.clone());
+        let new_new_owner = deps.api.addr_make("new_new_owner");
+        let result = set_controller(
+            deps.as_mut(),
+            &info_unauthorized,
+            new_new_owner.clone(),
+            new_rewards_updater.clone(),
+            new_delegation_manager.clone(),
+            new_strategy_manager.clone(),
+        );
 
         assert!(result.is_err());
         if let Err(err) = result {
             assert_eq!(err, ContractError::Unauthorized {});
         }
 
-        let stored_owner = OWNER.load(&deps.storage).unwrap();
+        let stored_owner = controller::OWNER.load(&deps.storage).unwrap();
         assert_eq!(stored_owner, new_owner);
     }
 
@@ -1744,88 +1624,6 @@ mod tests {
             stored_activation_delay_after_unauthorized_attempt,
             new_activation_delay
         );
-    }
-
-    #[test]
-    fn test_set_rewards_updater_internal() {
-        let (
-            mut deps,
-            _env,
-            _owner_info,
-            _pauser_info,
-            _unpauser_info,
-            _strategy_manager_info,
-            _delegation_manager_info,
-            _rewards_updater_info,
-        ) = instantiate_contract();
-
-        let new_updater = deps.api.addr_make("new_updater");
-
-        let result = set_rewards_updater_internal(deps.as_mut(), new_updater.clone());
-
-        assert!(result.is_ok());
-
-        let response = result.unwrap();
-        assert_eq!(response.events.len(), 1);
-
-        let event = response.events.first().unwrap();
-        assert_eq!(event.ty, "SetRewardsUpdater");
-        assert_eq!(event.attributes.len(), 2);
-        assert_eq!(event.attributes[0].key, "method");
-        assert_eq!(event.attributes[0].value, "set_rewards_updater");
-        assert_eq!(event.attributes[1].key, "new_updater");
-        assert_eq!(event.attributes[1].value, new_updater.to_string());
-
-        let stored_updater = REWARDS_UPDATER.load(&deps.storage).unwrap();
-        assert_eq!(stored_updater, new_updater);
-    }
-
-    #[test]
-    fn test_set_rewards_updater() {
-        let (
-            mut deps,
-            _env,
-            owner_info,
-            _pauser_info,
-            _unpauser_info,
-            _strategy_manager_info,
-            _delegation_manager_info,
-            _rewards_updater_info,
-        ) = instantiate_contract();
-
-        let new_updater = deps.api.addr_make("new_updater");
-        let result = set_rewards_updater(deps.as_mut(), owner_info, new_updater.clone());
-
-        assert!(result.is_ok());
-
-        let response = result.unwrap();
-        assert_eq!(response.events.len(), 1);
-
-        let event = response.events.first().unwrap();
-        assert_eq!(event.ty, "SetRewardsUpdater");
-        assert_eq!(event.attributes.len(), 2);
-        assert_eq!(event.attributes[0].key, "method");
-        assert_eq!(event.attributes[0].value, "set_rewards_updater");
-        assert_eq!(event.attributes[1].key, "new_updater");
-        assert_eq!(event.attributes[1].value, new_updater.to_string());
-
-        let stored_updater = REWARDS_UPDATER.load(&deps.storage).unwrap();
-        assert_eq!(stored_updater, new_updater);
-
-        let unauthorized_info = message_info(&Addr::unchecked("not_owner"), &[]);
-        let result = set_rewards_updater(
-            deps.as_mut(),
-            unauthorized_info,
-            Addr::unchecked("another_updater"),
-        );
-
-        assert!(result.is_err());
-        if let Err(err) = result {
-            assert_eq!(err, ContractError::Unauthorized {});
-        }
-
-        let stored_updater = REWARDS_UPDATER.load(&deps.storage).unwrap();
-        assert_eq!(stored_updater, new_updater);
     }
 
     #[test]
@@ -2892,6 +2690,9 @@ mod tests {
             .save(&mut deps.storage, &1000)
             .unwrap();
         ACTIVATION_DELAY.save(&mut deps.storage, &60u32).unwrap();
+        controller::REWARDS_UPDATER
+            .save(&mut deps.storage, &rewards_updater_info.sender)
+            .unwrap();
 
         let root = Binary::from(b"valid_root".to_vec());
         let rewards_calculation_end_timestamp = 1100;
@@ -2964,7 +2765,7 @@ mod tests {
         );
         assert!(result.is_err());
         if let Err(err) = result {
-            assert_eq!(err, ContractError::NotRewardsUpdater {});
+            assert_eq!(err, ContractError::Unauthorized {});
         }
     }
 
@@ -3014,27 +2815,20 @@ mod tests {
     fn test_process_claim() {
         let (mut deps, env, _info) = setup_test_environment();
 
-        let initial_owner = deps.api.addr_make("initial_owner").to_string();
-        let delegation_manager = deps.api.addr_make("delegation_manager").to_string();
-        let strategy_manager = deps.api.addr_make("strategy_manager").to_string();
+        let owner = deps.api.addr_make("owner");
         let registry = deps.api.addr_make("registry").to_string();
-        let rewards_updater = deps.api.addr_make("rewards_updater").to_string();
 
-        let owner_info = message_info(&Addr::unchecked(initial_owner.clone()), &[]);
-        message_info(&Addr::unchecked(delegation_manager.clone()), &[]);
+        let owner_info = message_info(&owner, &[]);
 
         let msg = InstantiateMsg {
-            initial_owner: initial_owner.clone(),
+            owner: owner.to_string(),
+            registry,
             calculation_interval_seconds: 86_400, // 1 day
             max_rewards_duration: 30 * 86_400,    // 30 days
             max_retroactive_length: 5 * 86_400,   // 5 days
             max_future_length: 10 * 86_400,       // 10 days
             genesis_rewards_timestamp: env.block.time.seconds() / 86_400 * 86_400,
-            delegation_manager: delegation_manager.clone(),
-            strategy_manager: strategy_manager.clone(),
-            rewards_updater: rewards_updater.clone(),
             activation_delay: 60, // 1 minute
-            registry,
         };
 
         instantiate(deps.as_mut(), env.clone(), owner_info.clone(), msg).unwrap();
@@ -3294,7 +3088,7 @@ mod tests {
         let rewards_updater = deps.api.addr_make("rewards_updater");
         let rewards_updater_info = message_info(&rewards_updater, &[]);
 
-        REWARDS_UPDATER
+        controller::REWARDS_UPDATER
             .save(&mut deps.storage, &deps.api.addr_make("rewards_updater"))
             .unwrap();
 
@@ -3368,7 +3162,7 @@ mod tests {
         let result = disable_root(deps.as_mut(), env, unauthorized_info, 1);
         assert!(result.is_err());
         if let Err(err) = result {
-            assert_eq!(err, ContractError::NotRewardsUpdater {});
+            assert_eq!(err, ContractError::Unauthorized {});
         }
     }
 }

--- a/crates/bvs-rewards-coordinator/src/controller.rs
+++ b/crates/bvs-rewards-coordinator/src/controller.rs
@@ -1,0 +1,122 @@
+use crate::ContractError;
+use cosmwasm_std::{Addr, Deps, DepsMut, Event, MessageInfo, Response};
+use cw_storage_plus::Item;
+
+pub const OWNER: Item<Addr> = Item::new("owner");
+pub const DELEGATION_MANAGER: Item<Addr> = Item::new("delegation_manager");
+pub const STRATEGY_MANAGER: Item<Addr> = Item::new("strategy_manager");
+pub const REWARDS_UPDATER: Item<Addr> = Item::new("rewards_updater");
+
+pub fn set_controller(
+    deps: DepsMut,
+    info: &MessageInfo,
+    owner: Addr,
+    rewards_updater: Addr,
+    delegation_manager: Addr,
+    strategy_manager: Addr,
+) -> Result<Response, ContractError> {
+    only_owner(deps.as_ref(), info)?;
+
+    OWNER.save(deps.storage, &owner)?;
+    REWARDS_UPDATER.save(deps.storage, &rewards_updater)?;
+    DELEGATION_MANAGER.save(deps.storage, &delegation_manager)?;
+    STRATEGY_MANAGER.save(deps.storage, &strategy_manager)?;
+
+    Ok(Response::new().add_event(
+        Event::new("SetController")
+            .add_attribute("owner", owner)
+            .add_attribute("rewards_updater", rewards_updater)
+            .add_attribute("delegation_manager", delegation_manager)
+            .add_attribute("strategy_manager", strategy_manager),
+    ))
+}
+
+pub fn only_owner(deps: Deps, info: &MessageInfo) -> Result<(), ContractError> {
+    let owner = OWNER.load(deps.storage)?;
+    if info.sender != owner {
+        return Err(ContractError::Unauthorized {});
+    }
+    Ok(())
+}
+
+pub fn only_rewards_updater(deps: Deps, info: &MessageInfo) -> Result<(), ContractError> {
+    let rewards_updater = REWARDS_UPDATER.load(deps.storage)?;
+    if info.sender != rewards_updater {
+        return Err(ContractError::Unauthorized {});
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::controller::REWARDS_UPDATER;
+    use crate::{controller, ContractError};
+    use controller::{only_owner, only_rewards_updater, OWNER};
+    use cosmwasm_std::testing::{message_info, mock_dependencies};
+    use cosmwasm_std::Addr;
+
+    #[test]
+    fn test_only_owner() {
+        let mut deps = mock_dependencies();
+
+        let owner_addr = deps.api.addr_make("owner");
+        OWNER.save(deps.as_mut().storage, &owner_addr).unwrap();
+
+        let owner_info = message_info(&owner_addr, &[]);
+
+        let result = only_owner(deps.as_ref(), &owner_info);
+        assert!(result.is_ok());
+
+        let info = message_info(&Addr::unchecked("not_owner"), &[]);
+        let result = only_owner(deps.as_ref(), &info);
+        assert_eq!(result, Err(ContractError::Unauthorized {}));
+    }
+
+    #[test]
+    fn test_only_owner_fail() {
+        let mut deps = mock_dependencies();
+
+        let owner_addr = deps.api.addr_make("owner");
+        OWNER.save(deps.as_mut().storage, &owner_addr).unwrap();
+
+        let owner_info = message_info(&owner_addr, &[]);
+
+        let result = only_owner(deps.as_ref(), &owner_info);
+        assert!(result.is_ok());
+
+        let info = message_info(&Addr::unchecked("not_owner"), &[]);
+        let result = only_owner(deps.as_ref(), &info);
+        assert_eq!(result, Err(ContractError::Unauthorized {}));
+    }
+
+    #[test]
+    fn test_only_rewards_updater() {
+        let mut deps = mock_dependencies();
+
+        let rewards_updater_addr = deps.api.addr_make("rewards_updater");
+        REWARDS_UPDATER
+            .save(deps.as_mut().storage, &rewards_updater_addr)
+            .unwrap();
+
+        let info = message_info(&rewards_updater_addr, &[]);
+        let result = only_rewards_updater(deps.as_ref(), &info);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_only_rewards_updater_fail() {
+        let mut deps = mock_dependencies();
+
+        let rewards_updater_addr = deps.api.addr_make("rewards_updater");
+        REWARDS_UPDATER
+            .save(&mut deps.storage, &rewards_updater_addr)
+            .unwrap();
+
+        let rewards_updater_addr = deps.api.addr_make("not_rewards_updater");
+        let info = message_info(&rewards_updater_addr, &[]);
+        let result = only_rewards_updater(deps.as_ref(), &info);
+
+        assert_eq!(result, Err(ContractError::Unauthorized {}));
+    }
+}

--- a/crates/bvs-rewards-coordinator/src/error.rs
+++ b/crates/bvs-rewards-coordinator/src/error.rs
@@ -15,9 +15,6 @@ pub enum ContractError {
     #[error("RewardsCoordinator.instantiate: invalid calculation interval")]
     InvalidCalculationInterval {},
 
-    #[error("RewardsCoordinator._only_rewards_updater: caller is not the rewardsUpdater")]
-    NotRewardsUpdater {},
-
     #[error("RewardsCoordinator._only_rewards_for_all_submitter: caller is not a valid createRewardsForAllSubmission submitter")]
     ValidCreateRewardsForAllSubmission {},
 

--- a/crates/bvs-rewards-coordinator/src/lib.rs
+++ b/crates/bvs-rewards-coordinator/src/lib.rs
@@ -2,9 +2,10 @@ pub mod contract;
 pub mod msg;
 pub mod query;
 pub mod state;
-pub mod utils;
 
+mod controller;
 mod error;
+mod utils;
 
 pub use crate::error::ContractError;
 

--- a/crates/bvs-rewards-coordinator/src/msg.rs
+++ b/crates/bvs-rewards-coordinator/src/msg.rs
@@ -10,17 +10,15 @@ use cosmwasm_std::{Binary, Uint128};
 
 #[cw_serde]
 pub struct InstantiateMsg {
-    pub initial_owner: String,
-    pub rewards_updater: String,
+    pub owner: String,
+    pub registry: String,
+
     pub calculation_interval_seconds: u64,
     pub max_rewards_duration: u64,
     pub max_retroactive_length: u64,
     pub max_future_length: u64,
     pub genesis_rewards_timestamp: u64,
-    pub delegation_manager: String,
-    pub strategy_manager: String,
     pub activation_delay: u32,
-    pub registry: String,
 }
 
 #[cw_serde]
@@ -49,9 +47,6 @@ pub enum ExecuteMsg {
     SetActivationDelay {
         new_activation_delay: u32,
     },
-    SetRewardsUpdater {
-        new_updater: String,
-    },
     SetRewardsForAllSubmitter {
         submitter: String,
         new_value: bool,
@@ -59,8 +54,15 @@ pub enum ExecuteMsg {
     SetGlobalOperatorCommission {
         new_commission_bips: u16,
     },
-    TransferOwnership {
-        new_owner: String,
+    /// Instantiate creates the contract: gives the contract an address.
+    /// This sets up the contract for routing and access control management.
+    /// It can be called more than once to set new value but only by the owner.
+    /// Contract admin (cosmwasm feature) has omni-ability—can do anything, owner logic is app-level.
+    SetController {
+        owner: String,
+        rewards_updater: String,
+        delegation_manager: String,
+        strategy_manager: String,
     },
 }
 

--- a/crates/bvs-rewards-coordinator/src/state.rs
+++ b/crates/bvs-rewards-coordinator/src/state.rs
@@ -2,8 +2,6 @@ use crate::msg::DistributionRoot;
 use cosmwasm_std::{Addr, Uint128};
 use cw_storage_plus::{Item, Map};
 
-pub const OWNER: Item<Addr> = Item::new("owner");
-pub const REWARDS_UPDATER: Item<Addr> = Item::new("rewards_updater");
 pub const DISTRIBUTION_ROOTS: Map<u64, DistributionRoot> = Map::new("distribution_roots");
 pub const DISTRIBUTION_ROOTS_COUNT: Item<u64> = Item::new("distribution_roots_count");
 pub const CUMULATIVE_CLAIMED: Map<(Addr, String), Uint128> = Map::new("cumulative_claimed");
@@ -20,7 +18,5 @@ pub const MAX_FUTURE_LENGTH: Item<u64> = Item::new("max_future_length");
 pub const GENESIS_REWARDS_TIMESTAMP: Item<u64> = Item::new("genesis_rewards_timestamp");
 pub const CURR_REWARDS_CALCULATION_END_TIMESTAMP: Item<u64> =
     Item::new("curr_rewards_calculation_end_timestamp");
-pub const DELEGATION_MANAGER: Item<Addr> = Item::new("delegation_manager");
-pub const STRATEGY_MANAGER: Item<Addr> = Item::new("strategy_manager");
 pub const GLOBAL_OPERATOR_COMMISSION_BIPS: Item<u16> = Item::new("global_operator_commission_bips");
 pub const CLAIMER_FOR: Map<Addr, Addr> = Map::new("claimer_for");

--- a/crates/bvs-rewards-coordinator/src/testing.rs
+++ b/crates/bvs-rewards-coordinator/src/testing.rs
@@ -21,27 +21,18 @@ pub fn contract() -> Box<dyn Contract<Empty>> {
 }
 
 impl InstantiateMsg {
-    pub fn default(
-        app: &mut App,
-        env: &Env,
-        registry: &Addr,
-        delegation_manager: &Addr,
-        strategy_manager: &Addr,
-    ) -> Self {
+    pub fn default(app: &mut App, env: &Env, registry: &Addr) -> Self {
         let owner = app.api().addr_make("owner");
 
         Self {
-            initial_owner: owner.to_string(),
+            owner: owner.to_string(),
+            registry: registry.to_string(),
             calculation_interval_seconds: 86_400, // 1 day
             max_rewards_duration: 30 * 86_400,    // 30 days
             max_retroactive_length: 5 * 86_400,   // 5 days
             max_future_length: 10 * 86_400,       // 10 days
             genesis_rewards_timestamp: env.block.time.seconds() / 86_400 * 86_400,
             activation_delay: 60,
-            delegation_manager: delegation_manager.to_string(),
-            strategy_manager: strategy_manager.to_string(),
-            rewards_updater: owner.to_string(),
-            registry: registry.to_string(),
         }
     }
 }

--- a/crates/bvs-rewards-coordinator/tests/integration_test.rs
+++ b/crates/bvs-rewards-coordinator/tests/integration_test.rs
@@ -16,15 +16,7 @@ fn instantiate() -> (App, RewardsContract) {
 
     let code_id = app.store_code(testing::contract());
 
-    let delegate_manager = app.api().addr_make("delegation_manager");
-    let strategy_manager = app.api().addr_make("strategy_manager");
-    let init_msg = InstantiateMsg::default(
-        &mut app,
-        &env,
-        &registry.addr,
-        &delegate_manager,
-        &strategy_manager,
-    );
+    let init_msg = InstantiateMsg::default(&mut app, &env, &registry.addr);
 
     let (addr, msg) = testing::instantiate(&mut app, code_id, init_msg);
     (
@@ -41,9 +33,8 @@ fn instantiate() -> (App, RewardsContract) {
 fn set_rewards_updater() {
     let (mut app, contract) = instantiate();
 
-    let new_updater = app.api().addr_make("new_updater");
-    let msg = to_json_binary(&ExecuteMsg::SetRewardsUpdater {
-        new_updater: new_updater.to_string(),
+    let msg = to_json_binary(&ExecuteMsg::SetActivationDelay {
+        new_activation_delay: 100,
     });
     let execute_msg = WasmMsg::Execute {
         contract_addr: contract.addr.to_string(),
@@ -60,7 +51,7 @@ fn set_rewards_updater() {
         Event::new("wasm-SetRewardsUpdater")
             .add_attribute("_contract_address", contract.addr.to_string())
             .add_attribute("method", "set_rewards_updater")
-            .add_attribute("new_updater", new_updater.to_string())
+            .add_attribute("old", "100")
     );
 }
 
@@ -69,9 +60,8 @@ fn set_rewards_updater_but_paused() {
     let (mut app, contract) = instantiate();
     contract.registry.pause(&mut app);
 
-    let new_updater = app.api().addr_make("new_updater");
-    let msg = to_json_binary(&ExecuteMsg::SetRewardsUpdater {
-        new_updater: new_updater.to_string(),
+    let msg = to_json_binary(&ExecuteMsg::SetActivationDelay {
+        new_activation_delay: 100,
     });
     let execute_msg = WasmMsg::Execute {
         contract_addr: contract.addr.to_string(),


### PR DESCRIPTION
#### What this PR does / why we need it:

```rs
/// Instantiate creates the contract: gives the contract an address.
/// This sets up the contract for routing and access control management.
/// It can be called more than once to set new value but only by the owner.
/// Contract admin (cosmwasm feature) has omni-ability—can do anything, owner logic is app-level.
SetController {
    owner: String,
    rewards_updater: String,
    delegation_manager: String,
    strategy_manager: String,
},
```

Cleanup contracts `Instantiate` lifecycle.

Closes SL-280
