### PR TITLE
chore: rename RegistryError to Registry

### DIFF
--- a/crates/bvs-directory/src/error.rs
+++ b/crates/bvs-directory/src/error.rs
@@ -7,7 +7,7 @@ pub enum ContractError {
     Std(#[from] StdError),
 
     #[error("{0}")]
-    RegistryError(#[from] bvs_registry::api::RegistryError),
+    Registry(#[from] bvs_registry::api::RegistryError),
 
     #[error("BVSDirectory.registerOperatorToBVS: operator signature expired")]
     SignatureExpired {},

--- a/crates/bvs-directory/tests/integration_test.rs
+++ b/crates/bvs-directory/tests/integration_test.rs
@@ -392,6 +392,6 @@ fn register_bvs_but_paused() {
 
     assert_eq!(
         err.root_cause().to_string(),
-        bvs_directory::ContractError::RegistryError(RegistryError::IsPaused).to_string()
+        bvs_directory::ContractError::Registry(RegistryError::IsPaused).to_string()
     );
 }

--- a/crates/bvs-rewards-coordinator/src/error.rs
+++ b/crates/bvs-rewards-coordinator/src/error.rs
@@ -7,7 +7,7 @@ pub enum ContractError {
     Std(#[from] StdError),
 
     #[error("{0}")]
-    RegistryError(#[from] bvs_registry::api::RegistryError),
+    Registry(#[from] bvs_registry::api::RegistryError),
 
     #[error("RewardsCoordinator: Unauthorized")]
     Unauthorized {},

--- a/crates/bvs-rewards-coordinator/tests/integration_test.rs
+++ b/crates/bvs-rewards-coordinator/tests/integration_test.rs
@@ -53,6 +53,6 @@ fn set_rewards_updater_but_paused() {
     let err = rewards.execute(&mut app, &owner, &msg).unwrap_err();
     assert_eq!(
         err.root_cause().to_string(),
-        bvs_rewards_coordinator::ContractError::RegistryError(RegistryError::IsPaused).to_string()
+        bvs_rewards_coordinator::ContractError::Registry(RegistryError::IsPaused).to_string()
     );
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

Drop double error in `ContractError::RegistryError`, just call it `ContractError::Registry`.