### PR TITLE
chore(bump): babylonlabs/babylond:v1.0.0-rc.6

### DIFF
--- a/modules/babylond/babylond.go
+++ b/modules/babylond/babylond.go
@@ -170,7 +170,7 @@ func Run(ctx context.Context) *BabylonContainer {
 
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image: "babylonlabs/babylond:v1.0.0-rc.5",
+			Image: "babylonlabs/babylond:v1.0.0-rc.6",
 			Entrypoint: []string{
 				"sh",
 				"-c",


### PR DESCRIPTION
#### What this PR does / why we need it:

As per title, bump to rc6.