### PR TITLE
chore: format after generate:schema

### DIFF
--- a/crates/bvs-delegation-manager/src/msg.rs
+++ b/crates/bvs-delegation-manager/src/msg.rs
@@ -75,12 +75,7 @@ pub enum ExecuteMsg {
         withdrawal_delay_blocks: Vec<u64>,
     },
     TransferOwnership {
-        /// Transfer ownership of the contract to a new owner.
-        /// Contract admin (set for all BVS contracts, a cosmwasm feature)
-        /// has the omni-ability to override by migration;
-        /// this logic is app-level.
-        /// > 2-step ownership transfer is mostly redundant for CosmWasm contracts with the admin set.
-        /// > You can override ownership with using CosmWasm migrate `entry_point`.
+        /// See `ownership::transfer_ownership` for more information on this field
         new_owner: String,
     },
     Pause {},

--- a/crates/bvs-directory/src/msg.rs
+++ b/crates/bvs-directory/src/msg.rs
@@ -35,12 +35,7 @@ pub enum ExecuteMsg {
         salt: Binary,
     },
     TransferOwnership {
-        /// Transfer ownership of the contract to a new owner.
-        /// Contract admin (set for all BVS contracts, a cosmwasm feature)
-        /// has the omni-ability to override by migration;
-        /// this logic is app-level.
-        /// > 2-step ownership transfer is mostly redundant for CosmWasm contracts with the admin set.
-        /// > You can override ownership with using CosmWasm migrate `entry_point`.
+        /// See `ownership::transfer_ownership` for more information on this field
         new_owner: String,
     },
 }

--- a/crates/bvs-library/src/ownership.rs
+++ b/crates/bvs-library/src/ownership.rs
@@ -18,8 +18,12 @@ pub fn _set_owner(storage: &mut dyn Storage, owner: &Addr) -> Result<(), Ownersh
     Ok(())
 }
 
-/// Transfer the ownership of the contract to a new address
-/// Only the current owner can do this
+/// Transfer ownership of the contract to a new owner.
+/// Contract admin (set for all BVS contracts, a cosmwasm feature)
+/// has the omni-ability to override by migration;
+/// this logic is app-level.
+/// > 2-step ownership transfer is mostly redundant for CosmWasm contracts with the admin set.
+/// > You can override ownership with using CosmWasm migrate `entry_point`.
 pub fn transfer_ownership(
     deps: DepsMut,
     info: &MessageInfo,

--- a/crates/bvs-registry/src/msg.rs
+++ b/crates/bvs-registry/src/msg.rs
@@ -15,12 +15,7 @@ pub enum ExecuteMsg {
     Unpause {},
 
     TransferOwnership {
-        /// Transfer ownership of the contract to a new owner.
-        /// Contract admin (set for all BVS contracts, a cosmwasm feature)
-        /// has the omni-ability to override by migration;
-        /// this logic is app-level.
-        /// > 2-step ownership transfer is mostly redundant for CosmWasm contracts with the admin set.
-        /// > You can override ownership with using CosmWasm migrate `entry_point`.
+        /// See `ownership::transfer_ownership` for more information on this field
         new_owner: String,
     },
 }

--- a/crates/bvs-rewards-coordinator/src/msg.rs
+++ b/crates/bvs-rewards-coordinator/src/msg.rs
@@ -60,12 +60,7 @@ pub enum ExecuteMsg {
         new_commission_bips: u16,
     },
     TransferOwnership {
-        /// Transfer ownership of the contract to a new owner.
-        /// Contract admin (set for all BVS contracts, a cosmwasm feature)
-        /// has the omni-ability to override by migration;
-        /// this logic is app-level.
-        /// > 2-step ownership transfer is mostly redundant for CosmWasm contracts with the admin set.
-        /// > You can override ownership with using CosmWasm migrate `entry_point`.
+        /// See `ownership::transfer_ownership` for more information on this field
         new_owner: String,
     },
 }

