### PR TITLE
fix: flaky tests due to GetTx returning error

### DIFF
--- a/modules/cosmwasm-api/client_test.go
+++ b/modules/cosmwasm-api/client_test.go
@@ -118,14 +118,14 @@ func (s *ClientTestSuite) TestExecute() {
 	s.Equal(pauser.IsPausedResponse(1), isPausedResponse)
 }
 
-func (s *ClientTestSuite) TestGetTx() {
+func (s *ClientTestSuite) TestWaitForTx() {
 	receiver := s.container.GenerateAddress("receiver")
 
 	// create a TX by sending some ubbn to the receiver
 	tx := s.container.FundAddressUbbn(receiver.String(), 10000)
 
 	txHash := tx.Hash.String()
-	txRes, err := GetTx(
+	txRes, err := WaitForTx(
 		s.container.ClientCtx,
 		context.Background(),
 		txHash,


### PR DESCRIPTION
#### What this PR does / why we need it:

Updated test from `GetTx` to `WaitForTx`

<!-- remove if not applicable -->
