### PR TITLE
fix: replace deprecated ValidateBasic with custom message validation

### DIFF
--- a/modules/bvs-api/signer/msg_validator.go
+++ b/modules/bvs-api/signer/msg_validator.go
@@ -1,0 +1,40 @@
+package signer
+
+import (
+	"encoding/json"
+	"errors"
+
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	sdktypes "github.com/cosmos/cosmos-sdk/types"
+)
+
+// MsgValidator defines the interface for message validation
+type MsgValidator interface {
+	ValidateMsg(msg sdktypes.Msg) error
+}
+
+// DefaultMsgValidator implements basic message validation
+type DefaultMsgValidator struct{}
+
+func (v *DefaultMsgValidator) ValidateMsg(msg sdktypes.Msg) error {
+	// Check if message is nil
+	if msg == nil {
+		return errors.New("nil message")
+	}
+
+	// Validate JSON in execute contract message
+	if execMsg, ok := msg.(*wasmtypes.MsgExecuteContract); ok {
+		if !json.Valid(execMsg.Msg) {
+			return errors.New("invalid JSON in execute message")
+		}
+	}
+
+	// Validate JSON in query contract message
+	if queryMsg, ok := msg.(*wasmtypes.QuerySmartContractStateRequest); ok {
+		if !json.Valid(queryMsg.QueryData) {
+			return errors.New("invalid JSON in query message")
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

fix dedaub L2

- Remove dependency on deprecated ValidateBasic() method
- Add MsgValidator interface for message validation
- Implement DefaultMsgValidator with extensible validation logic
- Allow custom validator injection through SetMsgValidator
- Move message validation to dedicated validator component

This change removes the usage of deprecated ValidateBasic() method
and provides a more flexible and maintainable message validation
mechanism.

<!-- remove if not applicable -->
Closes SL-325
