### PR TITLE
chore(cargo): use target_arch flagging instead of feature flagging

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -267,7 +267,6 @@ dependencies = [
 name = "bvs-rewards-coordinator"
 version = "0.1.0"
 dependencies = [
- "base64",
  "bvs-library",
  "bvs-registry",
  "bvs-strategy-base",

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -52,11 +52,11 @@ base64 = "0.22.1"
 cw-utils = "2.0.0"
 
 # CosmWasm Libraries & Contracts
-bvs-library = { path = "./bvs-library", default-features = false }
-bvs-registry = { path = "./bvs-registry", default-features = false, features = ["library"] }
-bvs-delegation-manager = { path = "./bvs-delegation-manager", default-features = false, features = ["library"] }
-bvs-directory = { path = "./bvs-directory", default-features = false, features = ["library"] }
-bvs-rewards-coordinator = { path = "./bvs-rewards-coordinator", default-features = false, features = ["library"] }
-bvs-slash-manager = { path = "./bvs-slash-manager", default-features = false, features = ["library"] }
-bvs-strategy-base = { path = "./bvs-strategy-base", default-features = false, features = ["library"] }
-bvs-strategy-manager = { path = "./bvs-strategy-manager", default-features = false, features = ["library"] }
+bvs-library = { path = "./bvs-library" }
+bvs-registry = { path = "./bvs-registry", features = ["library"] }
+bvs-delegation-manager = { path = "./bvs-delegation-manager", features = ["library"] }
+bvs-directory = { path = "./bvs-directory", features = ["library"] }
+bvs-rewards-coordinator = { path = "./bvs-rewards-coordinator", features = ["library"] }
+bvs-slash-manager = { path = "./bvs-slash-manager", features = ["library"] }
+bvs-strategy-base = { path = "./bvs-strategy-base", features = ["library"] }
+bvs-strategy-manager = { path = "./bvs-strategy-manager", features = ["library"] }

--- a/crates/bvs-delegation-manager/Cargo.toml
+++ b/crates/bvs-delegation-manager/Cargo.toml
@@ -14,14 +14,8 @@ include = ["src"]
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[package.metadata.optimizer]
-standard-build = false
-builds = [{ name = "", default-features = false }]
-
 [features]
-default = ["testing"]
 library = []
-testing = ["library", "dep:cw-multi-test"]
 
 [dependencies]
 cosmwasm-std = { workspace = true }
@@ -32,15 +26,11 @@ thiserror = { workspace = true }
 serde = { workspace = true }
 schemars = { workspace = true }
 sha2 = { workspace = true }
-cw-multi-test = { workspace = true, optional = true }
 
 bvs-library = { workspace = true }
 bvs-registry = { workspace = true }
 bvs-strategy-manager = { workspace = true }
 
-[dev-dependencies]
+[target."cfg(not(target_arch = \"wasm32\"))".dependencies]
 cw-multi-test = { workspace = true }
-bvs-library = { workspace = true, features = ["testing"] }
-bvs-registry = { workspace = true, features = ["testing"] }
-bvs-strategy-base = { workspace = true, features = ["testing"] }
-bvs-strategy-manager = { workspace = true, features = ["testing"] }
+bvs-strategy-base = { workspace = true }

--- a/crates/bvs-delegation-manager/src/lib.rs
+++ b/crates/bvs-delegation-manager/src/lib.rs
@@ -8,5 +8,4 @@ mod state;
 
 pub use crate::error::ContractError;
 
-#[cfg(feature = "testing")]
 pub mod testing;

--- a/crates/bvs-delegation-manager/src/testing.rs
+++ b/crates/bvs-delegation-manager/src/testing.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_arch = "wasm32"))]
+
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use bvs_library::testing::TestingContract;
 use cosmwasm_std::{Addr, Empty, Env};

--- a/crates/bvs-directory/Cargo.toml
+++ b/crates/bvs-directory/Cargo.toml
@@ -14,14 +14,8 @@ include = ["src"]
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[package.metadata.optimizer]
-standard-build = false
-builds = [{ name = "", default-features = false }]
-
 [features]
-default = ["testing"]
 library = []
-testing = ["library", "dep:cw-multi-test", "bvs-library/testing"]
 
 [dependencies]
 cosmwasm-std = { workspace = true }
@@ -31,17 +25,12 @@ cw2 = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }
 schemars = { workspace = true }
-cw-multi-test = { workspace = true, optional = true }
 
 bvs-library = { workspace = true }
 bvs-registry = { workspace = true }
 bvs-delegation-manager = { workspace = true }
 
-[dev-dependencies]
+[target."cfg(not(target_arch = \"wasm32\"))".dependencies]
 cw-multi-test = { workspace = true }
-
-bvs-library = { workspace = true, features = ["testing"] }
-bvs-registry = { workspace = true, features = ["testing"] }
-bvs-strategy-base = { workspace = true, features = ["testing"] }
-bvs-strategy-manager = { workspace = true, features = ["testing"] }
-bvs-delegation-manager = { workspace = true, features = ["testing"] }
+bvs-strategy-base = { workspace = true }
+bvs-strategy-manager = { workspace = true }

