### PR TITLE
chore: vault_factory improvements

### DIFF
--- a/crates/bvs-vault-factory/src/auth.rs
+++ b/crates/bvs-vault-factory/src/auth.rs
@@ -10,11 +10,11 @@ pub fn assert_operator(deps: Deps, info: &MessageInfo) -> Result<(), ContractErr
         msg: to_json_binary(&msg)?,
     };
 
-    let is_operator: bvs_registry::msg::IsOperatorResponse =
+    let bvs_registry::msg::IsOperatorResponse(is_operator) =
         deps.querier.query(&QueryRequest::Wasm(query))?;
 
-    if !is_operator.0 {
-        Err(crate::error::ContractError::Unauthorized {})
+    if !is_operator {
+        Err(ContractError::Unauthorized {})
     } else {
         Ok(())
     }

--- a/crates/bvs-vault-factory/src/error.rs
+++ b/crates/bvs-vault-factory/src/error.rs
@@ -18,6 +18,6 @@ pub enum ContractError {
     #[error("Unauthorized")]
     Unauthorized {},
 
-    #[error("Code Id Not Found")]
+    #[error("Code id not found")]
     CodeIdNotFound {},
 }

--- a/crates/bvs-vault-factory/src/lib.rs
+++ b/crates/bvs-vault-factory/src/lib.rs
@@ -1,8 +1,9 @@
 pub mod contract;
-pub mod error;
 pub mod msg;
-pub mod state;
+pub mod testing;
 
 mod auth;
+mod error;
+mod state;
 
-pub mod testing;
+pub use crate::error::ContractError;

--- a/crates/bvs-vault-factory/src/msg.rs
+++ b/crates/bvs-vault-factory/src/msg.rs
@@ -1,8 +1,6 @@
 use bvs_pauser::api::Display;
 use cosmwasm_schema::{cw_serde, QueryResponses};
 
-use crate::state::VaultType;
-
 #[cw_serde]
 pub struct InstantiateMsg {
     pub owner: String,
@@ -36,13 +34,21 @@ pub enum ExecuteMsg {
 }
 
 #[cw_serde]
-#[derive(QueryResponses)]
-pub enum QueryMsg {
-    #[returns(VaultCodeIdsResponse)]
-    VaultCodeIds {},
+#[derive(Display)]
+pub enum VaultType {
+    Bank,
+    Cw20,
 }
 
 #[cw_serde]
-pub struct VaultCodeIdsResponse {
-    pub code_ids: std::collections::BTreeMap<String, u64>,
+#[derive(QueryResponses)]
+pub enum QueryMsg {
+    #[returns(CodeIdResponse)]
+    CodeId { vault_type: VaultType },
 }
+
+/// The response to the `CodeId` query.
+/// Not exported.
+/// This is just a wrapper around `u64`, so that the schema can be generated.
+#[cw_serde]
+struct CodeIdResponse(u64);

--- a/crates/bvs-vault-factory/src/state.rs
+++ b/crates/bvs-vault-factory/src/state.rs
@@ -1,60 +1,80 @@
-use std::fmt;
-
-use cosmwasm_schema::cw_serde;
-use cosmwasm_std::Addr;
-use cw_storage_plus::{Item, Key, KeyDeserialize, Map, PrimaryKey};
+use crate::msg::VaultType;
+use crate::ContractError;
+use cosmwasm_std::{Addr, StdError, StdResult, Storage};
+use cw_storage_plus::{Item, Map};
 
 pub const ROUTER: Item<Addr> = Item::new("router");
 pub const REGISTRY: Item<Addr> = Item::new("registry");
 
-/// Contains the code_ids of the contracts that are allowed to be deployed by the factory
-/// Permissioned by owner address of factory contract.
-/// When operator trigger a deployment of contract, factory contract need to know the code_id of the
-/// contract.
-/// Which code_id is allowed in the system is determined by the factory contract
-pub const CODE_IDS: Map<&VaultType, u64> = Map::new("code_ids");
+/// Contains the code_ids of the contracts that are allowed to be deployed by the factory.
+/// > Permissioned by owner address of factory contract.
+/// When an operator triggers a deployment of a contract,
+/// the factory contract needs to know the code_id of the contract.
+const CODE_IDS: Map<&u8, u64> = Map::new("code_ids");
 
-#[cw_serde]
-#[derive(PartialOrd, Eq, Ord)]
-pub enum VaultType {
-    Cw20Vault,
-    BankVault,
+pub fn get_code_id(store: &dyn Storage, vault_type: &VaultType) -> Result<u64, ContractError> {
+    CODE_IDS
+        .load(store, &vault_type.into())
+        .map_err(|_| ContractError::CodeIdNotFound {})
 }
 
-impl KeyDeserialize for &VaultType {
-    type Output = Self;
-    const KEY_ELEMS: u16 = 1;
+pub fn set_code_id(
+    store: &mut dyn Storage,
+    vault_type: &VaultType,
+    code_id: &u64,
+) -> StdResult<()> {
+    CODE_IDS.save(store, &vault_type.into(), code_id)
+}
 
-    fn from_vec(value: Vec<u8>) -> cosmwasm_std::StdResult<Self::Output> {
-        let trimmed: Vec<u8> = value.into_iter().take_while(|&b| b != 0).collect();
-        match std::str::from_utf8(&trimmed) {
-            Ok("Cw20Vault") => Ok(&VaultType::Cw20Vault),
-            Ok("BankVault") => Ok(&VaultType::BankVault),
-            _ => Err(cosmwasm_std::StdError::generic_err("Invalid VaultType")),
+impl From<&VaultType> for u8 {
+    fn from(value: &VaultType) -> u8 {
+        match value {
+            VaultType::Bank => 1,
+            VaultType::Cw20 => 2,
         }
     }
 }
 
-impl PrimaryKey<'_> for VaultType {
-    type Prefix = ();
-    type SubPrefix = ();
-    type Suffix = ();
-    type SuperSuffix = ();
+impl TryFrom<u8> for VaultType {
+    type Error = StdError;
 
-    fn key(&self) -> Vec<Key> {
-        let s = self.to_string();
-        let bytes = s.as_bytes();
-        let mut buffer = [0u8; 16];
-        buffer[..bytes.len().min(16)].copy_from_slice(bytes);
-        vec![Key::Val128(buffer)]
+    fn try_from(value: u8) -> Result<Self, StdError> {
+        match value {
+            1 => Ok(VaultType::Bank),
+            2 => Ok(VaultType::Cw20),
+            _ => Err(StdError::generic_err("VaultType out of range")),
+        }
     }
 }
 
-impl fmt::Display for VaultType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            VaultType::Cw20Vault => write!(f, "Cw20Vault"),
-            VaultType::BankVault => write!(f, "BankVault"),
-        }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cosmwasm_std::testing::MockStorage;
+
+    #[test]
+    fn code_id() {
+        let code_id: u8 = (&VaultType::Bank).into();
+        assert_eq!(code_id, 1);
+
+        let code_id: u8 = (&VaultType::Cw20).into();
+        assert_eq!(code_id, 2);
+    }
+
+    #[test]
+    fn set_get_test() {
+        let mut store = MockStorage::new();
+        let vault_type = VaultType::Bank;
+        let code_id = 1234;
+
+        set_code_id(&mut store, &vault_type, &code_id).unwrap();
+        let res = get_code_id(&store, &vault_type).unwrap();
+        assert_eq!(res, code_id);
+
+        let res = get_code_id(&store, &VaultType::Cw20);
+        assert!(res.is_err());
+
+        let res = get_code_id(&store, &VaultType::Bank).unwrap();
+        assert_eq!(res, code_id);
     }
 }


### PR DESCRIPTION
Remove custom `PrimaryKey` serializer. 
The previous implementation only stores up to `[u;16]`, that doesn't work for long run.
The code, prone to error, this is easier to manage.

Also fixed a bunch of others issues.