--- a/crates/bvs-slash-manager/src/msg.rs
+++ b/crates/bvs-slash-manager/src/msg.rs
@@ -47,12 +47,7 @@ pub enum ExecuteMsg {
         new_strategy_manager: String,
     },
     TransferOwnership {
-        /// Transfer ownership of the contract to a new owner.
-        /// Contract admin (set for all BVS contracts, a cosmwasm feature)
-        /// has the omni-ability to override by migration;
-        /// this logic is app-level.
-        /// > 2-step ownership transfer is mostly redundant for CosmWasm contracts with the admin set.
-        /// > You can override ownership with using CosmWasm migrate `entry_point`.
+        /// See `ownership::transfer_ownership` for more information on this field
         new_owner: String,
     },
     Pause {},

--- a/crates/bvs-strategy-base/src/msg.rs
+++ b/crates/bvs-strategy-base/src/msg.rs
@@ -31,12 +31,7 @@ pub enum ExecuteMsg {
         new_strategy_manager: String,
     },
     TransferOwnership {
-        /// Transfer ownership of the contract to a new owner.
-        /// Contract admin (set for all BVS contracts, a cosmwasm feature)
-        /// has the omni-ability to override by migration;
-        /// this logic is app-level.
-        /// > 2-step ownership transfer is mostly redundant for CosmWasm contracts with the admin set.
-        /// > You can override ownership with using CosmWasm migrate `entry_point`.
+        /// See `ownership::transfer_ownership` for more information on this field
         new_owner: String,
     },
     Pause {},

--- a/crates/bvs-strategy-manager/src/msg.rs
+++ b/crates/bvs-strategy-manager/src/msg.rs
@@ -65,12 +65,7 @@ pub enum ExecuteMsg {
         new_slash_manager: String,
     },
     TransferOwnership {
-        /// Transfer ownership of the contract to a new owner.
-        /// Contract admin (set for all BVS contracts, a cosmwasm feature)
-        /// has the omni-ability to override by migration;
-        /// this logic is app-level.
-        /// > 2-step ownership transfer is mostly redundant for CosmWasm contracts with the admin set.
-        /// > You can override ownership with using CosmWasm migrate `entry_point`.
+        /// See `ownership::transfer_ownership` for more information on this field
         new_owner: String,
     },
     Pause {},

--- a/modules/bvs-cw/delegation-manager/schema.go
+++ b/modules/bvs-cw/delegation-manager/schema.go
@@ -300,10 +300,7 @@ type SetUnpauser struct {
 }
 
 type TransferOwnership struct {
-	// Transfer ownership of the contract to a new owner. Contract admin (set for all BVS
-	// contracts, a cosmwasm feature) has the omni-ability to override by migration; this logic
-	// is app-level. > 2-step ownership transfer is mostly redundant for CosmWasm contracts with
-	// the admin set. > You can override ownership with using CosmWasm migrate `entry_point`.
+	// See `ownership::transfer_ownership` for more information on this field
 	NewOwner string `json:"new_owner"`
 }
 

--- a/modules/bvs-cw/directory/schema.go
+++ b/modules/bvs-cw/directory/schema.go
@@ -194,10 +194,7 @@ type SetDelegationManager struct {
 }
 
 type TransferOwnership struct {
-	// Transfer ownership of the contract to a new owner. Contract admin (set for all BVS
-	// contracts, a cosmwasm feature) has the omni-ability to override by migration; this logic
-	// is app-level. > 2-step ownership transfer is mostly redundant for CosmWasm contracts with
-	// the admin set. > You can override ownership with using CosmWasm migrate `entry_point`.
+	// See `ownership::transfer_ownership` for more information on this field
 	NewOwner string `json:"new_owner"`
 }
 