--- a/crates/bvs-directory/src/lib.rs
+++ b/crates/bvs-directory/src/lib.rs
@@ -8,5 +8,4 @@ mod auth;
 
 pub use crate::error::ContractError;
 
-#[cfg(feature = "testing")]
 pub mod testing;

--- a/crates/bvs-directory/src/testing.rs
+++ b/crates/bvs-directory/src/testing.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_arch = "wasm32"))]
+
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use bvs_library::testing::TestingContract;
 use cosmwasm_std::{Addr, Empty, Env};

--- a/crates/bvs-library/Cargo.toml
+++ b/crates/bvs-library/Cargo.toml
@@ -15,8 +15,7 @@ include = ["src"]
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["testing"]
-testing = ["dep:cw-multi-test"]
+library = []
 
 [dependencies]
 cosmwasm-std = { workspace = true }
@@ -29,7 +28,6 @@ bech32 = { workspace = true }
 ripemd = { workspace = true }
 base64 = { workspace = true }
 serde = { workspace = true }
-cw-multi-test = { workspace = true, optional = true }
 
-[dev-dependencies]
+[target."cfg(not(target_arch = \"wasm32\"))".dependencies]
 cw-multi-test = { workspace = true }

--- a/crates/bvs-library/src/lib.rs
+++ b/crates/bvs-library/src/lib.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "testing")]
 pub mod testing;
 
 /// This module contains the implementation of the `ownership` module.

--- a/crates/bvs-library/src/testing.rs
+++ b/crates/bvs-library/src/testing.rs
@@ -1,3 +1,6 @@
+#![cfg(not(target_arch = "wasm32"))]
+// Only exposed on unit and integration testing, not compiled to Wasm.
+
 mod account;
 mod contract;
 

--- a/crates/bvs-registry/Cargo.toml
+++ b/crates/bvs-registry/Cargo.toml
@@ -14,14 +14,8 @@ include = ["src"]
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[package.metadata.optimizer]
-standard-build = false
-builds = [{ name = "", default-features = false }]
-
 [features]
-default = ["testing"]
-library = ["dep:strum"]
-testing = ["library", "dep:cw-multi-test", "bvs-library/testing"]
+library = []
 
 [dependencies]
 cosmwasm-std = { workspace = true }
@@ -31,10 +25,8 @@ cw2 = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }
 schemars = { workspace = true }
-strum = { version = "0.27", features = ["derive"], optional = true }
-cw-multi-test = { workspace = true, optional = true }
-
+strum = { version = "0.27", features = ["derive"] }
 bvs-library = { workspace = true }
 
-[dev-dependencies]
+[target."cfg(not(target_arch = \"wasm32\"))".dependencies]
 cw-multi-test = { workspace = true }

--- a/crates/bvs-registry/src/lib.rs
+++ b/crates/bvs-registry/src/lib.rs
@@ -5,7 +5,6 @@ pub mod state;
 
 pub use crate::error::ContractError;
 
-#[cfg(feature = "testing")]
 pub mod testing;
 
 #[cfg(feature = "library")]

--- a/crates/bvs-registry/src/testing.rs
+++ b/crates/bvs-registry/src/testing.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_arch = "wasm32"))]
+
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use bvs_library::testing::TestingContract;
 use cosmwasm_std::{Addr, Empty, Env};

--- a/crates/bvs-rewards-coordinator/Cargo.toml
+++ b/crates/bvs-rewards-coordinator/Cargo.toml
@@ -14,14 +14,8 @@ include = ["src"]
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[package.metadata.optimizer]
-standard-build = false
-builds = [{ name = "", default-features = false }]
-
 [features]
-default = ["testing"]
 library = []
-testing = ["library", "dep:cw-multi-test", "bvs-library/testing"]
 
 [dependencies]
 cosmwasm-std = { workspace = true }
@@ -34,15 +28,11 @@ serde = { workspace = true }
 schemars = { workspace = true }
 sha2 = { workspace = true }
 serde_json = { workspace = true }
-base64 = { workspace = true }
-cw-multi-test = { workspace = true, optional = true }
 
 bvs-library = { workspace = true }
 bvs-registry = { workspace = true }
 bvs-strategy-manager = { workspace = true }
 
-[dev-dependencies]
+[target."cfg(not(target_arch = \"wasm32\"))".dependencies]
 cw-multi-test = { workspace = true }
-bvs-registry = { workspace = true, features = ["testing"] }
-bvs-strategy-base = { workspace = true, features = ["testing"] }
-bvs-strategy-manager = { workspace = true, features = ["testing"] }
+bvs-strategy-base = { workspace = true }

--- a/crates/bvs-rewards-coordinator/src/lib.rs
+++ b/crates/bvs-rewards-coordinator/src/lib.rs
@@ -9,5 +9,4 @@ mod error;
 
 pub use crate::error::ContractError;
 
-#[cfg(feature = "testing")]
 pub mod testing;

