### PR TITLE
fix: `bvs-strategy-base`'s `before_withdrawal` function

### DIFF
--- a/crates/bvs-delegation-manager/src/contract.rs
+++ b/crates/bvs-delegation-manager/src/contract.rs
@@ -992,7 +992,6 @@ fn complete_queued_withdrawal_internal(
                     recipient: info.sender.to_string(),
                     strategy: strategy.to_string(),
                     shares: withdrawal.shares[i],
-                    token: tokens[i].to_string(),
                 })?,
                 funds: vec![],
             };

--- a/crates/bvs-strategy-base/src/msg.rs
+++ b/crates/bvs-strategy-base/src/msg.rs
@@ -24,7 +24,6 @@ pub enum ExecuteMsg {
     },
     Withdraw {
         recipient: String,
-        token: String,
         amount_shares: Uint128,
     },
     SetStrategyManager {

--- a/crates/bvs-strategy-manager/src/contract.rs
+++ b/crates/bvs-strategy-manager/src/contract.rs
@@ -134,20 +134,11 @@ pub fn execute(
             recipient,
             strategy,
             shares,
-            token,
         } => {
             let strategy_addr = deps.api.addr_validate(&strategy)?;
             let recipient_addr = deps.api.addr_validate(&recipient)?;
-            let token_addr = deps.api.addr_validate(&token)?;
 
-            withdraw_shares_as_tokens(
-                deps,
-                info,
-                recipient_addr,
-                strategy_addr,
-                shares,
-                token_addr,
-            )
+            withdraw_shares_as_tokens(deps, info, recipient_addr, strategy_addr, shares)
         }
         ExecuteMsg::RemoveShares {
             staker,
@@ -357,7 +348,6 @@ pub fn withdraw_shares_as_tokens(
     recipient: Addr,
     strategy: Addr,
     shares: Uint128,
-    token: Addr,
 ) -> Result<Response, ContractError> {
     only_delegation_manager(deps.as_ref(), &info)?;
 
@@ -365,7 +355,6 @@ pub fn withdraw_shares_as_tokens(
         contract_addr: strategy.to_string(),
         msg: to_json_binary(&StrategyExecuteMsg::Withdraw {
             recipient: recipient.to_string(),
-            token: token.to_string(),
             amount_shares: shares,
         })?,
         funds: vec![],

--- a/crates/bvs-strategy-manager/src/msg.rs
+++ b/crates/bvs-strategy-manager/src/msg.rs
@@ -44,7 +44,6 @@ pub enum ExecuteMsg {
         recipient: String,
         strategy: String,
         shares: Uint128,
-        token: String,
     },
     AddShares {
         staker: String,


### PR DESCRIPTION
#### What this PR does / why we need it:

This fix is to resolve: The before_withdrawal is redundant

Closes SL-294