--- a/modules/bvs-cw/package.json
+++ b/modules/bvs-cw/package.json
@@ -2,7 +2,7 @@
   "name": "@modules/bvs-cw",
   "private": true,
   "scripts": {
-    "generate:schema": "node generate.mjs",
+    "generate:schema": "node generate.mjs && goimports -w */schema.go",
     "test": "gotestsum"
   },
   "devDependencies": {

--- a/modules/bvs-cw/registry/schema.go
+++ b/modules/bvs-cw/registry/schema.go
@@ -91,10 +91,7 @@ type Pause struct {
 }
 
 type TransferOwnership struct {
-	// Transfer ownership of the contract to a new owner. Contract admin (set for all BVS
-	// contracts, a cosmwasm feature) has the omni-ability to override by migration; this logic
-	// is app-level. > 2-step ownership transfer is mostly redundant for CosmWasm contracts with
-	// the admin set. > You can override ownership with using CosmWasm migrate `entry_point`.
+	// See `ownership::transfer_ownership` for more information on this field
 	NewOwner string `json:"new_owner"`
 }
 

--- a/modules/bvs-cw/rewards-coordinator/schema.go
+++ b/modules/bvs-cw/rewards-coordinator/schema.go
@@ -279,10 +279,7 @@ type SubmitRoot struct {
 }
 
 type TransferOwnership struct {
-	// Transfer ownership of the contract to a new owner. Contract admin (set for all BVS
-	// contracts, a cosmwasm feature) has the omni-ability to override by migration; this logic
-	// is app-level. > 2-step ownership transfer is mostly redundant for CosmWasm contracts with
-	// the admin set. > You can override ownership with using CosmWasm migrate `entry_point`.
+	// See `ownership::transfer_ownership` for more information on this field
 	NewOwner string `json:"new_owner"`
 }
 

--- a/modules/bvs-cw/slash-manager/schema.go
+++ b/modules/bvs-cw/slash-manager/schema.go
@@ -182,10 +182,7 @@ type SubmitSlashRequestSlashDetails struct {
 }
 
 type TransferOwnership struct {
-	// Transfer ownership of the contract to a new owner. Contract admin (set for all BVS
-	// contracts, a cosmwasm feature) has the omni-ability to override by migration; this logic
-	// is app-level. > 2-step ownership transfer is mostly redundant for CosmWasm contracts with
-	// the admin set. > You can override ownership with using CosmWasm migrate `entry_point`.
+	// See `ownership::transfer_ownership` for more information on this field
 	NewOwner string `json:"new_owner"`
 }
 

--- a/modules/bvs-cw/strategy-base/schema.go
+++ b/modules/bvs-cw/strategy-base/schema.go
@@ -214,10 +214,7 @@ type SetUnpauser struct {
 }
 
 type TransferOwnership struct {
-	// Transfer ownership of the contract to a new owner. Contract admin (set for all BVS
-	// contracts, a cosmwasm feature) has the omni-ability to override by migration; this logic
-	// is app-level. > 2-step ownership transfer is mostly redundant for CosmWasm contracts with
-	// the admin set. > You can override ownership with using CosmWasm migrate `entry_point`.
+	// See `ownership::transfer_ownership` for more information on this field
 	NewOwner string `json:"new_owner"`
 }
 

--- a/modules/bvs-cw/strategy-manager/schema.go
+++ b/modules/bvs-cw/strategy-manager/schema.go
@@ -263,10 +263,7 @@ type SetUnpauser struct {
 }
 
 type TransferOwnership struct {
-	// Transfer ownership of the contract to a new owner. Contract admin (set for all BVS
-	// contracts, a cosmwasm feature) has the omni-ability to override by migration; this logic
-	// is app-level. > 2-step ownership transfer is mostly redundant for CosmWasm contracts with
-	// the admin set. > You can override ownership with using CosmWasm migrate `entry_point`.
+	// See `ownership::transfer_ownership` for more information on this field
 	NewOwner string `json:"new_owner"`
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:


```diff
-    "generate:schema": "node generate.mjs",
+    "generate:schema": "node generate.mjs && goimports -w */schema.go",
```

So that git commit don't keep showing false positive.