### PR TITLE
chore: clean up cosmwasm crates dependencies

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,7 +1,7 @@
 name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
 categories:
-  - title: "CosmWasm Contracts"
+  - title: "CosmWasm"
     labels: ["a/crates"]
 
   - title: "@modules/babylond"

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -33,7 +33,7 @@ documentation = "https://github.com/satlayer/satlayer-bvs.git"
 keywords = ["SatLayer", "Restaking", "BTC", "cosmos", "cosmwasm"]
 
 [workspace.dependencies]
-# CosmWasm Core
+# CW Core
 cosmwasm-schema = "2.2.2"
 cosmwasm-std = { version = "2.2.2", features = [
   # https://github.com/babylonlabs-io/babylon/blob/d065cdd9d7f1219fece38cb678d1233566cf530b/app/keepers/keepers.go#L101
@@ -42,23 +42,16 @@ cosmwasm-std = { version = "2.2.2", features = [
 cosmwasm-crypto = "2.2.2"
 cw-multi-test = { version = "2.3.2", features = ["cosmwasm_2_0"] }
 cw-storage-plus = "2.0.0"
-cw2 = "2.0.0"
 schemars = "0.8.22"
 serde = { version = "1.0.219", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.58" }
-
-# CosmWasm Utilties
 sha2 = { version = "0.10.8", default-features = false }
-hex = "0.4"
-secp256k1 = "0.29.1"
+
+# CW Standards & Utility
+cw2 = "2.0.0"
 cw20 = "2.0.0"
 cw20-base = "2.0.0"
-bech32 = "0.8.0"
-ripemd = "0.1.0"
-serde_json = "1.0.139"
-base64 = "0.22.1"
 cw-utils = "2.0.0"
-rs_merkle = "=1.4"
 
 # CosmWasm Libraries & Contracts
 bvs-library = { path = "./bvs-library" }

--- a/crates/bvs-library/Cargo.toml
+++ b/crates/bvs-library/Cargo.toml
@@ -22,14 +22,14 @@ cosmwasm-std = { workspace = true }
 cosmwasm-crypto = { workspace = true }
 cw-storage-plus = { workspace = true }
 thiserror = { workspace = true }
-sha2 = { workspace = true }
-secp256k1 = { workspace = true }
-bech32 = { workspace = true }
-ripemd = { workspace = true }
-base64 = { workspace = true }
 serde = { workspace = true }
 
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies]
 cw-multi-test = { workspace = true }
 cw20-base = { workspace = true }
 cw20 = { workspace = true }
+secp256k1 = "0.29.1"
+sha2 = { version = "0.10.8", default-features = false }
+bech32 = "0.8.0"
+ripemd = "0.1.0"
+base64 = "0.22.1"

--- a/crates/bvs-rewards-coordinator/Cargo.toml
+++ b/crates/bvs-rewards-coordinator/Cargo.toml
@@ -27,8 +27,9 @@ thiserror = { workspace = true }
 serde = { workspace = true }
 schemars = { workspace = true }
 sha2 = { workspace = true }
-serde_json = { workspace = true }
-rs_merkle = { workspace = true }
+
+rs_merkle = "=1.4"
+serde_json = "1.0.139"
 
 bvs-library = { workspace = true }
 bvs-pauser = { workspace = true }

--- a/crates/bvs-slash-manager/Cargo.toml
+++ b/crates/bvs-slash-manager/Cargo.toml
@@ -27,12 +27,13 @@ thiserror = { workspace = true }
 serde = { workspace = true }
 schemars = { workspace = true }
 sha2 = { workspace = true }
-hex = { workspace = true }
-secp256k1 = { workspace = true }
-bech32 = { workspace = true }
-ripemd = { workspace = true }
-base64 = { workspace = true }
-serde_json = { workspace = true }
+
+serde_json = "1.0.139"
+secp256k1 = "0.29.1"
+hex = "0.4"
+bech32 = "0.8.0"
+ripemd = "0.1.0"
+base64 = "0.22.1"
 
 bvs-library = { workspace = true }
 bvs-pauser = { workspace = true }


### PR DESCRIPTION
#### What this PR does / why we need it:

We should only be using `wasm` pure dependencies or CW-related dependencies. 
I'm moving dependencies that should not be part of the workspace to their individual crates.

> Once we remove them, we can remove `RUN apk update && apk add clang && apk add binaryen` in our Dockerfile.