### PR TITLE
chore: use docker-cosmwasm-optimizer

### DIFF
--- a/crates/bvs-delegation-manager/package.json
+++ b/crates/bvs-delegation-manager/package.json
@@ -6,7 +6,7 @@
     "schema"
   ],
   "scripts": {
-    "build:wasm": "cosmwasm-optimizer",
+    "build:wasm": "cosmwasm-optimizer --root=../",
     "generate:schema": "cargo run --bin schema --no-default-features",
     "test": "cargo test"
   }

--- a/crates/bvs-directory/package.json
+++ b/crates/bvs-directory/package.json
@@ -6,7 +6,7 @@
     "schema"
   ],
   "scripts": {
-    "build:wasm": "cosmwasm-optimizer",
+    "build:wasm": "cosmwasm-optimizer --root=../",
     "generate:schema": "cargo run --bin schema --no-default-features",
     "test": "cargo test"
   }

--- a/crates/bvs-registry/package.json
+++ b/crates/bvs-registry/package.json
@@ -6,7 +6,7 @@
     "schema"
   ],
   "scripts": {
-    "build:wasm": "cosmwasm-optimizer",
+    "build:wasm": "cosmwasm-optimizer --root=../",
     "generate:schema": "cargo run --bin schema --no-default-features",
     "test": "cargo test"
   }

--- a/crates/bvs-rewards-coordinator/package.json
+++ b/crates/bvs-rewards-coordinator/package.json
@@ -6,7 +6,7 @@
     "schema"
   ],
   "scripts": {
-    "build:wasm": "cosmwasm-optimizer",
+    "build:wasm": "cosmwasm-optimizer --root=../",
     "generate:schema": "cargo run --bin schema --no-default-features",
     "test": "cargo test"
   }

--- a/crates/bvs-slash-manager/package.json
+++ b/crates/bvs-slash-manager/package.json
@@ -6,7 +6,7 @@
     "schema"
   ],
   "scripts": {
-    "build:wasm": "cosmwasm-optimizer",
+    "build:wasm": "cosmwasm-optimizer --root=../",
     "generate:schema": "cargo run --bin schema --no-default-features",
     "test": "cargo test"
   }

--- a/crates/bvs-strategy-base/package.json
+++ b/crates/bvs-strategy-base/package.json
@@ -6,7 +6,7 @@
     "schema"
   ],
   "scripts": {
-    "build:wasm": "cosmwasm-optimizer",
+    "build:wasm": "cosmwasm-optimizer --root=../",
     "generate:schema": "cargo run --bin schema --no-default-features",
     "test": "cargo test"
   }

--- a/crates/bvs-strategy-manager/package.json
+++ b/crates/bvs-strategy-manager/package.json
@@ -6,7 +6,7 @@
     "schema"
   ],
   "scripts": {
-    "build:wasm": "cosmwasm-optimizer",
+    "build:wasm": "cosmwasm-optimizer --root=../",
     "generate:schema": "cargo run --bin schema --no-default-features",
     "test": "cargo test"
   }

--- a/examples/squaring/squaring-contract/package.json
+++ b/examples/squaring/squaring-contract/package.json
@@ -6,7 +6,7 @@
     "schema"
   ],
   "scripts": {
-    "build:wasm": "docker run --pull=always --rm -v \"$(pwd)/../../../crates\":/crates -v \"$(pwd)\":/code --mount type=volume,source=\"$(basename \"$(pwd)\")_cache\",target=/target --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry cosmwasm/optimizer:0.16.0",
+    "build:wasm": "cosmwasm-optimizer",
     "generate:schema": "cargo run --bin schema --no-default-features",
     "test": "cargo test"
   }

--- a/packages/docker-cosmwasm-optimizer/Dockerfile
+++ b/packages/docker-cosmwasm-optimizer/Dockerfile
@@ -10,9 +10,8 @@ RUN apk update && apk add clang && apk add binaryen
 COPY . /code
 
 FROM optimizer AS builder
-ARG CRATE
-RUN /usr/local/bin/optimize.sh ./${CRATE}
+ARG DIRECTORY
+RUN /usr/local/bin/optimize.sh ${DIRECTORY}
 
 FROM scratch
-ARG CRATE
 COPY --from=builder /code/artifacts ./

--- a/packages/docker-cosmwasm-optimizer/bin.js
+++ b/packages/docker-cosmwasm-optimizer/bin.js
@@ -1,26 +1,45 @@
 #!/usr/bin/env node
 
-const { execSync } = require("child_process");
-const path = require("path");
+const { execSync } = require("node:child_process");
+const { parseArgs } = require("node:util");
+const path = require("node:path");
+
+const options = {
+  root: {
+    type: "string",
+  },
+  name: {
+    type: "string",
+  },
+};
+const { values } = parseArgs({ options });
 
 const cwd = process.cwd();
-const crate = path.basename(cwd);
-const parentDir = path.dirname(cwd);
+const rootDir = (values.root && path.join(cwd, values.root)) || cwd;
+const name = values.name ?? path.basename(cwd);
+
+function getDirectory() {
+  if (values.root) {
+    return "./" + path.basename(cwd);
+  }
+  return ".";
+}
 
 const command = [
   "docker buildx build",
   "-f",
   path.join(path.dirname(require.main.filename), "Dockerfile"),
   `--output=./artifacts`,
-  `--build-arg CRATE=${crate}`,
-  parentDir,
+  // We only need to pass the directory if it is different from the current working directory
+  `--build-arg DIRECTORY=${getDirectory()}`,
+  rootDir,
 ];
 
 if (process.env.CI) {
-  command.push("--cache-from", `type=registry,ref=ghcr.io/satlayer/cosmwasm-optimizer-cache:${crate}`);
+  command.push("--cache-from", `type=registry,ref=ghcr.io/satlayer/cosmwasm-optimizer-cache:${name}`);
 
   if (process.env.DOCKER_CACHE_TO === "ghcr") {
-    command.push("--cache-to", `type=registry,ref=ghcr.io/satlayer/cosmwasm-optimizer-cache:${crate},mode=max`);
+    command.push("--cache-to", `type=registry,ref=ghcr.io/satlayer/cosmwasm-optimizer-cache:${name},mode=max`);
   }
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Use `docker-cosmwasm-optimizer` to build squaring wasm.

> I'm using a remote context, so mounting volume isn't supported.