### PR TITLE
feat: bvs-slash-base, establish basic pipeline for slashing contracts within satlayer

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -266,6 +266,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "bvs-slash-base"
+version = "0.0.0"
+dependencies = [
+ "bvs-library",
+ "bvs-pauser",
+ "bvs-vault-router",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-multi-test",
+ "cw-storage-plus",
+ "cw2",
+ "schemars",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "bvs-slash-manager"
 version = "0.0.0"
 dependencies = [

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -281,6 +281,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bvs-slash-election"
+version = "0.0.0"
+dependencies = [
+ "bvs-library",
+ "bvs-pauser",
+ "bvs-registry",
+ "bvs-slash-base",
+ "bvs-vault-router",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-multi-test",
+ "cw-storage-plus",
+ "cw-utils",
+ "cw2",
+ "schemars",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "bvs-slash-manager"
 version = "0.0.0"
 dependencies = [

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -269,9 +269,7 @@ dependencies = [
 name = "bvs-slash-base"
 version = "0.0.0"
 dependencies = [
- "bvs-library",
  "bvs-pauser",
- "bvs-vault-router",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "bvs-vault-bank",
   "bvs-vault-cw20",
   "bvs-vault-factory",
+  "bvs-slash-base",
 ]
 
 resolver = "2"
@@ -59,3 +60,10 @@ bvs-vault-base = { path = "./bvs-vault-base", features = ["library"] }
 bvs-vault-bank = { path = "./bvs-vault-bank", features = ["library"] }
 bvs-vault-cw20 = { path = "./bvs-vault-cw20", features = ["library"] }
 bvs-vault-factory = { path = "./bvs-vault-factory", features = ["library"] }
+bvs-slash-base = { path = "./bvs-slash-base", features = ["library"] }
+
+bvs-delegation-manager = { path = "./bvs-delegation-manager", features = ["library"] }
+bvs-directory = { path = "./bvs-directory", features = ["library"] }
+bvs-slash-manager = { path = "./bvs-slash-manager", features = ["library"] }
+bvs-strategy-base = { path = "./bvs-strategy-base", features = ["library"] }
+bvs-strategy-manager = { path = "./bvs-strategy-manager", features = ["library"] }

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -14,6 +14,7 @@ members = [
   "bvs-vault-cw20",
   "bvs-vault-factory",
   "bvs-slash-base",
+  "bvs-slash-election",
 ]
 
 resolver = "2"

--- a/crates/bvs-slash-base/Cargo.toml
+++ b/crates/bvs-slash-base/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "bvs-slash-base"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+keywords.workspace = true
+
+include = ["src"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+library = []
+
+[dependencies]
+cosmwasm-std = { workspace = true }
+cosmwasm-schema = { workspace = true }
+cw-storage-plus = { workspace = true }
+cw2 = { workspace = true }
+thiserror = { workspace = true }
+serde = { workspace = true }
+schemars = { workspace = true }
+
+bvs-library = { workspace = true }
+bvs-pauser = { workspace = true }
+bvs-vault-router = { workspace = true }
+
+[target."cfg(not(target_arch = \"wasm32\"))".dependencies]
+cw-multi-test = { workspace = true }

--- a/crates/bvs-slash-base/Cargo.toml
+++ b/crates/bvs-slash-base/Cargo.toml
@@ -26,9 +26,7 @@ thiserror = { workspace = true }
 serde = { workspace = true }
 schemars = { workspace = true }
 
-bvs-library = { workspace = true }
 bvs-pauser = { workspace = true }
-bvs-vault-router = { workspace = true }
 
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies]
 cw-multi-test = { workspace = true }

--- a/crates/bvs-slash-base/src/error.rs
+++ b/crates/bvs-slash-base/src/error.rs
@@ -1,0 +1,20 @@
+use cosmwasm_std::StdError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum SlasherError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+
+    #[error("Unauthorized: {msg}")]
+    Unauthorized { msg: String },
+
+    #[error("Invalid Offender: {msg}")]
+    InvalidOffender { msg: String },
+}
+
+impl SlasherError {
+    pub fn unauthorized(msg: impl Into<String>) -> Self {
+        SlasherError::Unauthorized { msg: msg.into() }
+    }
+}

--- a/crates/bvs-slash-base/src/lib.rs
+++ b/crates/bvs-slash-base/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod error;
+pub mod msg;
+pub mod router;

--- a/crates/bvs-slash-base/src/msg.rs
+++ b/crates/bvs-slash-base/src/msg.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Addr, Api, Uint128};
+use cosmwasm_std::{Addr, Uint128};
 
 /// Slash `ExecuteMsg`, to be implemented by the Slash strategy specific contract.
 #[cw_serde]

--- a/crates/bvs-slash-base/src/msg.rs
+++ b/crates/bvs-slash-base/src/msg.rs
@@ -20,7 +20,11 @@ pub enum SlasherExecuteMsg<Offense, Evidence, SlashDetail> {
 
 #[cw_serde]
 pub struct SubmitSlash<Offense, Evidence> {
+    /// The operator who is being accused of misbehaviour
     pub offender: String,
+
+    /// A generic type for downstream slashing strategy contract should define
+    /// allowing them to have custom slashing strategy
     pub offense: Offense,
     pub evidence: Evidence,
 }

--- a/crates/bvs-slash-base/src/msg.rs
+++ b/crates/bvs-slash-base/src/msg.rs
@@ -24,7 +24,7 @@ pub enum SlasherExecuteMsg<Offense, Evidence, SlashDetail> {
 
 #[cw_serde]
 #[derive(QueryResponses)]
-pub enum SlashQueryMsg {
+pub enum SlasherQueryMsg {
     /// QueryMsg VaultInfo: get the vault information.
     #[returns(SlasherInfoResponse)]
     SlasherInfo {},
@@ -50,3 +50,4 @@ pub struct SlasherInfoResponse {
     /// The version of the vault contract, see [`cw2::set_contract_version`] for more information.
     pub version: String,
 }
+

--- a/crates/bvs-slash-base/src/msg.rs
+++ b/crates/bvs-slash-base/src/msg.rs
@@ -1,0 +1,47 @@
+use cosmwasm_schema::{cw_serde, QueryResponses};
+use cosmwasm_std::{Addr, Api, Uint128};
+
+/// Slash `ExecuteMsg`, to be implemented by the Slash strategy specific contract.
+#[cw_serde]
+#[derive(bvs_pauser::api::Display)]
+pub enum SlasherExecuteMsg {
+    /// SubmitOffense: submit an offense to the slash strategy contract.
+    /// offender: the address of the operator.
+    /// offense: the offense committed.
+    SubmitSlash { offender: String, offense: String },
+
+    /// ExecuteSlash: trigger the slash on slash strategy contract to execute the slash.
+    /// Exacatly how the slash is executed is up to the slash strategy contract.
+    /// How the slash entries will be hash is also up to the slash strategy contract.
+    /// slash_hash: the hash of the slash.
+    ExecuteSlash { slash_hash: String },
+}
+
+#[cw_serde]
+#[derive(QueryResponses)]
+pub enum SlashQueryMsg {
+    /// QueryMsg VaultInfo: get the vault information.
+    #[returns(SlasherInfoResponse)]
+    SlasherInfo {},
+}
+
+#[cw_serde]
+pub struct SlasherInfoResponse {
+    /// Queued slash entries
+    pub outstanding_slash: Uint128,
+
+    /// The `vault-router` contract address
+    pub router: Addr,
+
+    /// The `pauser` contract address
+    pub pauser: Addr,
+
+    /// The `vault` contract address where this slasher contract is managing slash for
+    pub vault: String,
+
+    /// The name of the vault contract, see [`cw2::set_contract_version`] for more information.
+    pub contract: String,
+
+    /// The version of the vault contract, see [`cw2::set_contract_version`] for more information.
+    pub version: String,
+}

--- a/crates/bvs-slash-base/src/msg.rs
+++ b/crates/bvs-slash-base/src/msg.rs
@@ -9,17 +9,25 @@ pub enum SlasherExecuteMsg<Offense, Evidence, SlashDetail> {
     /// offender: the address of the operator.
     /// offense: the offense committed. (Opaque to the slasher contract)
     /// evidence: the evidence of the offense. (Opaque to the slasher contract)
-    SubmitSlash {
-        offender: String,
-        offense: Offense,
-        evidence: Evidence,
-    },
+    SubmitSlash(SubmitSlash<Offense, Evidence>),
 
     /// ExecuteSlash: trigger the slash on slash strategy contract to execute the slash.
     /// Exacatly how the slash is executed is up to the slash strategy contract.
     /// How the slash entries will be hash is also up to the slash strategy contract.
     /// slash_detail: the hash of the slash.
-    ExecuteSlash { slash_detail: SlashDetail },
+    ExecuteSlash(ExecuteSlash<SlashDetail>),
+}
+
+#[cw_serde]
+pub struct SubmitSlash<Offense, Evidence> {
+    pub offender: String,
+    pub offense: Offense,
+    pub evidence: Evidence,
+}
+
+#[cw_serde]
+pub struct ExecuteSlash<SlashDetail> {
+    pub slash_detail: SlashDetail,
 }
 
 #[cw_serde]

--- a/crates/bvs-slash-base/src/msg.rs
+++ b/crates/bvs-slash-base/src/msg.rs
@@ -4,17 +4,22 @@ use cosmwasm_std::{Addr, Uint128};
 /// Slash `ExecuteMsg`, to be implemented by the Slash strategy specific contract.
 #[cw_serde]
 #[derive(bvs_pauser::api::Display)]
-pub enum SlasherExecuteMsg {
+pub enum SlasherExecuteMsg<Offense, Evidence, SlashDetail> {
     /// SubmitOffense: submit an offense to the slash strategy contract.
     /// offender: the address of the operator.
-    /// offense: the offense committed.
-    SubmitSlash { offender: String, offense: String },
+    /// offense: the offense committed. (Opaque to the slasher contract)
+    /// evidence: the evidence of the offense. (Opaque to the slasher contract)
+    SubmitSlash {
+        offender: String,
+        offense: Offense,
+        evidence: Evidence,
+    },
 
     /// ExecuteSlash: trigger the slash on slash strategy contract to execute the slash.
     /// Exacatly how the slash is executed is up to the slash strategy contract.
     /// How the slash entries will be hash is also up to the slash strategy contract.
-    /// slash_hash: the hash of the slash.
-    ExecuteSlash { slash_hash: String },
+    /// slash_detail: the hash of the slash.
+    ExecuteSlash { slash_detail: SlashDetail },
 }
 
 #[cw_serde]

--- a/crates/bvs-slash-base/src/msg.rs
+++ b/crates/bvs-slash-base/src/msg.rs
@@ -50,4 +50,3 @@ pub struct SlasherInfoResponse {
     /// The version of the vault contract, see [`cw2::set_contract_version`] for more information.
     pub version: String,
 }
-

--- a/crates/bvs-slash-base/src/router.rs
+++ b/crates/bvs-slash-base/src/router.rs
@@ -1,6 +1,5 @@
 use crate::error::SlasherError;
-use bvs_vault_router::msg::QueryMsg;
-use cosmwasm_std::{Addr, Deps, Env, MessageInfo, StdError, StdResult, Storage};
+use cosmwasm_std::{Addr, MessageInfo, StdError, StdResult, Storage};
 use cw_storage_plus::Item;
 
 const ROUTER: Item<Addr> = Item::new("router");
@@ -63,8 +62,7 @@ mod tests {
         router,
         router::{assert_router, set_router, ROUTER},
     };
-    use cosmwasm_std::testing::{message_info, mock_dependencies, mock_env};
-    use cosmwasm_std::{to_json_binary, ContractResult, SystemError, SystemResult, WasmQuery};
+    use cosmwasm_std::testing::{message_info, mock_dependencies};
 
     #[test]
     fn test_set_router() {

--- a/crates/bvs-slash-base/src/router.rs
+++ b/crates/bvs-slash-base/src/router.rs
@@ -3,7 +3,6 @@ use cosmwasm_std::{Addr, MessageInfo, StdError, StdResult, Storage};
 use cw_storage_plus::Item;
 
 const ROUTER: Item<Addr> = Item::new("router");
-const VAULT: Item<Addr> = Item::new("vault");
 
 /// Set the `vault-router` address, called once during `initialization`.
 /// The `router` is the address where the vault calls
@@ -29,28 +28,6 @@ pub fn assert_router(storage: &dyn Storage, info: &MessageInfo) -> Result<(), Sl
         .ok_or(SlasherError::unauthorized("no router set"))?;
     if info.sender != router {
         return Err(SlasherError::unauthorized("not router"));
-    }
-    Ok(())
-}
-
-/// Set the `vault` address, called once during `initialization`.
-pub fn set_vault(storage: &mut dyn Storage, vault: &Addr) -> StdResult<()> {
-    VAULT.save(storage, vault)?;
-    Ok(())
-}
-
-/// Get the `vault` address
-pub fn get_vault(storage: &dyn Storage) -> StdResult<Addr> {
-    VAULT.may_load(storage)?.ok_or(StdError::not_found("vault"))
-}
-
-/// Asserts that the sender is the `vault`
-pub fn assert_vault(storage: &dyn Storage, info: &MessageInfo) -> Result<(), SlasherError> {
-    let vault = VAULT
-        .may_load(storage)?
-        .ok_or(SlasherError::unauthorized("no vault set"))?;
-    if info.sender != vault {
-        return Err(SlasherError::unauthorized("not vault"));
     }
     Ok(())
 }

--- a/crates/bvs-slash-base/src/router.rs
+++ b/crates/bvs-slash-base/src/router.rs
@@ -1,0 +1,118 @@
+use crate::error::SlasherError;
+use bvs_vault_router::msg::QueryMsg;
+use cosmwasm_std::{Addr, Deps, Env, MessageInfo, StdError, StdResult, Storage};
+use cw_storage_plus::Item;
+
+const ROUTER: Item<Addr> = Item::new("router");
+const VAULT: Item<Addr> = Item::new("vault");
+
+/// Set the `vault-router` address, called once during `initialization`.
+/// The `router` is the address where the vault calls
+/// or receives calls from to perform slashing or delegation operations.
+pub fn set_router(storage: &mut dyn Storage, router: &Addr) -> StdResult<()> {
+    ROUTER.save(storage, router)?;
+    Ok(())
+}
+
+/// Get the `vault-router` address
+/// If [`instantiate`] has not been called, it will return an [StdError::NotFound]
+pub fn get_router(storage: &dyn Storage) -> StdResult<Addr> {
+    ROUTER
+        .may_load(storage)?
+        .ok_or(StdError::not_found("router"))
+}
+
+/// Asserts that the sender is the `vault-router`
+/// For delegation/slashing operations.
+pub fn assert_router(storage: &dyn Storage, info: &MessageInfo) -> Result<(), SlasherError> {
+    let router = ROUTER
+        .may_load(storage)?
+        .ok_or(SlasherError::unauthorized("no router set"))?;
+    if info.sender != router {
+        return Err(SlasherError::unauthorized("not router"));
+    }
+    Ok(())
+}
+
+/// Set the `vault` address, called once during `initialization`.
+pub fn set_vault(storage: &mut dyn Storage, vault: &Addr) -> StdResult<()> {
+    VAULT.save(storage, vault)?;
+    Ok(())
+}
+
+/// Get the `vault` address
+pub fn get_vault(storage: &dyn Storage) -> StdResult<Addr> {
+    VAULT.may_load(storage)?.ok_or(StdError::not_found("vault"))
+}
+
+/// Asserts that the sender is the `vault`
+pub fn assert_vault(storage: &dyn Storage, info: &MessageInfo) -> Result<(), SlasherError> {
+    let vault = VAULT
+        .may_load(storage)?
+        .ok_or(SlasherError::unauthorized("no vault set"))?;
+    if info.sender != vault {
+        return Err(SlasherError::unauthorized("not vault"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        error::SlasherError,
+        router,
+        router::{assert_router, set_router, ROUTER},
+    };
+    use cosmwasm_std::testing::{message_info, mock_dependencies, mock_env};
+    use cosmwasm_std::{to_json_binary, ContractResult, SystemError, SystemResult, WasmQuery};
+
+    #[test]
+    fn test_set_router() {
+        let mut deps = mock_dependencies();
+        let router = deps.api.addr_make("router/1");
+        set_router(deps.as_mut().storage, &router).unwrap();
+    }
+
+    #[test]
+    fn test_get_router() {
+        let mut deps = mock_dependencies();
+
+        let router = deps.api.addr_make("router/2");
+        ROUTER.save(deps.as_mut().storage, &router).unwrap();
+
+        let result = router::get_router(deps.as_mut().storage).unwrap();
+
+        assert_eq!(result, router);
+    }
+
+    #[test]
+    fn test_assert_router() {
+        let mut deps = mock_dependencies();
+
+        let router = deps.api.addr_make("router/3");
+        ROUTER.save(deps.as_mut().storage, &router).unwrap();
+
+        let info = message_info(&router, &[]);
+        assert_router(&deps.storage, &info).unwrap();
+    }
+
+    #[test]
+    fn test_assert_router_fail() {
+        let mut deps = mock_dependencies();
+
+        let router = deps.api.addr_make("router/4");
+        ROUTER.save(&mut deps.storage, &router).unwrap();
+
+        let not_router = deps.api.addr_make("router/not");
+        let sender_info = message_info(&not_router, &[]);
+        let error = assert_router(&deps.storage, &sender_info).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            SlasherError::Unauthorized {
+                msg: "not router".to_string()
+            }
+            .to_string()
+        );
+    }
+}

--- a/crates/bvs-slash-election/Cargo.toml
+++ b/crates/bvs-slash-election/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "bvs-slash-election"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+keywords.workspace = true
+
+include = ["src"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+library = []
+
+[dependencies]
+cosmwasm-std = { workspace = true }
+cosmwasm-schema = { workspace = true }
+cw-storage-plus = { workspace = true }
+cw2 = { workspace = true }
+thiserror = { workspace = true }
+serde = { workspace = true }
+schemars = { workspace = true }
+cw-utils = { workspace = true }
+
+bvs-library = { workspace = true }
+bvs-pauser = { workspace = true }
+bvs-vault-router = { workspace = true }
+bvs-slash-base = { workspace = true }
+bvs-registry = { workspace = true }
+
+[target."cfg(not(target_arch = \"wasm32\"))".dependencies]
+cw-multi-test = { workspace = true }

--- a/crates/bvs-slash-election/src/auth.rs
+++ b/crates/bvs-slash-election/src/auth.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{to_json_binary, Deps, MessageInfo, QueryRequest, WasmQuery};
+use cosmwasm_std::{to_json_binary, Deps, Env, MessageInfo, QueryRequest, WasmQuery};
 
 use crate::{error::ContractError, state::REGISTRY};
 
@@ -15,6 +15,16 @@ pub fn assert_operator(deps: Deps, info: &MessageInfo) -> Result<(), ContractErr
 
     if !is_operator {
         Err(ContractError::Unauthorized {})
+    } else {
+        Ok(())
+    }
+}
+
+pub fn assert_voting_period(env: Env, start_height: u64) -> Result<(), ContractError> {
+    let current_height = env.block.height;
+
+    if current_height > start_height + 100 {
+        Err(ContractError::VotingPeriodExpired {})
     } else {
         Ok(())
     }

--- a/crates/bvs-slash-election/src/auth.rs
+++ b/crates/bvs-slash-election/src/auth.rs
@@ -1,0 +1,21 @@
+use cosmwasm_std::{to_json_binary, Deps, MessageInfo, QueryRequest, WasmQuery};
+
+use crate::{error::ContractError, state::REGISTRY};
+
+pub fn assert_operator(deps: Deps, info: &MessageInfo) -> Result<(), ContractError> {
+    let msg = bvs_registry::msg::QueryMsg::IsOperator(info.sender.to_string());
+
+    let query = WasmQuery::Smart {
+        contract_addr: REGISTRY.load(deps.storage)?.to_string(),
+        msg: to_json_binary(&msg)?,
+    };
+
+    let bvs_registry::msg::IsOperatorResponse(is_operator) =
+        deps.querier.query(&QueryRequest::Wasm(query))?;
+
+    if !is_operator {
+        Err(ContractError::Unauthorized {})
+    } else {
+        Ok(())
+    }
+}

--- a/crates/bvs-slash-election/src/contract.rs
+++ b/crates/bvs-slash-election/src/contract.rs
@@ -1,0 +1,117 @@
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+
+use crate::{
+    error::ContractError,
+    msg::{ExecuteMsg, ExecuteSlashMsg, InstantiateMsg, QueryMsg},
+    state::{REGISTRY, THRESHOLD},
+};
+use bvs_library::ownership;
+use cosmwasm_std::{Deps, DepsMut, Env, MessageInfo, Response};
+
+const CONTRACT_NAME: &str = concat!("crates.io:", env!("CARGO_PKG_NAME"));
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    msg: InstantiateMsg,
+) -> Result<Response, ContractError> {
+    cw2::set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    let owner = deps.api.addr_validate(&msg.owner)?;
+    let pauser = deps.api.addr_validate(&msg.pauser)?;
+    let registry = deps.api.addr_validate(&msg.registry)?;
+
+    ownership::set_owner(deps.storage, &owner)?;
+
+    bvs_pauser::api::set_pauser(deps.storage, &pauser);
+
+    THRESHOLD.save(deps.storage, &msg.threshold)?;
+
+    REGISTRY.save(deps.storage, &registry)?;
+
+    Ok(Response::default())
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn execute(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
+    match msg {
+        ExecuteMsg::SubmitSlash(msg) => execute::submit_slash(deps, env, info, msg),
+        ExecuteMsg::VoteSlash(msg) => execute::vote_slash(deps, env, info, msg),
+        ExecuteMsg::ExecuteSlash(msg) => execute::execute_slash(deps, env, info, msg),
+        ExecuteMsg::SetPunishment(msg) => execute::set_punishment(deps, env, info, msg),
+        ExecuteMsg::SetThreshold(threshold) => execute::set_threshold(deps, env, info, threshold),
+    }
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(
+    deps: Deps,
+    _env: Env,
+    _info: MessageInfo,
+    msg: QueryMsg,
+) -> Result<Response, ContractError> {
+    Ok(Response::default())
+}
+
+mod execute {
+
+    use super::*;
+    use crate::msg::{SetPunishmentMsg, SubmitSlashMsg, VoteSlashMsg};
+
+    pub fn submit_slash(
+        deps: DepsMut,
+        env: Env,
+        info: MessageInfo,
+        msg: SubmitSlashMsg,
+    ) -> Result<Response, ContractError> {
+    }
+
+    pub fn vote_slash(
+        deps: DepsMut,
+        env: Env,
+        info: MessageInfo,
+        msg: VoteSlashMsg,
+    ) -> Result<Response, ContractError> {
+        Ok(Response::default())
+    }
+
+    pub fn execute_slash(
+        deps: DepsMut,
+        env: Env,
+        info: MessageInfo,
+        msg: ExecuteSlashMsg,
+    ) -> Result<Response, ContractError> {
+        todo!()
+    }
+
+    pub fn set_punishment(
+        deps: DepsMut,
+        env: Env,
+        info: MessageInfo,
+        msg: SetPunishmentMsg,
+    ) -> Result<Response, ContractError> {
+        Ok(Response::default())
+    }
+
+    pub fn set_threshold(
+        deps: DepsMut,
+        env: Env,
+        info: MessageInfo,
+        threshold: u64,
+    ) -> Result<Response, ContractError> {
+        ownership::assert_owner(deps.storage, &info)?;
+
+        Ok(Response::default())
+    }
+}
+
+mod query {}

--- a/crates/bvs-slash-election/src/error.rs
+++ b/crates/bvs-slash-election/src/error.rs
@@ -18,4 +18,7 @@ pub enum ContractError {
 
     #[error("Unauthorized")]
     Unauthorized {},
+
+    #[error("Voting period expired")]
+    VotingPeriodExpired {},
 }

--- a/crates/bvs-slash-election/src/error.rs
+++ b/crates/bvs-slash-election/src/error.rs
@@ -1,0 +1,21 @@
+use bvs_library::ownership;
+use cosmwasm_std::StdError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ContractError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+
+    #[error("{0}")]
+    Vault(#[from] bvs_slash_base::error::SlasherError),
+
+    #[error("{0}")]
+    Pauser(#[from] bvs_pauser::api::PauserError),
+
+    #[error("{0}")]
+    Ownership(#[from] ownership::OwnershipError),
+
+    #[error("Unauthorized")]
+    Unauthorized {},
+}

--- a/crates/bvs-slash-election/src/lib.rs
+++ b/crates/bvs-slash-election/src/lib.rs
@@ -1,0 +1,5 @@
+mod auth;
+mod contract;
+mod error;
+mod msg;
+mod state;

--- a/crates/bvs-slash-election/src/msg.rs
+++ b/crates/bvs-slash-election/src/msg.rs
@@ -7,7 +7,7 @@ use crate::state::Offense;
 
 pub struct SlashDetails {
     pub offender: String,
-    pub offense: Offense,
+    pub offense: String,
     pub start_height: u64,
 }
 
@@ -16,12 +16,12 @@ pub type SubmitSlashMsg = SubmitSlash<Offense, Option<String>>;
 pub type ExecuteSlashMsg = ExecuteSlash<SlashDetails>;
 
 pub struct VoteSlashMsg {
-    slash: SlashDetails,
-    approve: bool,
+    pub slash: SlashDetails,
+    pub approve: bool,
 }
 pub struct SetPunishmentMsg {
-    slash: SlashDetails,
-    approve: bool,
+    pub slash: SlashDetails,
+    pub approve: bool,
 }
 
 pub enum ExecuteMsg {

--- a/crates/bvs-slash-election/src/msg.rs
+++ b/crates/bvs-slash-election/src/msg.rs
@@ -1,0 +1,47 @@
+use bvs_slash_base::{
+    self,
+    msg::{ExecuteSlash, SubmitSlash},
+};
+
+use crate::state::Offense;
+
+pub struct SlashDetails {
+    pub offender: String,
+    pub offense: Offense,
+    pub start_height: u64,
+}
+
+pub type SubmitSlashMsg = SubmitSlash<Offense, Option<String>>;
+
+pub type ExecuteSlashMsg = ExecuteSlash<SlashDetails>;
+
+pub struct VoteSlashMsg {
+    slash: SlashDetails,
+    approve: bool,
+}
+pub struct SetPunishmentMsg {
+    slash: SlashDetails,
+    approve: bool,
+}
+
+pub enum ExecuteMsg {
+    SubmitSlash(SubmitSlashMsg),
+
+    VoteSlash(VoteSlashMsg),
+
+    ExecuteSlash(ExecuteSlashMsg),
+
+    SetPunishment(SetPunishmentMsg),
+
+    SetThreshold(u64),
+}
+
+pub enum QueryMsg {}
+
+pub struct InstantiateMsg {
+    pub pauser: String,
+    pub router: String,
+    pub registry: String,
+    pub owner: String,
+    pub threshold: u64,
+}

--- a/crates/bvs-slash-election/src/state.rs
+++ b/crates/bvs-slash-election/src/state.rs
@@ -1,27 +1,61 @@
-use cosmwasm_std::{Addr, Uint128};
+use std::error::Error;
+
+use cosmwasm_std::{Addr, StdError, Uint128};
 use cw_storage_plus::{Item, Map};
 
 type Operator = Addr;
 type Vaults = Vec<Addr>;
 type Offender = Operator;
+type Voter = Operator;
+type Vote = bool;
 
 /// This state contains the amount of slash per an offense type
 pub const PUNISHMENT: Map<Offense, Uint128> = Map::new("punishment");
 
 /// This state contains the slashing entry
-/// The key is composit, made of the accused operator's address, the offense type
-/// and the height of the block where the slash was requested
+/// The key is composite, made of the (accused operator's address, the offense type,
+/// and the height of the block where the slash was requested)
 /// The value is the total yes votes
-pub const SLASHES: Map<(Operator, Offense, u64), u64> = Map::new("slashes");
+pub const SLASHES: Map<(&Offender, &str, u64), u64> = Map::new("slashes");
+
+pub const SLASHES_VOTERS: Map<(&Offender, &str, u64), Vec<Voter>> = Map::new("slashes_voters");
 
 /// This state contains the minimum number of yes votes required for a slash to proceed
 pub const THRESHOLD: Item<u64> = Item::new("threshold");
 
 pub const REGISTRY: Item<Addr> = Item::new("registry");
 
-pub const VAULTS: Map<Operator, Vaults> = Map::new("vaults");
+pub const VOTE_PERIOD: Item<u64> = Item::new("vote_period");
 
+#[derive(Debug, PartialEq, Eq)]
 pub enum Offense {
     DoubleSign,
     MissingBlock,
+}
+
+impl Offense {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Offense::DoubleSign => "DoubleSign",
+            Offense::MissingBlock => "MissingBlock",
+        }
+    }
+}
+
+impl From<&Offense> for &str {
+    fn from(value: &Offense) -> Self {
+        value.as_str()
+    }
+}
+
+impl TryFrom<&str> for Offense {
+    type Error = StdError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "DoubleSign" => Ok(Offense::DoubleSign),
+            "MissingBlock" => Ok(Offense::MissingBlock),
+            _ => Err(StdError::generic_err("Unknown offense variant")),
+        }
+    }
 }

--- a/crates/bvs-slash-election/src/state.rs
+++ b/crates/bvs-slash-election/src/state.rs
@@ -1,0 +1,27 @@
+use cosmwasm_std::{Addr, Uint128};
+use cw_storage_plus::{Item, Map};
+
+type Operator = Addr;
+type Vaults = Vec<Addr>;
+type Offender = Operator;
+
+/// This state contains the amount of slash per an offense type
+pub const PUNISHMENT: Map<Offense, Uint128> = Map::new("punishment");
+
+/// This state contains the slashing entry
+/// The key is composit, made of the accused operator's address, the offense type
+/// and the height of the block where the slash was requested
+/// The value is the total yes votes
+pub const SLASHES: Map<(Operator, Offense, u64), u64> = Map::new("slashes");
+
+/// This state contains the minimum number of yes votes required for a slash to proceed
+pub const THRESHOLD: Item<u64> = Item::new("threshold");
+
+pub const REGISTRY: Item<Addr> = Item::new("registry");
+
+pub const VAULTS: Map<Operator, Vaults> = Map::new("vaults");
+
+pub enum Offense {
+    DoubleSign,
+    MissingBlock,
+}

--- a/crates/bvs-vault-router/Cargo.toml
+++ b/crates/bvs-vault-router/Cargo.toml
@@ -34,5 +34,5 @@ bvs-pauser = { workspace = true }
 cw-multi-test = { workspace = true }
 
 [dev-dependencies]
-bvs-vault-bank = { workspace = true }
 bvs-vault-cw20 = { workspace = true }
+bvs-vault-bank = { workspace = true }

--- a/crates/bvs-vault-router/src/contract.rs
+++ b/crates/bvs-vault-router/src/contract.rs
@@ -787,7 +787,7 @@ mod tests {
 
         // let's test pagination sync this time
         {
-            let mut response1 =
+            let response1 =
                 query::list_vaults_by_operator(deps.as_ref(), operator.clone(), 5, None).unwrap();
             assert_eq!(response1.0.len(), 5);
 

--- a/crates/bvs-vault-router/src/contract.rs
+++ b/crates/bvs-vault-router/src/contract.rs
@@ -371,7 +371,7 @@ mod tests {
     };
     use cosmwasm_std::{
         from_json, Attribute, ContractResult, Event, OwnedDeps, QuerierResult, SystemError,
-        SystemResult, Uint128, Uint64, WasmQuery,
+        SystemResult, Uint64, WasmQuery,
     };
 
     #[test]
@@ -487,15 +487,13 @@ mod tests {
                 .unwrap();
             assert!(!vault.whitelisted);
 
-            let exist = MAPPED_VAULTS
+            MAPPED_VAULTS
                 .may_load(
                     deps.as_ref().storage,
                     (&operator_addr, &vault_contract_addr),
                 )
                 .unwrap()
                 .unwrap();
-
-            assert_eq!(exist, ());
         }
 
         let vault = deps.api.addr_make("vault");

--- a/crates/bvs-vault-router/src/contract.rs
+++ b/crates/bvs-vault-router/src/contract.rs
@@ -365,7 +365,7 @@ mod tests {
         message_info, mock_dependencies, mock_env, MockApi, MockQuerier, MockStorage,
     };
     use cosmwasm_std::{
-        from_json, Addr, Attribute, ContractResult, Event, OwnedDeps, QuerierResult, SystemError,
+        from_json, Attribute, ContractResult, Event, OwnedDeps, QuerierResult, SystemError,
         SystemResult, Uint128, Uint64, WasmQuery,
     };
 

--- a/crates/bvs-vault-router/src/contract.rs
+++ b/crates/bvs-vault-router/src/contract.rs
@@ -336,7 +336,7 @@ mod query {
         );
 
         let vaults = items
-            .take(limit.try_into().unwrap())
+            .take(limit as usize)
             .map(|item| {
                 let (k, v) = item?;
                 Ok(Vault {

--- a/crates/bvs-vault-router/src/contract.rs
+++ b/crates/bvs-vault-router/src/contract.rs
@@ -208,7 +208,7 @@ pub mod vault {
         {
             Ok(response) => Ok(response),
             Err(_) => Err(ContractError::VaultError {
-                msg: format!("No such contract: {}", vault.to_string()).to_string(),
+                msg: format!("No such contract: {}", vault).to_string(),
             }),
         }
     }
@@ -487,7 +487,7 @@ mod tests {
                 .may_load(deps.as_ref().storage, &vault_contract_addr)
                 .unwrap()
                 .unwrap();
-            assert_eq!(vault.whitelisted, false);
+            assert!(!vault.whitelisted);
 
             let delegated_service = DELEGATED_SERVICES
                 .may_load(
@@ -497,7 +497,7 @@ mod tests {
                 .unwrap()
                 .unwrap();
 
-            assert_eq!(delegated_service, false);
+            assert!(!delegated_service);
         }
 
         let vault = deps.api.addr_make("vault");
@@ -528,7 +528,7 @@ mod tests {
                 .may_load(deps.as_ref().storage, &vault)
                 .unwrap()
                 .unwrap();
-            assert_eq!(vault.whitelisted, true);
+            assert!(vault.whitelisted);
         }
 
         // whitelist is true and failed to set: No such contract
@@ -546,7 +546,7 @@ mod tests {
             let err = result.unwrap_err();
             assert_eq!(
                 err.to_string(),
-                format!("Vault error: No such contract: {}", empty_vault.to_string())
+                format!("Vault error: No such contract: {}", empty_vault)
             );
         }
 

--- a/crates/bvs-vault-router/src/contract.rs
+++ b/crates/bvs-vault-router/src/contract.rs
@@ -784,6 +784,37 @@ mod tests {
         for i in 0..10 {
             assert_eq!(response.0[i].vault, vaults[i]);
         }
+
+        // let's test pagination sync this time
+        {
+            let mut response1 =
+                query::list_vaults_by_operator(deps.as_ref(), operator.clone(), 5, None).unwrap();
+            assert_eq!(response1.0.len(), 5);
+
+            let next_start_after = response1.0[4].vault.clone();
+
+            let response2 = query::list_vaults_by_operator(
+                deps.as_ref(),
+                operator.clone(),
+                5,
+                Some(next_start_after),
+            )
+            .unwrap();
+
+            assert_eq!(response2.0.len(), 5);
+
+            let mut total_vaults = response1
+                .0
+                .iter()
+                .chain(response2.0.iter())
+                .collect::<Vec<_>>();
+
+            total_vaults.sort_by(|a, b| a.vault.cmp(&b.vault));
+
+            for i in 0..10 {
+                assert_eq!(total_vaults[i].vault, vaults[i]);
+            }
+        }
     }
 
     #[test]

--- a/crates/bvs-vault-router/src/msg.rs
+++ b/crates/bvs-vault-router/src/msg.rs
@@ -10,12 +10,8 @@ pub struct InstantiateMsg {
 
 #[cw_serde]
 pub enum MigrateMsg {
-    MapVaults {
-        /// The operator to vault mapping
-        /// .0 is the operator and .1 is the vault
-        /// In json format it looks like: [["operator1", "vault1"], ["operator2", "vault2"]]
-        map: Vec<(String, String)>,
-    },
+    /// This is a type of payload that trigger the migration of OPERATOR_VAULTS state.
+    MapVaults {},
 }
 
 #[cw_serde]

--- a/crates/bvs-vault-router/src/msg.rs
+++ b/crates/bvs-vault-router/src/msg.rs
@@ -46,6 +46,13 @@ pub enum QueryMsg {
         start_after: Option<String>,
     },
 
+    #[returns(VaultListResponse)]
+    ListVaultsByOperator {
+        operator: String,
+        limit: Option<u32>,
+        start_after: Option<String>,
+    },
+
     /// QueryMsg WithdrawalLockPeriod: returns the withdrawal lock period.
     #[returns(WithdrawalLockPeriodResponse)]
     WithdrawalLockPeriod {},

--- a/crates/bvs-vault-router/src/msg.rs
+++ b/crates/bvs-vault-router/src/msg.rs
@@ -9,6 +9,16 @@ pub struct InstantiateMsg {
 }
 
 #[cw_serde]
+pub enum MigrateMsg {
+    MapVaults {
+        /// The operator to vault mapping
+        /// .0 is the operator and .1 is the vault
+        /// In json format it looks like: [["operator1", "vault1"], ["operator2", "vault2"]]
+        map: Vec<(String, String)>,
+    },
+}
+
+#[cw_serde]
 #[derive(bvs_pauser::api::Display)]
 pub enum ExecuteMsg {
     /// ExecuteMsg SetVault the vault contract in the router and whitelist (true/false) it.

--- a/crates/bvs-vault-router/src/msg.rs
+++ b/crates/bvs-vault-router/src/msg.rs
@@ -56,6 +56,9 @@ pub enum QueryMsg {
         start_after: Option<String>,
     },
 
+    /// QueryMsg ListVaultsByOperator: returns a list of vaults managed by given operator.
+    /// You can provide `limit` and `start_after` to paginate the results.
+    /// The max `limit` is 100.
     #[returns(VaultListResponse)]
     ListVaultsByOperator {
         operator: String,

--- a/crates/bvs-vault-router/src/state.rs
+++ b/crates/bvs-vault-router/src/state.rs
@@ -33,3 +33,6 @@ pub const WITHDRAWAL_LOCK_PERIOD: Item<Uint64> = Item::new("withdrawal_lock_peri
 /// This is used when the withdrawal lock period is not set.
 /// The default value is 7 days.
 pub const DEFAULT_WITHDRAWAL_LOCK_PERIOD: Uint64 = Uint64::new(604800);
+
+/// Operator to its managed vaults
+pub const DELEGATED_SERVICES: Map<(&Addr, &Addr), bool> = Map::new("delegated_services");

--- a/crates/bvs-vault-router/src/state.rs
+++ b/crates/bvs-vault-router/src/state.rs
@@ -35,4 +35,4 @@ pub const WITHDRAWAL_LOCK_PERIOD: Item<Uint64> = Item::new("withdrawal_lock_peri
 pub const DEFAULT_WITHDRAWAL_LOCK_PERIOD: Uint64 = Uint64::new(604800);
 
 /// Operator to its managed vaults
-pub const MAPPED_VAULTS: Map<(&Addr, &Addr), ()> = Map::new("delegated_services");
+pub const OPERATOR_VAULTS: Map<(&Addr, &Addr), ()> = Map::new("delegated_services");

--- a/crates/bvs-vault-router/src/state.rs
+++ b/crates/bvs-vault-router/src/state.rs
@@ -35,4 +35,4 @@ pub const WITHDRAWAL_LOCK_PERIOD: Item<Uint64> = Item::new("withdrawal_lock_peri
 pub const DEFAULT_WITHDRAWAL_LOCK_PERIOD: Uint64 = Uint64::new(604800);
 
 /// Operator to its managed vaults
-pub const OPERATOR_VAULTS: Map<(&Addr, &Addr), ()> = Map::new("delegated_services");
+pub const OPERATOR_VAULTS: Map<(&Addr, &Addr), ()> = Map::new("operator_vaults");

--- a/crates/bvs-vault-router/src/state.rs
+++ b/crates/bvs-vault-router/src/state.rs
@@ -35,4 +35,4 @@ pub const WITHDRAWAL_LOCK_PERIOD: Item<Uint64> = Item::new("withdrawal_lock_peri
 pub const DEFAULT_WITHDRAWAL_LOCK_PERIOD: Uint64 = Uint64::new(604800);
 
 /// Operator to its managed vaults
-pub const DELEGATED_SERVICES: Map<(&Addr, &Addr), bool> = Map::new("delegated_services");
+pub const MAPPED_VAULTS: Map<(&Addr, &Addr), ()> = Map::new("delegated_services");

--- a/crates/bvs-vault-router/tests/integration_test.rs
+++ b/crates/bvs-vault-router/tests/integration_test.rs
@@ -47,10 +47,10 @@ impl TestContracts {
 fn set_vault_whitelist_false_successfully() {
     let (mut app, tc) = TestContracts::init();
     let owner = app.api().addr_make("owner");
-    let vault = app.api().addr_make("vault");
+    let bank_vault = tc.bank_vault.addr();
 
     let msg = &ExecuteMsg::SetVault {
-        vault: vault.to_string(),
+        vault: bank_vault.to_string(),
         whitelisted: false,
     };
 
@@ -62,14 +62,14 @@ fn set_vault_whitelist_false_successfully() {
             Event::new("execute").add_attribute("_contract_address", tc.vault_router.addr.as_str()),
             Event::new("wasm-VaultUpdated")
                 .add_attribute("_contract_address", tc.vault_router.addr.as_str())
-                .add_attribute("vault", vault.to_string())
+                .add_attribute("vault", bank_vault.to_string())
                 .add_attribute("whitelisted", "false"),
         ]
     );
 
     // query is whitelisted
     let msg = QueryMsg::IsWhitelisted {
-        vault: vault.to_string(),
+        vault: bank_vault.to_string(),
     };
     let is_whitelisted: bool = tc.vault_router.query(&mut app, &msg).unwrap();
     assert_eq!(is_whitelisted, false);

--- a/crates/bvs-vault-router/tests/integration_test.rs
+++ b/crates/bvs-vault-router/tests/integration_test.rs
@@ -89,6 +89,15 @@ fn set_vault_whitelist_false_successfully() {
     };
     let response: VaultListResponse = tc.vault_router.query(&mut app, &msg).unwrap();
     assert_eq!(response.0.len(), 1);
+
+    let msg = QueryMsg::ListVaultsByOperator {
+        operator: operator.to_string(),
+        start_after: None,
+        limit: None,
+    };
+
+    let response: VaultListResponse = tc.vault_router.query(&mut app, &msg).unwrap();
+    assert_eq!(response.0.len(), 1);
 }
 
 #[test]
@@ -120,6 +129,17 @@ fn set_vault_whitelist_true_bank_vault_successfully() {
     };
     let is_whitelisted: bool = tc.vault_router.query(&mut app, &msg).unwrap();
     assert!(is_whitelisted);
+
+    let operator = app.api().addr_make("operator");
+
+    let msg = QueryMsg::ListVaultsByOperator {
+        operator: operator.to_string(),
+        start_after: None,
+        limit: None,
+    };
+
+    let response: VaultListResponse = tc.vault_router.query(&mut app, &msg).unwrap();
+    assert_eq!(response.0.len(), 1);
 }
 
 #[test]
@@ -151,6 +171,18 @@ fn set_vault_whitelist_true_cw20_vault_successfully() {
     };
     let is_whitelisted: bool = tc.vault_router.query(&mut app, &msg).unwrap();
     assert!(is_whitelisted);
+
+    let operator = app.api().addr_make("operator");
+
+    let msg = QueryMsg::ListVaultsByOperator {
+        operator: operator.to_string(),
+        start_after: None,
+        limit: None,
+    };
+
+    let response: VaultListResponse = tc.vault_router.query(&mut app, &msg).unwrap();
+
+    assert_eq!(response.0.len(), 1);
 }
 
 #[test]

--- a/crates/bvs-vault-router/tests/integration_test.rs
+++ b/crates/bvs-vault-router/tests/integration_test.rs
@@ -54,7 +54,7 @@ fn set_vault_whitelist_false_successfully() {
         whitelisted: false,
     };
 
-    let response = tc.vault_router.execute(&mut app, &owner, &msg).unwrap();
+    let response = tc.vault_router.execute(&mut app, &owner, msg).unwrap();
 
     assert_eq!(
         response.events,
@@ -72,7 +72,7 @@ fn set_vault_whitelist_false_successfully() {
         vault: bank_vault.to_string(),
     };
     let is_whitelisted: bool = tc.vault_router.query(&mut app, &msg).unwrap();
-    assert_eq!(is_whitelisted, false);
+    assert!(!is_whitelisted);
 
     // query is delegated
     let operator = app.api().addr_make("operator");
@@ -80,7 +80,7 @@ fn set_vault_whitelist_false_successfully() {
         operator: operator.to_string(),
     };
     let is_validating: bool = tc.vault_router.query(&mut app, &msg).unwrap();
-    assert_eq!(is_validating, false);
+    assert!(!is_validating);
 
     // list vaults
     let msg = QueryMsg::ListVaults {
@@ -101,7 +101,7 @@ fn set_vault_whitelist_true_bank_vault_successfully() {
         whitelisted: true,
     };
 
-    let response = tc.vault_router.execute(&mut app, &owner, &msg).unwrap();
+    let response = tc.vault_router.execute(&mut app, &owner, msg).unwrap();
 
     assert_eq!(
         response.events,
@@ -119,7 +119,7 @@ fn set_vault_whitelist_true_bank_vault_successfully() {
         vault: tc.bank_vault.addr().to_string(),
     };
     let is_whitelisted: bool = tc.vault_router.query(&mut app, &msg).unwrap();
-    assert_eq!(is_whitelisted, true);
+    assert!(is_whitelisted);
 }
 
 #[test]
@@ -132,7 +132,7 @@ fn set_vault_whitelist_true_cw20_vault_successfully() {
         whitelisted: true,
     };
 
-    let response = tc.vault_router.execute(&mut app, &owner, &msg).unwrap();
+    let response = tc.vault_router.execute(&mut app, &owner, msg).unwrap();
 
     assert_eq!(
         response.events,
@@ -150,7 +150,7 @@ fn set_vault_whitelist_true_cw20_vault_successfully() {
         vault: tc.cw20_vault.addr().to_string(),
     };
     let is_whitelisted: bool = tc.vault_router.query(&mut app, &msg).unwrap();
-    assert_eq!(is_whitelisted, true);
+    assert!(is_whitelisted);
 }
 
 #[test]
@@ -164,7 +164,7 @@ fn set_withdrawal_lock_period() {
     {
         let msg = &ExecuteMsg::SetWithdrawalLockPeriod(withdrawal_lock_period1);
 
-        let response = tc.vault_router.execute(&mut app, &owner, &msg).unwrap();
+        let response = tc.vault_router.execute(&mut app, &owner, msg).unwrap();
 
         assert_eq!(
             response.events,
@@ -191,7 +191,7 @@ fn set_withdrawal_lock_period() {
     {
         let msg = &ExecuteMsg::SetWithdrawalLockPeriod(withdrawal_lock_period2);
 
-        let response = tc.vault_router.execute(&mut app, &owner, &msg).unwrap();
+        let response = tc.vault_router.execute(&mut app, &owner, msg).unwrap();
 
         assert_eq!(
             response.events,
@@ -230,7 +230,7 @@ fn transfer_ownership_successfully() {
 
     let response = tc
         .vault_router
-        .execute(&mut app, &owner, &transfer_msg)
+        .execute(&mut app, &owner, transfer_msg)
         .unwrap();
 
     assert_eq!(
@@ -256,14 +256,11 @@ fn transfer_ownership_but_not_owner() {
 
     let err = tc
         .vault_router
-        .execute(&mut app, &not_owner, &transfer_msg)
+        .execute(&mut app, &not_owner, transfer_msg)
         .unwrap_err();
 
     assert_eq!(
         err.root_cause().to_string(),
-        ContractError::Ownership {
-            0: OwnershipError::Unauthorized
-        }
-        .to_string()
+        ContractError::Ownership(OwnershipError::Unauthorized).to_string()
     );
 }

--- a/modules/cosmwasm-schema/vault-router/schema.go
+++ b/modules/cosmwasm-schema/vault-router/schema.go
@@ -54,6 +54,7 @@ type QueryMsg struct {
 	IsWhitelisted        *IsWhitelisted        `json:"is_whitelisted,omitempty"`
 	IsValidating         *IsValidating         `json:"is_validating,omitempty"`
 	ListVaults           *ListVaults           `json:"list_vaults,omitempty"`
+	ListVaultsByOperator *ListVaultsByOperator `json:"list_vaults_by_operator,omitempty"`
 	WithdrawalLockPeriod *WithdrawalLockPeriod `json:"withdrawal_lock_period,omitempty"`
 }
 
@@ -67,6 +68,12 @@ type IsWhitelisted struct {
 
 type ListVaults struct {
 	Limit      *int64  `json:"limit"`
+	StartAfter *string `json:"start_after"`
+}
+
+type ListVaultsByOperator struct {
+	Limit      *int64  `json:"limit"`
+	Operator   string  `json:"operator"`
 	StartAfter *string `json:"start_after"`
 }
 

--- a/modules/cosmwasm-schema/vault-router/schema.go
+++ b/modules/cosmwasm-schema/vault-router/schema.go
@@ -49,6 +49,9 @@ type TransferOwnership struct {
 // QueryMsg ListVaults: returns a list of vaults. You can provide `limit` and `start_after`
 // to paginate the results. The max `limit` is 100.
 //
+// QueryMsg ListVaultsByOperator: returns a list of vaults managed by given operator. You
+// can provide `limit` and `start_after` to paginate the results. The max `limit` is 100.
+//
 // QueryMsg WithdrawalLockPeriod: returns the withdrawal lock period.
 type QueryMsg struct {
 	IsWhitelisted        *IsWhitelisted        `json:"is_whitelisted,omitempty"`

--- a/packages/cosmwasm-schema/vault-router.d.ts
+++ b/packages/cosmwasm-schema/vault-router.d.ts
@@ -100,6 +100,7 @@ export interface QueryMsg {
   is_whitelisted?: IsWhitelisted;
   is_validating?: IsValidating;
   list_vaults?: ListVaults;
+  list_vaults_by_operator?: ListVaultsByOperator;
   withdrawal_lock_period?: WithdrawalLockPeriod;
 }
 
@@ -113,6 +114,12 @@ export interface IsWhitelisted {
 
 export interface ListVaults {
   limit?: number | null;
+  start_after?: null | string;
+}
+
+export interface ListVaultsByOperator {
+  limit?: number | null;
+  operator: string;
   start_after?: null | string;
 }
 

--- a/packages/cosmwasm-schema/vault-router.d.ts
+++ b/packages/cosmwasm-schema/vault-router.d.ts
@@ -94,6 +94,9 @@ export interface TransferOwnership {
  * QueryMsg ListVaults: returns a list of vaults. You can provide `limit` and `start_after`
  * to paginate the results. The max `limit` is 100.
  *
+ * QueryMsg ListVaultsByOperator: returns a list of vaults managed by given operator. You
+ * can provide `limit` and `start_after` to paginate the results. The max `limit` is 100.
+ *
  * QueryMsg WithdrawalLockPeriod: returns the withdrawal lock period.
  */
 export interface QueryMsg {


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR attempt to establish a slashing pipline for satlayer eco-system. `bvs-slash-base` similarly named to `bvs-vault-base` serves similar purpose as `bvs-vault-base` does to downstream specific vaults except for strategy specific slashing contracts.

> **Prior-art**
> It is apparent that there are usually 3 stages to slashing (each implementation does it differently when it comes to specifics): 1. initiate slash or (accusation) 2. (trial, consensus, verification, voting etc.) 3. (sentencing - the burning of assets, what to do with seized assets etc)


Slashing stages. 
1. Initiating a slash, at this stage depending on the slash impl and strategy it's either the network, middle-wares contracts, or operator themselves initiate the slash for the accused. This stage, does not decide or dictate a slash is valid. This is purely a kick-start to submit a slash. 
2. Slash resolver, at this stage is where a lot of stuff varies between different strategies and network. In social slashing, this step is responsible for collecting vote by the operators. Some implementation in other chain have a whole subsystem just to verify the validity of accusation. In a perfect world this could be totally programmatic and intelligent trial system that can prove if a node has commit an offense. The point is that at this stage is where a slash is being decided to be proceed or to be rejected.
3. Burning of assets, in the most simplest form, this just burn the asset into oblivion. Or there is a scenario where a network might want to dedicate a portion of slashed asset to a pool that will then get voted for other usage. 

The bottom line here's that it boiled down to 3 stage even if strategy may varied.

With that, this PR (specifically `bvs-slash-base`) is designed to established a pipeline that satlayer ecosystem slashing contract can follow while reasonably opaque enough to allow third party to deploy custom strategy and protocols.

Each slash-contract should implement stage 1 and 3 as a minimum. For the stage 2, the downstream contract will have to implement as an extended `ExecuteMsg` set. 
```rust
#[cw_serde]
#[derive(bvs_pauser::api::Display)]
pub enum SlasherExecuteMsg<Offense, Evidence, SlashDetail> {
    /// SubmitOffense: submit an offense to the slash strategy contract.
    /// offender: the address of the operator.
    /// offense: the offense committed. (Opaque to the slasher contract)
    /// evidence: the evidence of the offense. (Opaque to the slasher contract)
    SubmitSlash {
        offender: String,
        offense: Offense,
        evidence: Evidence,
    },

    /// ExecuteSlash: trigger the slash on slash strategy contract to execute the slash.
    /// Exacatly how the slash is executed is up to the slash strategy contract.
    /// How the slash entries will be hash is also up to the slash strategy contract.
    /// slash_detail: the hash of the slash.
    ExecuteSlash { slash_detail: SlashDetail },
}
```
The bvs-slash-base reinforce the implementation of stage 1, and 3. Where stage 2. The slash resolving stage is up to the downstream slashing contract. The usage of template types, (generic types), allow for custom payload being able to accommodate for their own custom strategy. 

I actually wanted to include an example slashing contract that utilized social voting between operator. But I've been warned for robbing alot of attention toward my PRs, I want to keep the changes in this PR small.

Regardless I'll provide a pseudo contract  in PR description that conform to the bvs-slash-base. Let's call this contract 
`bvs-slash-social-vote`.  For the simplicity of the exemplification. This is purely majority willed voting mechanism and we will omit the evidence type.  Keep in mind social voting strategy is arbitrary that i only picked for the purpose of exemplification. Satlayer do not reinforce nor suggest any particular slashing strategy. 

```rust
/// contract.rs
Struct InstantiateMsg {
   router: String
   underlying_vault: String
   ...
}

/// State.rs
OPERATORS: Map<addr, bool> = Map::new("operators")

/// dictate how much asset should be slashed based on the reported offense.
PUNISHMENT: Map<Offense, Uint128> = Map::new("punishment")

/// Voting threshold to pass slash request
/// This value should be mutated every-time, OPERATORS item's been mutated. 
/// I know OPERATORS is with bvs-registry but it's getting off-topic for the purpose of this PR 
THRESHOLD: Item<U128> = (OPERATORS.size / 2 ).ceil() // about 50%.

/// Slash entries 
/// Key string, hash of the slash entry
/// Value, the amount of yes vote
Slashes: Map<HashString, u128> = Map::new("slashes")

enum Offense{
 DoubleSigning
 MissingBlocks
}

///Execute.rs
Struct SlashDetails {
 offender: addr,
 start_height: uint128,
 end_height: uint128,
 offense: Offense,
 amount: uint128
}

/// this is extended execute msg unique to this particular contract
[cw_serde]
  VoteSlash {
     vote: bool,
     SlashDetails: SlashDetails
  }

pub  struct ExecuteMsg {
   SubmitSlash: bvs_slash_base:SubmitSlash<Offense, Some(string)>
   ExecuteSlash: bvs_slash_base::ExecuteSlash<SlashDetails>
   VoteSlash(VoteSlash)
}

match msg {
     Execute::SubmitSlash {...}  => {
        // only operator or in other strategy this may be callable by their network 
         submit_slash(...);
     }
     Execute::VoteSlash {...} => {
        // only operator or in other strategy this may be callable by their network 
         vote_slash(...);
     }
    Execute::ExecuteSlash {...} => {
        // only operator or in other strategy this may be callable by their network 
         execute_slash(...);
     }
}

fn submit_slash( ...., offender, offense) {
   sender = operator ?;
    is_offender_operator ?;
    
    // let say 100 block is period to vote
    let details = SlashDetails {
        start_height: current_block,
        end_height: current_block + 100,
        offense: offense,
        amount: PUNISHMENT.load(offense),
    }
    
    let hash = HashFunc(details)
    
    Slashes.add(hash, false);
}

fn vote_slash(..., vote, slashDetails) {

  let hash = hashFunc(SlashDetails)
  
 Slashes.load(hash)?; // does slash entry exist?
  
  SlashDetails.end_height < current_height?; // is slash voting period for this slash entry over
  
    let current_vote = Slashes.load(hash)
    let new_vote = {
       match vote {
           true => { return current_vote + 1; }
           false => { return current_vote - 1; }
       }
    }
    
    Slashes.save(hash, new_vote);
}

fn execute_slash(..., slash_details){
let slash_hash = hashFnc(slash_details);
 let votes = SLASHES.load(slash_hash)?; // does slash exist?
 
 votes > THRESHOLD.load()?;
 
 //// implement custom logic like seizing the assets to a voted pool.
 //// but for the sake of this example let's just burn it
 
   let submsg = Vault::Burn {
       amount: slash_details.amount
  }
  let vault = VAULT.load()?;

  vault.execute(submsg);
    
 }
 
}

```

The flow for our imaginary slashing strategy contract would be 
```mermaid
sequenceDiagram
    operator->>+bvs-slash-social-vote: 1.ExecuteMsg::SubmitSlash
    operatorGroup ->>+ bvs-slash-social-vote: 2.ExecuteMsg::VoteSlash
    bvs-slash-social-vote ->>+ bvs-slash-social-vote: 3.collect vote

    operator ->>+ bvs-slash-social-vote: 4.Execute::ExecuteSlash
    operator ->>+ router: 5. ask the vault to give up collateral
```
Closes - SL-378