### PR TITLE
chore: remove BVS initialism in contracts

### DIFF
--- a/crates/bvs-delegation-manager/src/error.rs
+++ b/crates/bvs-delegation-manager/src/error.rs
@@ -12,7 +12,7 @@ pub enum ContractError {
     #[error("{0}")]
     Ownership(#[from] bvs_library::ownership::OwnershipError),
 
-    #[error("DelegationManager: Unauthorized")]
+    #[error("Unauthorized")]
     Unauthorized {},
 
     #[error("DelegationManager.set_operator_details: stakerOptOutWindowBlocks cannot be > MAX_STAKER_OPT_OUT_WINDOW_BLOCKS")]

--- a/crates/bvs-directory/src/contract.rs
+++ b/crates/bvs-directory/src/contract.rs
@@ -177,7 +177,7 @@ pub fn register_operator_to_bvs(
     )?;
     OPERATOR_SALT_SPENT.save(deps.storage, (operator.clone(), salt_str.clone()), &true)?;
 
-    let event = Event::new("OperatorBVSRegistrationStatusUpdated")
+    let event = Event::new("OperatorRegistrationStatusUpdated")
         .add_attribute("method", "register_operator")
         .add_attribute("operator", operator.to_string())
         .add_attribute("bvs", info.sender.to_string())
@@ -202,7 +202,7 @@ pub fn deregister_operator_from_bvs(
             &OperatorBvsRegistrationStatus::Unregistered,
         )?;
 
-        let event = Event::new("OperatorBVSRegistrationStatusUpdated")
+        let event = Event::new("OperatorRegistrationStatusUpdated")
             .add_attribute("method", "deregister_operator")
             .add_attribute("operator", operator.to_string())
             .add_attribute("bvs", info.sender.to_string())
@@ -218,7 +218,7 @@ pub fn update_bvs_metadata_uri(
     info: MessageInfo,
     metadata_uri: String,
 ) -> Result<Response, ContractError> {
-    let event = Event::new("BVSMetadataURIUpdated")
+    let event = Event::new("MetadataURIUpdated")
         .add_attribute("method", "update_metadata_uri")
         .add_attribute("bvs", info.sender.to_string())
         .add_attribute("metadata_uri", metadata_uri.clone());
@@ -553,7 +553,7 @@ mod tests {
         assert_eq!(res.events.len(), 1);
 
         let event = &res.events[0];
-        assert_eq!(event.ty, "OperatorBVSRegistrationStatusUpdated");
+        assert_eq!(event.ty, "OperatorRegistrationStatusUpdated");
         assert_eq!(event.attributes.len(), 5);
         assert_eq!(event.attributes[0].key, "method");
         assert_eq!(event.attributes[0].value, "register_operator");
@@ -659,7 +659,7 @@ mod tests {
         assert_eq!(res.events.len(), 1);
 
         let event = &res.events[0];
-        assert_eq!(event.ty, "OperatorBVSRegistrationStatusUpdated");
+        assert_eq!(event.ty, "OperatorRegistrationStatusUpdated");
         assert_eq!(event.attributes.len(), 4);
         assert_eq!(event.attributes[0].key, "method");
         assert_eq!(event.attributes[0].value, "deregister_operator");
@@ -695,7 +695,7 @@ mod tests {
         assert_eq!(res.events.len(), 1);
 
         let event = &res.events[0];
-        assert_eq!(event.ty, "BVSMetadataURIUpdated");
+        assert_eq!(event.ty, "MetadataURIUpdated");
         assert_eq!(event.attributes.len(), 3);
         assert_eq!(event.attributes[0].key, "method");
         assert_eq!(event.attributes[0].value, "update_metadata_uri");
@@ -799,7 +799,7 @@ mod tests {
         assert_eq!(res.events.len(), 1);
 
         let event = &res.events[0];
-        assert_eq!(event.ty, "OperatorBVSRegistrationStatusUpdated");
+        assert_eq!(event.ty, "OperatorRegistrationStatusUpdated");
         assert_eq!(event.attributes.len(), 5);
         assert_eq!(event.attributes[0].key, "method");
         assert_eq!(event.attributes[0].value, "register_operator");

--- a/crates/bvs-directory/src/error.rs
+++ b/crates/bvs-directory/src/error.rs
@@ -12,24 +12,24 @@ pub enum ContractError {
     #[error("{0}")]
     Ownership(#[from] bvs_library::ownership::OwnershipError),
 
-    #[error("BVSDirectory.registerOperatorToBVS: operator signature expired")]
-    SignatureExpired {},
-
-    #[error("BVSDirectory.registerOperatorToBVS: operator already registered")]
-    OperatorAlreadyRegistered {},
-
-    #[error("BVSDirectory.registerOperatorToBVS: salt already spent")]
-    SaltAlreadySpent {},
-
-    #[error("BVSDirectory.deregisterOperatorFromBVS: operator not registered yet")]
-    OperatorNotRegistered {},
-
-    #[error("BVSDirectory.registerOperatorToBVS: invalid signature")]
-    InvalidSignature {},
-
-    #[error("BVSDirectory.transferOwnership: unauthorized")]
+    #[error("Unauthorized")]
     Unauthorized {},
 
-    #[error("DelegationManager.IsOperator: operator not registered yet from delegation manager")]
+    #[error("operator signature expired")]
+    SignatureExpired {},
+
+    #[error("operator already registered")]
+    OperatorAlreadyRegistered {},
+
+    #[error("salt already spent")]
+    SaltAlreadySpent {},
+
+    #[error("operator not registered yet")]
+    OperatorNotRegistered {},
+
+    #[error("invalid signature")]
+    InvalidSignature {},
+
+    #[error("operator not registered yet from delegation manager")]
     OperatorNotRegisteredFromDelegationManager {},
 }

--- a/crates/bvs-directory/tests/integration_test.rs
+++ b/crates/bvs-directory/tests/integration_test.rs
@@ -199,7 +199,7 @@ fn register_update_metadata_uri_successfully() {
     assert_eq!(response.events.len(), 2);
     assert_eq!(
         response.events[1],
-        Event::new("wasm-BVSMetadataURIUpdated")
+        Event::new("wasm-MetadataURIUpdated")
             .add_attribute("_contract_address", mock_env.bvs_directory.contract_addr)
             .add_attribute("method", "update_metadata_uri")
             .add_attribute("bvs", anyone.into_string())

--- a/crates/bvs-rewards-coordinator/src/contract.rs
+++ b/crates/bvs-rewards-coordinator/src/contract.rs
@@ -199,7 +199,7 @@ pub fn create_bvs_rewards_submission(
 
         response = response.add_message(transfer_msg);
 
-        let event = Event::new("BVSRewardsSubmissionCreated")
+        let event = Event::new("RewardsSubmissionCreated")
             .add_attribute("sender", info.sender.to_string())
             .add_attribute("nonce", nonce.to_string())
             .add_attribute(
@@ -1307,7 +1307,7 @@ mod tests {
         assert_eq!(response.events.len(), 1);
 
         let event = response.events.first().unwrap();
-        assert_eq!(event.ty, "BVSRewardsSubmissionCreated");
+        assert_eq!(event.ty, "RewardsSubmissionCreated");
         assert_eq!(event.attributes.len(), 5);
         assert_eq!(event.attributes[0].key, "sender");
         assert_eq!(

--- a/crates/bvs-rewards-coordinator/src/error.rs
+++ b/crates/bvs-rewards-coordinator/src/error.rs
@@ -12,7 +12,7 @@ pub enum ContractError {
     #[error("{0}")]
     Ownership(#[from] bvs_library::ownership::OwnershipError),
 
-    #[error("RewardsCoordinator: Unauthorized")]
+    #[error("Unauthorized")]
     Unauthorized {},
 
     #[error("RewardsCoordinator.instantiate: invalid genesis timestamp")]

--- a/crates/bvs-slash-manager/src/error.rs
+++ b/crates/bvs-slash-manager/src/error.rs
@@ -12,7 +12,7 @@ pub enum ContractError {
     #[error("{0}")]
     Ownership(#[from] bvs_library::ownership::OwnershipError),
 
-    #[error("SlashManager: unauthorized")]
+    #[error("Unauthorized")]
     Unauthorized {},
 
     #[error("SlashManager.set_slash_validator: invalid input length")]

--- a/crates/bvs-strategy-base/src/error.rs
+++ b/crates/bvs-strategy-base/src/error.rs
@@ -12,7 +12,7 @@ pub enum ContractError {
     #[error("{0}")]
     Ownership(#[from] bvs_library::ownership::OwnershipError),
 
-    #[error("StrategyBase: unauthorized")]
+    #[error("Unauthorized")]
     Unauthorized {},
 
     #[error("StrategyBase.deposit: new_shares cannot be zero")]

--- a/crates/bvs-strategy-manager/src/error.rs
+++ b/crates/bvs-strategy-manager/src/error.rs
@@ -12,11 +12,11 @@ pub enum ContractError {
     #[error("{0}")]
     Ownership(#[from] bvs_library::ownership::OwnershipError),
 
+    #[error("Unauthorized")]
+    Unauthorized {},
+
     #[error("StrategyManager: strategy not whitelisted")]
     StrategyNotWhitelisted {},
-
-    #[error("StrategyManager: unauthorized")]
-    Unauthorized {},
 
     #[error("StrategyManager: invalid shares")]
     InvalidShares {},


### PR DESCRIPTION
#### What this PR does / why we need it:

As per title.

Closes SL-335