--- a/crates/bvs-rewards-coordinator/src/testing.rs
+++ b/crates/bvs-rewards-coordinator/src/testing.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_arch = "wasm32"))]
+
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use bvs_library::testing::TestingContract;
 use cosmwasm_std::{Addr, Empty, Env};

--- a/crates/bvs-slash-manager/Cargo.toml
+++ b/crates/bvs-slash-manager/Cargo.toml
@@ -14,14 +14,8 @@ include = ["src"]
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[package.metadata.optimizer]
-standard-build = false
-builds = [{ name = "", default-features = false }]
-
 [features]
-default = ["testing"]
 library = []
-testing = ["library", "dep:cw-multi-test"]
 
 [dependencies]
 cosmwasm-std = { workspace = true }
@@ -39,15 +33,12 @@ bech32 = { workspace = true }
 ripemd = { workspace = true }
 base64 = { workspace = true }
 serde_json = { workspace = true }
-cw-multi-test = { workspace = true, optional = true }
 
 bvs-library = { workspace = true }
 bvs-registry = { workspace = true }
 bvs-strategy-manager = { workspace = true }
 bvs-delegation-manager = { workspace = true }
 
-[dev-dependencies]
+[target."cfg(not(target_arch = \"wasm32\"))".dependencies]
 cw-multi-test = { workspace = true }
-bvs-strategy-base = { workspace = true, features = ["testing"] }
-bvs-strategy-manager = { workspace = true, features = ["testing"] }
-bvs-delegation-manager = { workspace = true, features = ["testing"] }
+bvs-strategy-base = { workspace = true }

--- a/crates/bvs-strategy-base/Cargo.toml
+++ b/crates/bvs-strategy-base/Cargo.toml
@@ -14,14 +14,8 @@ include = ["src"]
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[package.metadata.optimizer]
-standard-build = false
-builds = [{ name = "", default-features = false }]
-
 [features]
-default = ["testing"]
 library = []
-testing = ["library", "dep:cw-multi-test", "dep:cw20-base", "bvs-library/testing"]
 
 [dependencies]
 cosmwasm-std = { workspace = true }
@@ -32,13 +26,10 @@ cw20 = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }
 schemars = { workspace = true }
-cw-multi-test = { workspace = true, optional = true }
 
 bvs-library = { workspace = true }
 bvs-registry = { workspace = true }
-cw20-base = { workspace = true, optional = true }
 
-[dev-dependencies]
+[target."cfg(not(target_arch = \"wasm32\"))".dependencies]
 cw-multi-test = { workspace = true }
-bvs-registry = { workspace = true, features = ["testing"] }
 cw20-base = { workspace = true }

--- a/crates/bvs-strategy-base/src/lib.rs
+++ b/crates/bvs-strategy-base/src/lib.rs
@@ -8,5 +8,4 @@ mod token;
 
 pub use crate::error::ContractError;
 
-#[cfg(feature = "testing")]
 pub mod testing;

--- a/crates/bvs-strategy-base/src/testing.rs
+++ b/crates/bvs-strategy-base/src/testing.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_arch = "wasm32"))]
+
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use bvs_library::testing::TestingContract;
 use cosmwasm_std::{Addr, Empty, Env};

--- a/crates/bvs-strategy-manager/Cargo.toml
+++ b/crates/bvs-strategy-manager/Cargo.toml
@@ -14,14 +14,8 @@ include = ["src"]
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[package.metadata.optimizer]
-standard-build = false
-builds = [{ name = "", default-features = false }]
-
 [features]
-default = ["testing"]
 library = []
-testing = ["library", "dep:cw-multi-test", "bvs-library/testing"]
 
 [dependencies]
 cosmwasm-std = { workspace = true }
@@ -38,9 +32,9 @@ bvs-library = { workspace = true }
 bvs-registry = { workspace = true }
 bvs-strategy-base = { workspace = true }
 
-[dev-dependencies]
+[target."cfg(not(target_arch = \"wasm32\"))".dependencies]
 cw-multi-test = { workspace = true }
-bvs-registry = { workspace = true, features = ["testing"] }
-bvs-strategy-base = { workspace = true, features = ["testing"] }
 cw20-base = { workspace = true }
-bvs-delegation-manager = { workspace = true, features = ["testing"] }
+
+[dev-dependencies]
+bvs-delegation-manager = { workspace = true }

--- a/crates/bvs-strategy-manager/src/lib.rs
+++ b/crates/bvs-strategy-manager/src/lib.rs
@@ -8,5 +8,4 @@ mod state;
 
 pub use crate::error::ContractError;
 
-#[cfg(feature = "testing")]
 pub mod testing;

--- a/crates/bvs-strategy-manager/src/testing.rs
+++ b/crates/bvs-strategy-manager/src/testing.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_arch = "wasm32"))]
+
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use bvs_library::testing::TestingContract;
 use cosmwasm_std::{Addr, Empty, Env};


### PR DESCRIPTION
#### What this PR does / why we need it:

Use `#![cfg(not(target_arch = "wasm32"))]`
Instead of `#[cfg(feature = "testing")]`

Reduce complexity, let convention take over.

Closes SL-342