### PR TITLE
fix: change ExecuteSlashRequest to use validator key names

### DIFF
--- a/modules/bvs-cli/commands/slash/exec.go
+++ b/modules/bvs-cli/commands/slash/exec.go
@@ -152,19 +152,7 @@ func ExecuteSlashRequest(userKeyNames []string, slashHash string) {
 	s := NewService()
 	ctx := context.Background()
 
-	var validatorsPublicKeys []cryptotypes.PubKey
-
-	for _, keyName := range userKeyNames {
-		newChainIO, err := s.ChainIO.SetupKeyring(keyName, conf.C.Account.KeyringBackend)
-		if err != nil {
-			panic(fmt.Sprintf("Failed to setup keyring for %s: %v", keyName, err))
-		}
-
-		pubKey := newChainIO.GetCurrentAccountPubKey()
-		validatorsPublicKeys = append(validatorsPublicKeys, pubKey)
-	}
-
-	txResp, err := s.Slash.ExecuteSlashRequest(ctx, slashHash, validatorsPublicKeys)
+	txResp, err := s.Slash.ExecuteSlashRequest(ctx, slashHash, userKeyNames)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:

fix dedaub go-H2 Wrong signer in ExecuteSlashRequest

- Change function signature to accept validator key names instead of public keys
- Update ExecuteSlashRequest to sign with validator private keys
- Simplify CLI command implementation by removing public key collection
- Keep consistent order between validator keys and signatures
﻿
BREAKING CHANGE: ExecuteSlashRequest now takes validator key names as input
instead of public keys. This change improves security by ensuring each
validator signs with their own private key.

<!-- remove if not applicable -->
Closes SL-320