### PR TITLE
fix: `bvs-strategy-base`'s `GetShares` parameter

### DIFF
--- a/crates/bvs-strategy-base/src/contract.rs
+++ b/crates/bvs-strategy-base/src/contract.rs
@@ -283,9 +283,9 @@ pub fn user_underlying_view(deps: Deps, env: Env, user: Addr) -> StdResult<Uint1
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
-        QueryMsg::GetShares { staker, strategy } => {
+        QueryMsg::GetShares { staker } => {
             let staker_addr = deps.api.addr_validate(&staker)?;
-            let strategy_addr = Addr::unchecked(strategy);
+            let strategy_addr = env.contract.address.clone();
 
             to_json_binary(&shares(deps, staker_addr, strategy_addr)?)
         }
@@ -865,10 +865,7 @@ mod tests {
             }
         });
 
-        let query_msg = QueryMsg::GetShares {
-            staker: user,
-            strategy: contract_address.to_string(),
-        };
+        let query_msg = QueryMsg::GetShares { staker: user };
         let res: SharesResponse =
             from_json(query(deps.as_ref(), env.clone(), query_msg).unwrap()).unwrap();
 

--- a/crates/bvs-strategy-base/src/msg.rs
+++ b/crates/bvs-strategy-base/src/msg.rs
@@ -36,7 +36,7 @@ pub enum ExecuteMsg {
 #[derive(QueryResponses)]
 pub enum QueryMsg {
     #[returns(SharesResponse)]
-    GetShares { staker: String, strategy: String },
+    GetShares { staker: String },
 
     #[returns(SharesToUnderlyingResponse)]
     SharesToUnderlyingView { amount_shares: Uint128 },


### PR DESCRIPTION
#### What this PR does / why we need it:

This fix is to resolve: QueryMsg::GetShares currently having a strategy parameter, to be removed

Closes SL-297
