### PR TITLE
chore: remove strategy_whitelister use owner for whitelisting

### DIFF
--- a/crates/bvs-strategy-manager/src/msg.rs
+++ b/crates/bvs-strategy-manager/src/msg.rs
@@ -1,7 +1,7 @@
 use crate::query::{
     DepositsResponse, IsTokenBlacklistedResponse, StakerStrategyListLengthResponse,
     StakerStrategyListResponse, StakerStrategySharesResponse, StrategyWhitelistedResponse,
-    StrategyWhitelisterResponse, TokenStrategyResponse,
+    TokenStrategyResponse,
 };
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Uint128;
@@ -10,7 +10,6 @@ use cosmwasm_std::Uint128;
 pub struct InstantiateMsg {
     pub owner: String,
     pub registry: String,
-    pub initial_strategy_whitelister: String,
 }
 
 #[cw_serde]
@@ -28,9 +27,6 @@ pub enum ExecuteMsg {
     },
     RemoveStrategiesFromWhitelist {
         strategies: Vec<String>,
-    },
-    SetStrategyWhitelister {
-        new_strategy_whitelister: String,
     },
     DepositIntoStrategy {
         strategy: String,
@@ -79,9 +75,6 @@ pub enum QueryMsg {
 
     #[returns(StrategyWhitelistedResponse)]
     IsStrategyWhitelisted { strategy: String },
-
-    #[returns(StrategyWhitelisterResponse)]
-    GetStrategyWhitelister {},
 
     #[returns(IsTokenBlacklistedResponse)]
     IsTokenBlacklisted { token: String },

--- a/crates/bvs-strategy-manager/src/query.rs
+++ b/crates/bvs-strategy-manager/src/query.rs
@@ -28,11 +28,6 @@ pub struct StrategyWhitelistedResponse {
 }
 
 #[cw_serde]
-pub struct StrategyWhitelisterResponse {
-    pub whitelister: Addr,
-}
-
-#[cw_serde]
 pub struct TokenStrategyResponse {
     pub strategy: Addr,
 }

--- a/crates/bvs-strategy-manager/src/state.rs
+++ b/crates/bvs-strategy-manager/src/state.rs
@@ -1,7 +1,6 @@
 use cosmwasm_std::{Addr, Uint128};
-use cw_storage_plus::{Item, Map};
+use cw_storage_plus::Map;
 
-pub const STRATEGY_WHITELISTER: Item<Addr> = Item::new("strategy_whitelister");
 pub const STRATEGY_IS_WHITELISTED_FOR_DEPOSIT: Map<&Addr, bool> = Map::new("strategy_whitelist");
 
 // DEPLOYED_STRATEGIES and IS_BLACKLISTED are previously handled by factory

--- a/crates/bvs-strategy-manager/src/testing.rs
+++ b/crates/bvs-strategy-manager/src/testing.rs
@@ -25,7 +25,6 @@ impl TestingContract<InstantiateMsg, ExecuteMsg, QueryMsg> for StrategyManagerCo
         InstantiateMsg {
             owner: owner.to_string(),
             registry: registry.to_string(),
-            initial_strategy_whitelister: owner.to_string(),
         }
     }
 

--- a/examples/squaring/modules/internal/tests/utils.go
+++ b/examples/squaring/modules/internal/tests/utils.go
@@ -166,7 +166,7 @@ func (suite *TestSuite) DeployBvsContracts() {
 	directoryContract := deployer.DeployDirectory(registry.Address)
 	suite.DirectoryApi = api.NewDirectory(suite.ChainIO, directoryContract.Address)
 
-	strategyManagerContract := deployer.DeployStrategyManager(registry.Address, tempAddress.String())
+	strategyManagerContract := deployer.DeployStrategyManager(registry.Address)
 	suite.StrategyManagerApi = api.NewStrategyManager(suite.ChainIO)
 	suite.StrategyManagerApi.BindClient(strategyManagerContract.Address)
 

--- a/modules/babylond/bvs/deployer.go
+++ b/modules/babylond/bvs/deployer.go
@@ -72,12 +72,10 @@ func (d *Deployer) DeploySlashManager(
 
 func (d *Deployer) DeployStrategyManager(
 	registry string,
-	initialStrategyWhitelister string,
 ) *Contract[strategymanager.InstantiateMsg] {
 	initMsg := strategymanager.InstantiateMsg{
-		Owner:                      d.GenerateAddress("strategy-manager:initial_owner").String(),
-		Registry:                   registry,
-		InitialStrategyWhitelister: initialStrategyWhitelister,
+		Owner:    d.GenerateAddress("strategy-manager:initial_owner").String(),
+		Registry: registry,
 	}
 
 	return deployCrate(d, "bvs-strategy-manager", initMsg, "BVS Strategy Manager")

--- a/modules/bvs-api/chainio/api/strategy_manager.go
+++ b/modules/bvs-api/chainio/api/strategy_manager.go
@@ -88,16 +88,6 @@ func (r *StrategyManager) RemoveStrategiesFromWhitelist(ctx context.Context, str
 	return r.execute(ctx, msg)
 }
 
-func (r *StrategyManager) SetStrategyWhitelister(ctx context.Context, newStrategyWhitelister string) (*coretypes.ResultTx, error) {
-	msg := strategymanager.ExecuteMsg{
-		SetStrategyWhitelister: &strategymanager.SetStrategyWhitelister{
-			NewStrategyWhitelister: newStrategyWhitelister,
-		},
-	}
-
-	return r.execute(ctx, msg)
-}
-
 func (r *StrategyManager) DepositIntoStrategy(ctx context.Context, strategy string, token string, amount uint64) (*coretypes.ResultTx, error) {
 	msg := strategymanager.ExecuteMsg{
 		DepositIntoStrategy: &strategymanager.DepositIntoStrategy{
@@ -232,14 +222,6 @@ func (r *StrategyManager) IsStrategyWhitelisted(strategy string) (*wasmtypes.Que
 		IsStrategyWhitelisted: &strategymanager.IsStrategyWhitelisted{
 			Strategy: strategy,
 		},
-	}
-
-	return r.query(msg)
-}
-
-func (r *StrategyManager) GetStrategyWhitelister() (*wasmtypes.QuerySmartContractStateResponse, error) {
-	msg := strategymanager.QueryMsg{
-		GetStrategyWhitelister: &strategymanager.GetStrategyWhitelister{},
 	}
 
 	return r.query(msg)

--- a/modules/bvs-api/tests/e2e/delegation_manager_test.go
+++ b/modules/bvs-api/tests/e2e/delegation_manager_test.go
@@ -67,7 +67,7 @@ func (suite *delegationTestSuite) SetupSuite() {
 
 	container.ImportPrivKey("delegation-manager:initial_owner", "E5DBC50CB04311A2A5C3C0E0258D396E962F64C6C2F758458FFB677D7F0C0E94")
 
-	strategyManager := deployer.DeployStrategyManager(registry.Address, "bbn1dcpzdejnywqc4x8j5tyafv7y4pdmj7p9fmredf")
+	strategyManager := deployer.DeployStrategyManager(registry.Address)
 	delegationManager := deployer.DeployDelegationManager(registry.Address, 100, []string{tAddr}, []int64{50})
 
 	suite.strategyManager = strategyManager.Address

--- a/modules/bvs-api/tests/e2e/directory_test.go
+++ b/modules/bvs-api/tests/e2e/directory_test.go
@@ -45,7 +45,7 @@ func (s *DirectoryTestSuite) SetupSuite() {
 	// Setup DelegationManager,
 	// Setup StrategyManager,
 	// Add Operator to DelegationManager
-	strategyManager := deployer.DeployStrategyManager(registry.Address, "bbn1dcpzdejnywqc4x8j5tyafv7y4pdmj7p9fmredf")
+	strategyManager := deployer.DeployStrategyManager(registry.Address)
 	delegationManager := deployer.DeployDelegationManager(registry.Address, 100, []string{tAddr}, []int64{50})
 
 	s.contrAddr = deployer.DeployDirectory(registry.Address).Address

--- a/modules/bvs-api/tests/e2e/rewards_coordinator_test.go
+++ b/modules/bvs-api/tests/e2e/rewards_coordinator_test.go
@@ -68,7 +68,7 @@ func (suite *rewardsTestSuite) SetupSuite() {
 	suite.Require().NoError(err)
 	blockTime := status.SyncInfo.LatestBlockTime.Second()
 
-	strategyManager := deployer.DeployStrategyManager(registry.Address, "bbn1dcpzdejnywqc4x8j5tyafv7y4pdmj7p9fmredf")
+	strategyManager := deployer.DeployStrategyManager(registry.Address)
 	rewardsCoordinator := deployer.DeployRewardsCoordinator(
 		registry.Address,
 		// Test Vector taken from: bvs-rewards-coordinator/src/contract.rs

--- a/modules/bvs-api/tests/e2e/strategy_manager_test.go
+++ b/modules/bvs-api/tests/e2e/strategy_manager_test.go
@@ -48,7 +48,7 @@ func (suite *strategyManagerTestSuite) SetupSuite() {
 	registry := deployer.DeployRegistry(nil)
 
 	suite.container.ImportPrivKey("strategy-manager:initial_owner", "E5DBC50CB04311A2A5C3C0E0258D396E962F64C6C2F758458FFB677D7F0C0E94")
-	strategyManager := deployer.DeployStrategyManager(registry.Address, "bbn1dcpzdejnywqc4x8j5tyafv7y4pdmj7p9fmredf")
+	strategyManager := deployer.DeployStrategyManager(registry.Address)
 
 	suite.managerAddr = strategyManager.Address
 	suite.container.FundAddressUbbn("bbn1dcpzdejnywqc4x8j5tyafv7y4pdmj7p9fmredf", 1e8)
@@ -91,11 +91,6 @@ func (suite *strategyManagerTestSuite) Test_Init() {
 
 	resp, err = strategyManager.SetRouting(context.Background(), delegationAddr, slashManagerAddr)
 	assert.NoError(t, err, "execute contract")
-	assert.NotNil(t, resp, "response nil")
-	t.Logf("resp:%+v", resp)
-
-	resp, err = strategyManager.SetStrategyWhitelister(context.Background(), ownerAddr)
-	assert.NoError(t, err, "SetStrategyWhitelister")
 	assert.NotNil(t, resp, "response nil")
 	t.Logf("resp:%+v", resp)
 
@@ -259,11 +254,6 @@ func (suite *strategyManagerTestSuite) test_QueryStrategyManager() {
 
 	account, err := chainIO.GetCurrentAccount()
 	assert.NoError(t, err, "get account", account)
-
-	resp, err = strategyManager.GetStrategyWhitelister()
-	assert.NoError(t, err, "execute contract")
-	assert.NotNil(t, resp, "response nil")
-	t.Logf("GetStrategyWhitelister resp:%+v", resp)
 }
 
 func TestStrategyManagerTestSuite(t *testing.T) {

--- a/modules/bvs-cli/cmd/strategy.go
+++ b/modules/bvs-cli/cmd/strategy.go
@@ -24,14 +24,6 @@ func strategyCmd() *cobra.Command {
 		},
 	}
 
-	setStrategyWhitelistCmd := &cobra.Command{
-		Use:   "set-strategy-whitelist <userKeyName> <strategyWhitelist>",
-		Short: "To set the strategy whitelist.",
-		Args:  cobra.ExactArgs(2),
-		Run: func(cmd *cobra.Command, args []string) {
-			strategy.SetStrategyWhitelist(args[0], args[1])
-		},
-	}
 	removeStrategyFromWhitelistCmd := &cobra.Command{
 		Use:   "remove-strategy-from-whitelist <userKeyName> <strategyAddress>",
 		Short: "To remove the strategy from whitelist.",
@@ -124,21 +116,11 @@ func strategyCmd() *cobra.Command {
 			strategy.IsStrategyWhitelisted(args[0])
 		},
 	}
-	getStrategyWhitelistCmd := &cobra.Command{
-		Use:   "get-strategy-whitelist",
-		Short: "To get the strategy whitelist.",
-		Args:  cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			strategy.GetStrategyWhitelist()
-		},
-	}
 
 	subCmd.AddCommand(transferOwnerCmd)
 	subCmd.AddCommand(removeStrategyFromWhitelistCmd)
-	subCmd.AddCommand(setStrategyWhitelistCmd)
 	subCmd.AddCommand(getStakerStrategyListCmd)
 	subCmd.AddCommand(isStrategyWhitelistedCmd)
-	subCmd.AddCommand(getStrategyWhitelistCmd)
 	subCmd.AddCommand(addStrategyToWhitelistCmd)
 	subCmd.AddCommand(depositStrategyCmd)
 	subCmd.AddCommand(removeSharesCmd)

--- a/modules/bvs-cli/commands/strategy/exec.go
+++ b/modules/bvs-cli/commands/strategy/exec.go
@@ -31,15 +31,6 @@ func TransferOwner(userKeyName, newOwner string) {
 	fmt.Printf("Transfer ownership success. txn: %s\n", txResp.Hash)
 }
 
-func SetStrategyWhitelist(userKeyName, strategyWhitelist string) {
-	ctx := context.Background()
-	strategy, _ := newService(userKeyName)
-	txResp, err := strategy.SetStrategyWhitelister(ctx, strategyWhitelist)
-	if err != nil {
-		panic(err)
-	}
-	fmt.Printf("Set strategy whitelist success. txn: %s\n", txResp.Hash)
-}
 func AddStrategyWhitelist(userKeyName string, strategies []string) {
 	ctx := context.Background()
 	strategy, _ := newService(userKeyName)

--- a/modules/bvs-cli/commands/strategy/query.go
+++ b/modules/bvs-cli/commands/strategy/query.go
@@ -46,12 +46,3 @@ func IsStrategyWhitelisted(strategyAddress string) {
 	}
 	fmt.Printf("%s\n", resp.Data)
 }
-
-func GetStrategyWhitelist() {
-	s := NewService()
-	resp, err := s.Strategy.GetStrategyWhitelister()
-	if err != nil {
-		panic(err)
-	}
-	fmt.Printf("%s\n", resp.Data)
-}

--- a/modules/bvs-cw/strategy-manager/schema.go
+++ b/modules/bvs-cw/strategy-manager/schema.go
@@ -19,9 +19,6 @@
 //    stakerStrategySharesResponse, err := UnmarshalStakerStrategySharesResponse(bytes)
 //    bytes, err = stakerStrategySharesResponse.Marshal()
 //
-//    strategyWhitelisterResponse, err := UnmarshalStrategyWhitelisterResponse(bytes)
-//    bytes, err = strategyWhitelisterResponse.Marshal()
-//
 //    strategyWhitelistedResponse, err := UnmarshalStrategyWhitelistedResponse(bytes)
 //    bytes, err = strategyWhitelistedResponse.Marshal()
 //
@@ -98,16 +95,6 @@ func (r *StakerStrategySharesResponse) Marshal() ([]byte, error) {
 	return json.Marshal(r)
 }
 
-func UnmarshalStrategyWhitelisterResponse(data []byte) (StrategyWhitelisterResponse, error) {
-	var r StrategyWhitelisterResponse
-	err := json.Unmarshal(data, &r)
-	return r, err
-}
-
-func (r *StrategyWhitelisterResponse) Marshal() ([]byte, error) {
-	return json.Marshal(r)
-}
-
 func UnmarshalStrategyWhitelistedResponse(data []byte) (StrategyWhitelistedResponse, error) {
 	var r StrategyWhitelistedResponse
 	err := json.Unmarshal(data, &r)
@@ -149,9 +136,8 @@ func (r *TokenStrategyResponse) Marshal() ([]byte, error) {
 }
 
 type InstantiateMsg struct {
-	InitialStrategyWhitelister string `json:"initial_strategy_whitelister"`
-	Owner                      string `json:"owner"`
-	Registry                   string `json:"registry"`
+	Owner    string `json:"owner"`
+	Registry string `json:"registry"`
 }
 
 type ExecuteMsg struct {
@@ -159,7 +145,6 @@ type ExecuteMsg struct {
 	BlacklistTokens               *BlacklistTokens               `json:"blacklist_tokens,omitempty"`
 	AddStrategiesToWhitelist      *AddStrategiesToWhitelist      `json:"add_strategies_to_whitelist,omitempty"`
 	RemoveStrategiesFromWhitelist *RemoveStrategiesFromWhitelist `json:"remove_strategies_from_whitelist,omitempty"`
-	SetStrategyWhitelister        *SetStrategyWhitelister        `json:"set_strategy_whitelister,omitempty"`
 	DepositIntoStrategy           *DepositIntoStrategy           `json:"deposit_into_strategy,omitempty"`
 	WithdrawSharesAsTokens        *WithdrawSharesAsTokens        `json:"withdraw_shares_as_tokens,omitempty"`
 	AddShares                     *AddShares                     `json:"add_shares,omitempty"`
@@ -208,10 +193,6 @@ type SetRouting struct {
 	SlashManager      string `json:"slash_manager"`
 }
 
-type SetStrategyWhitelister struct {
-	NewStrategyWhitelister string `json:"new_strategy_whitelister"`
-}
-
 type TransferOwnership struct {
 	// See [`bvs_library::ownership::transfer_ownership`] for more information on this field
 	NewOwner string `json:"new_owner"`
@@ -229,7 +210,6 @@ type QueryMsg struct {
 	GetStakerStrategyShares  *GetStakerStrategyShares  `json:"get_staker_strategy_shares,omitempty"`
 	GetStakerStrategyList    *GetStakerStrategyList    `json:"get_staker_strategy_list,omitempty"`
 	IsStrategyWhitelisted    *IsStrategyWhitelisted    `json:"is_strategy_whitelisted,omitempty"`
-	GetStrategyWhitelister   *GetStrategyWhitelister   `json:"get_strategy_whitelister,omitempty"`
 	IsTokenBlacklisted       *IsTokenBlacklisted       `json:"is_token_blacklisted,omitempty"`
 	TokenStrategy            *TokenStrategy            `json:"token_strategy,omitempty"`
 }
@@ -245,9 +225,6 @@ type GetStakerStrategyList struct {
 type GetStakerStrategyShares struct {
 	Staker   string `json:"staker"`
 	Strategy string `json:"strategy"`
-}
-
-type GetStrategyWhitelister struct {
 }
 
 type IsStrategyWhitelisted struct {
@@ -277,10 +254,6 @@ type StakerStrategyListResponse struct {
 
 type StakerStrategySharesResponse struct {
 	Shares string `json:"shares"`
-}
-
-type StrategyWhitelisterResponse struct {
-	Whitelister string `json:"whitelister"`
 }
 
 type StrategyWhitelistedResponse struct {


### PR DESCRIPTION
#### What this PR does / why we need it:

Remove `strategy_whitelister`, `use ownership::OWNER` authorization to drive this feature.