### PR TITLE
chore(ops): add release.yml for building and releasing of schema and wasm code

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+  release:
+    types: [released]
+
+permissions:
+  id-token: write
+  packages: write
+  contents: read
+
+jobs:
+  version:
+    name: Version
+    runs-on: ubuntu-latest
+    outputs:
+      npm: ${{ steps.version.outputs.npm }}
+      npm_tag: ${{ steps.version.outputs.npm_tag }}
+      crate: ${{ steps.version.outputs.crate }}
+    steps:
+      - id: version
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            VERSION=${{ github.event.release.tag_name }}
+            echo "crate=${VERSION#v}" >> $GITHUB_OUTPUT
+            echo "npm=${VERSION}" >> $GITHUB_OUTPUT
+            echo "npm_tag=latest" >> $GITHUB_OUTPUT
+          else
+            # Use calendar versioning for the main branch
+            VERSION=$(date "+%Y.%m.%d-${{ github.run_number }}")
+            echo "crate=0.0.0" >> $GITHUB_OUTPUT
+            echo "npm=${VERSION}" >> $GITHUB_OUTPUT
+            echo "npm_tag=main" >> $GITHUB_OUTPUT
+          fi
+
+  npm_gh:
+    name: NPM [GitHub Packages]
+    runs-on: ubuntu-latest
+    needs:
+      - version
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+
+      - run: |
+          sed -i "s/version = \"0\.0\.0\"/version = \"${{ needs.version.outputs.crate }}\"/" Cargo.toml
+        working-directory: crates
+      - run: pnpm --filter "@satlayer/*" exec npm version ${{ needs.version.outputs.npm }} --git-tag-version=false
+
+      - run: pnpm turbo run build:wasm generate:schema --filter "@satlayer/*"
+
+      - run: |
+          pnpm config set "@satlayer:registry" "https://npm.pkg.github.com" --location=project
+          pnpm config set "//npm.pkg.github.com/:_authToken" "${NODE_AUTH_TOKEN}" --location=project
+        env:
+          NODE_AUTH_TOKEN: ${{ github.token }}
+      - run: pnpm publish --access public --tag ${{ needs.version.outputs.npm_tag }} --no-git-checks --filter "@satlayer/*"

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -194,7 +194,7 @@ checksum = "3e31ea183f6ee62ac8b8a8cf7feddd766317adfb13ff469de57ce033efd6a790"
 
 [[package]]
 name = "bvs-delegation-manager"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "bvs-library",
  "bvs-pauser",
@@ -213,7 +213,7 @@ dependencies = [
 
 [[package]]
 name = "bvs-directory"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "bvs-delegation-manager",
  "bvs-library",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "bvs-library"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "base64",
  "bech32 0.8.1",
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "bvs-pauser"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "bvs-library",
  "cosmwasm-schema",
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "bvs-registry"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "bvs-library",
  "bvs-pauser",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "bvs-rewards-coordinator"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "bvs-library",
  "bvs-pauser",
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "bvs-slash-manager"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "base64",
  "bech32 0.8.1",
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "bvs-strategy-base"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "bvs-library",
  "bvs-pauser",
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "bvs-strategy-manager"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "bvs-delegation-manager",
  "bvs-library",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "bvs-vault-bank"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "bvs-library",
  "bvs-pauser",
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "bvs-vault-base"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "bvs-library",
  "bvs-pauser",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "bvs-vault-cw20"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "bvs-library",
  "bvs-pauser",
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "bvs-vault-router"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "bvs-library",
  "bvs-pauser",

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -22,7 +22,8 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+# Version is managed by `.github/workflows/release.yml`
+version = "0.0.0"
 authors = ["SatLayer"]
 edition = "2021"
 license = "UNLICENSED"

--- a/crates/bvs-delegation-manager/package.json
+++ b/crates/bvs-delegation-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@satlayer/bvs-delegation-manager",
-  "private": false,
+  "private": true,
   "files": [
     "artifacts",
     "schema"

--- a/crates/bvs-directory/package.json
+++ b/crates/bvs-directory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@satlayer/bvs-directory",
-  "private": false,
+  "private": true,
   "files": [
     "artifacts",
     "schema"

--- a/crates/bvs-library/package.json
+++ b/crates/bvs-library/package.json
@@ -1,4 +1,0 @@
-{
-  "name": "@satlayer/bvs-library",
-  "private": false
-}

--- a/crates/bvs-rewards-coordinator/package.json
+++ b/crates/bvs-rewards-coordinator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@satlayer/bvs-rewards-coordinator",
-  "private": false,
+  "private": true,
   "files": [
     "artifacts",
     "schema"

--- a/crates/bvs-slash-manager/package.json
+++ b/crates/bvs-slash-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@satlayer/bvs-slash-manager",
-  "private": false,
+  "private": true,
   "files": [
     "artifacts",
     "schema"

--- a/crates/bvs-strategy-base/package.json
+++ b/crates/bvs-strategy-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@satlayer/bvs-strategy-base",
-  "private": false,
+  "private": true,
   "files": [
     "artifacts",
     "schema"

--- a/crates/bvs-strategy-manager/package.json
+++ b/crates/bvs-strategy-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@satlayer/bvs-strategy-manager",
-  "private": false,
+  "private": true,
   "files": [
     "artifacts",
     "schema"

--- a/crates/bvs-vault-base/package.json
+++ b/crates/bvs-vault-base/package.json
@@ -1,4 +1,0 @@
-{
-  "name": "@satlayer/bvs-vault-base",
-  "private": false
-}

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@docs/root",
+  "private": true,
   "scripts": {
     "build": "next build",
     "dev": "next",

--- a/examples/squaring/squaring-contract/package.json
+++ b/examples/squaring/squaring-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/squaring-contract",
-  "private": false,
+  "private": true,
   "files": [
     "artifacts",
     "schema"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,6 @@ importers:
 
   crates/bvs-directory: {}
 
-  crates/bvs-library: {}
-
   crates/bvs-pauser: {}
 
   crates/bvs-registry: {}
@@ -63,8 +61,6 @@ importers:
   crates/bvs-strategy-manager: {}
 
   crates/bvs-vault-bank: {}
-
-  crates/bvs-vault-base: {}
 
   crates/bvs-vault-cw20: {}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Private `packages` that we're not releasing.
Release on `push: branches: [main]` and `release: types: [released]`.
For main releases, we will use calver (`yyyy.mm.dd-build`), for production releases we will use semver.

Closes SL-55, SL-44
