### PR TITLE
chore: remove redundant fn and rewards for all submitter role

### DIFF
--- a/crates/bvs-rewards-coordinator/src/error.rs
+++ b/crates/bvs-rewards-coordinator/src/error.rs
@@ -21,9 +21,6 @@ pub enum ContractError {
     #[error("RewardsCoordinator.instantiate: invalid calculation interval")]
     InvalidCalculationInterval {},
 
-    #[error("RewardsCoordinator._only_rewards_for_all_submitter: caller is not a valid createRewardsForAllSubmission submitter")]
-    ValidCreateRewardsForAllSubmission {},
-
     #[error("RewardsCoordinator.validate_rewards_submission: no strategies set")]
     NoStrategiesSet {},
 

--- a/crates/bvs-rewards-coordinator/src/msg.rs
+++ b/crates/bvs-rewards-coordinator/src/msg.rs
@@ -26,9 +26,6 @@ pub enum ExecuteMsg {
     CreateRewardsSubmission {
         rewards_submissions: Vec<RewardsSubmission>,
     },
-    CreateRewardsForAllSubmission {
-        rewards_submissions: Vec<RewardsSubmission>,
-    },
     ProcessClaim {
         claim: RewardsMerkleClaim,
         recipient: String,
@@ -45,10 +42,6 @@ pub enum ExecuteMsg {
     },
     SetActivationDelay {
         new_activation_delay: u32,
-    },
-    SetRewardsForAllSubmitter {
-        submitter: String,
-        new_value: bool,
     },
     SetGlobalOperatorCommission {
         new_commission_bips: u16,

--- a/crates/bvs-rewards-coordinator/src/state.rs
+++ b/crates/bvs-rewards-coordinator/src/state.rs
@@ -15,9 +15,6 @@ pub const CUMULATIVE_CLAIMED: Map<(&Addr, &Addr), Uint128> = Map::new("cumulativ
 /// Stores the running count of [`RewardsSubmission`](crate::merkle::RewardsSubmission) submitted per `Service`
 pub const SUBMISSION_NONCE: Map<&Addr, u64> = Map::new("submission_nonce");
 
-/// Stores the address permissioned to call [`create_rewards_for_all_submission`](crate::contract::create_rewards_for_all_submission)
-pub const REWARDS_FOR_ALL_SUBMITTER: Map<&Addr, bool> = Map::new("rewards_for_all_submitter");
-
 /// Stores the delay from the time of reward submission to the time of activation / claimable time
 pub const ACTIVATION_DELAY: Item<u32> = Item::new("activation_delay");
 

--- a/examples/squaring/modules/uploader/uploader/rpc.go
+++ b/examples/squaring/modules/uploader/uploader/rpc.go
@@ -36,7 +36,7 @@ type UnderlyingTokenResponse struct {
 	UnderlyingTokenAddr string `json:"underlying_token_addr"`
 }
 
-// rpcSubmission sends a CreateRewardsForAllSubmission transaction to the rewards coordinator.
+// rpcSubmission sends a CreateRewardsSubmission transaction to the rewards coordinator.
 //
 // Given a list of Submission, this method creates a RewardsSubmission for each submission,
 // and sends a CreateRewardsForAllSubmission transaction to the rewards coordinator with the
@@ -65,12 +65,12 @@ func (u *Uploader) rpcSubmission(rewards []Submission) error {
 		})
 	}
 	fmt.Printf("submissions: %+v\n", submissions)
-	resp, err := u.rewardsCoordinator.CreateRewardsForAllSubmission(context.Background(), submissions)
+	resp, err := u.rewardsCoordinator.CreateRewardsSubmission(context.Background(), submissions)
 	if err != nil {
-		fmt.Println("CreateRewardsForAllSubmission err: ", err)
+		fmt.Println("CreateRewardsSubmission err: ", err)
 		return err
 	}
-	fmt.Println("CreateRewardsForAllSubmission txn hash: ", resp.Hash.String())
+	fmt.Println("CreateRewardsSubmission txn hash: ", resp.Hash.String())
 	return err
 }
 

--- a/modules/bvs-api/chainio/api/rewards_coordinator.go
+++ b/modules/bvs-api/chainio/api/rewards_coordinator.go
@@ -77,16 +77,6 @@ func (r *RewardsCoordinator) CreateRewardsSubmission(ctx context.Context, submis
 	return r.execute(ctx, msg)
 }
 
-func (r *RewardsCoordinator) CreateRewardsForAllSubmission(ctx context.Context, submissions []rewardscoordinator.RewardsSubmission) (*coretypes.ResultTx, error) {
-	msg := rewardscoordinator.ExecuteMsg{
-		CreateRewardsForAllSubmission: &rewardscoordinator.CreateRewardsForAllSubmission{
-			RewardsSubmissions: submissions,
-		},
-	}
-
-	return r.execute(ctx, msg)
-}
-
 func (r *RewardsCoordinator) ProcessClaim(ctx context.Context, claim rewardscoordinator.ProcessClaimClaim, recipient string) (*coretypes.ResultTx, error) {
 	msg := rewardscoordinator.ExecuteMsg{
 		ProcessClaim: &rewardscoordinator.ProcessClaim{
@@ -173,17 +163,6 @@ func (r *RewardsCoordinator) SetRouting(ctx context.Context, strategyManager str
 	msg := rewardscoordinator.ExecuteMsg{
 		SetRouting: &rewardscoordinator.SetRouting{
 			StrategyManager: strategyManager,
-		},
-	}
-
-	return r.execute(ctx, msg)
-}
-
-func (r *RewardsCoordinator) SetRewardsForAllSubmitter(ctx context.Context, submitter string, newValue bool) (*coretypes.ResultTx, error) {
-	msg := rewardscoordinator.ExecuteMsg{
-		SetRewardsForAllSubmitter: &rewardscoordinator.SetRewardsForAllSubmitter{
-			Submitter: submitter,
-			NewValue:  newValue,
 		},
 	}
 

--- a/modules/bvs-api/tests/e2e/rewards_coordinator_test.go
+++ b/modules/bvs-api/tests/e2e/rewards_coordinator_test.go
@@ -179,12 +179,7 @@ func (suite *rewardsTestSuite) Test_ExecuteRewardsCoordinator() {
 	assert.NotNil(t, resp, "response nil")
 	t.Logf("resp:%+v", resp)
 
-	resp, err = rewardsCoordinator.SetRewardsForAllSubmitter(context.Background(), suite.caller, true)
-	assert.NoError(t, err, "execute contract")
-	assert.NotNil(t, resp, "response nil")
-	t.Logf("resp:%+v", resp)
-
-	resp, err = rewardsCoordinator.CreateRewardsForAllSubmission(
+	resp, err = rewardsCoordinator.CreateRewardsSubmission(
 		context.Background(),
 		[]rewardscoordinator.RewardsSubmission{{
 			StrategiesAndMultipliers: []rewardscoordinator.StrategyAndMultiplier{{

--- a/modules/bvs-cli/cmd/reward.go
+++ b/modules/bvs-cli/cmd/reward.go
@@ -47,14 +47,6 @@ func rewardCmd() *cobra.Command {
 			reward.SetGlobalOperatorCommission(args[0], newCommissionBips)
 		},
 	}
-	setRewardsUpdaterCmd := &cobra.Command{
-		Use:   "set-rewards-updater <userKeyName> <RewardsUpdaterAddress>",
-		Short: "To set the rewards updater.",
-		Args:  cobra.ExactArgs(2),
-		Run: func(cmd *cobra.Command, args []string) {
-			reward.SetRewardUpdater(args[0], args[1])
-		},
-	}
 	transferOwnerCmd := &cobra.Command{
 		Use:   "transfer-owner <userKeyName> <NewOwnerAddress>",
 		Short: "To transfer the ownership.",
@@ -108,7 +100,6 @@ func rewardCmd() *cobra.Command {
 	subCmd.AddCommand(setClaimerCmd)
 	subCmd.AddCommand(setActivationDelayCmd)
 	subCmd.AddCommand(setGlobalOperatorCommissionCmd)
-	subCmd.AddCommand(setRewardsUpdaterCmd)
 	subCmd.AddCommand(transferOwnerCmd)
 	subCmd.AddCommand(getDistributionRootLengthCmd)
 	subCmd.AddCommand(getCurrentDistributionRootCmd)

--- a/modules/bvs-cli/commands/reward/exec.go
+++ b/modules/bvs-cli/commands/reward/exec.go
@@ -51,16 +51,6 @@ func SetGlobalOperatorCommission(userKeyName string, newCommissionBips int64) {
 	fmt.Printf("Set global operator commission success. txn: %s\n", resp.Hash.String())
 }
 
-func SetRewardUpdater(userKeyName, rewardUpdater string) {
-	ctx := context.Background()
-	reward, _ := newService(userKeyName)
-	resp, err := reward.SetRewardsUpdater(ctx, rewardUpdater)
-	if err != nil {
-		panic(err)
-	}
-	fmt.Printf("Set reward updater success. txn: %s\n", resp.Hash.String())
-}
-
 func TransferOwner(userKeyName, newOwner string) {
 	ctx := context.Background()
 	reward, _ := newService(userKeyName)

--- a/modules/bvs-cw/rewards-coordinator/schema.go
+++ b/modules/bvs-cw/rewards-coordinator/schema.go
@@ -147,21 +147,19 @@ type InstantiateMsg struct {
 }
 
 type ExecuteMsg struct {
-	CreateRewardsSubmission       *CreateRewardsSubmission       `json:"create_rewards_submission,omitempty"`
-	CreateRewardsForAllSubmission *CreateRewardsForAllSubmission `json:"create_rewards_for_all_submission,omitempty"`
-	ProcessClaim                  *ProcessClaim                  `json:"process_claim,omitempty"`
-	SubmitRoot                    *SubmitRoot                    `json:"submit_root,omitempty"`
-	DisableRoot                   *DisableRoot                   `json:"disable_root,omitempty"`
-	SetClaimerFor                 *SetClaimerFor                 `json:"set_claimer_for,omitempty"`
-	SetActivationDelay            *SetActivationDelay            `json:"set_activation_delay,omitempty"`
-	SetRewardsForAllSubmitter     *SetRewardsForAllSubmitter     `json:"set_rewards_for_all_submitter,omitempty"`
-	SetGlobalOperatorCommission   *SetGlobalOperatorCommission   `json:"set_global_operator_commission,omitempty"`
-	TransferOwnership             *TransferOwnership             `json:"transfer_ownership,omitempty"`
-	SetRewardsUpdater             *SetRewardsUpdater             `json:"set_rewards_updater,omitempty"`
-	SetRouting                    *SetRouting                    `json:"set_routing,omitempty"`
+	CreateRewardsSubmission     *CreateRewardsSubmission     `json:"create_rewards_submission,omitempty"`
+	ProcessClaim                *ProcessClaim                `json:"process_claim,omitempty"`
+	SubmitRoot                  *SubmitRoot                  `json:"submit_root,omitempty"`
+	DisableRoot                 *DisableRoot                 `json:"disable_root,omitempty"`
+	SetClaimerFor               *SetClaimerFor               `json:"set_claimer_for,omitempty"`
+	SetActivationDelay          *SetActivationDelay          `json:"set_activation_delay,omitempty"`
+	SetGlobalOperatorCommission *SetGlobalOperatorCommission `json:"set_global_operator_commission,omitempty"`
+	TransferOwnership           *TransferOwnership           `json:"transfer_ownership,omitempty"`
+	SetRewardsUpdater           *SetRewardsUpdater           `json:"set_rewards_updater,omitempty"`
+	SetRouting                  *SetRouting                  `json:"set_routing,omitempty"`
 }
 
-type CreateRewardsForAllSubmission struct {
+type CreateRewardsSubmission struct {
 	RewardsSubmissions []RewardsSubmission `json:"rewards_submissions"`
 }
 
@@ -182,10 +180,6 @@ type StrategyAndMultiplier struct {
 	Multiplier int64 `json:"multiplier"`
 	// strategy contract address
 	Strategy string `json:"strategy"`
-}
-
-type CreateRewardsSubmission struct {
-	RewardsSubmissions []RewardsSubmission `json:"rewards_submissions"`
 }
 
 type DisableRoot struct {
@@ -227,11 +221,6 @@ type SetClaimerFor struct {
 
 type SetGlobalOperatorCommission struct {
 	NewCommissionBips int64 `json:"new_commission_bips"`
-}
-
-type SetRewardsForAllSubmitter struct {
-	NewValue  bool   `json:"new_value"`
-	Submitter string `json:"submitter"`
 }
 
 type SetRewardsUpdater struct {


### PR DESCRIPTION
#### What this PR does / why we need it:

Remove `REWARDS_FOR_ALL_SUBMITTER` role and `create_rewards_for_all_submission` as its redundant for now.

Closes SL-287