### PR TITLE
fix: dedaub rust rewards-coordinator L1

### DIFF
--- a/crates/bvs-rewards-coordinator/src/msg.rs
+++ b/crates/bvs-rewards-coordinator/src/msg.rs
@@ -23,9 +23,6 @@ pub struct InstantiateMsg {
 #[cw_serde]
 #[derive(bvs_registry::api::Display)]
 pub enum ExecuteMsg {
-    CreateBvsRewardsSubmission {
-        rewards_submissions: Vec<RewardsSubmission>,
-    },
     CreateRewardsForAllSubmission {
         rewards_submissions: Vec<RewardsSubmission>,
     },

--- a/crates/bvs-rewards-coordinator/src/state.rs
+++ b/crates/bvs-rewards-coordinator/src/state.rs
@@ -8,8 +8,8 @@ pub const CUMULATIVE_CLAIMED: Map<(Addr, String), Uint128> = Map::new("cumulativ
 pub const SUBMISSION_NONCE: Map<Addr, u64> = Map::new("submission_nonce");
 pub const REWARDS_FOR_ALL_SUBMITTER: Map<Addr, bool> = Map::new("rewards_for_all_submitter");
 pub const ACTIVATION_DELAY: Item<u32> = Item::new("activation_delay");
-pub const IS_BVS_REWARDS_SUBMISSION_HASH: Map<(Addr, Vec<u8>), bool> =
-    Map::new("bvs_rewards_submission_hash");
+pub const IS_BVS_REWARDS_SUBMISSION_FOR_ALL_HASH: Map<(Addr, Vec<u8>), bool> =
+    Map::new("bvs_rewards_submission_for_all_hash");
 
 pub const CALCULATION_INTERVAL_SECONDS: Item<u64> = Item::new("calculation_interval_seconds");
 pub const MAX_REWARDS_DURATION: Item<u64> = Item::new("max_rewards_duration");


### PR DESCRIPTION
#### What this PR does / why we need it:

This fix is to resolve: Remove redundant function create_bvs_rewards_submission in rewards-coordinator and rename IS_BVS_REWARDS_SUBMISSION_HASH to IS_BVS_REWARDS_SUBMISSION_FOR_ALL_HASH

Fixes SL-287
