### PR TITLE
feat: schema for queued withdrawal

### DIFF
--- a/modules/cosmwasm-schema/vault-bank/schema.go
+++ b/modules/cosmwasm-schema/vault-bank/schema.go
@@ -38,9 +38,25 @@ type InstantiateMsg struct {
 // requested amount to the `recipient`. If the Vault is delegated to an `operator`,
 // withdrawals must be queued. Operator must not be validating any services for instant
 // withdrawals.
+//
+// ExecuteMsg QueueWithdrawal assets from the vault. Sender must have enough shares to queue
+// the requested amount to the `recipient`. Once the withdrawal is queued, the `recipient`
+// can redeem the withdrawal after the lock period. Once the withdrawal is locked, the
+// `sender` cannot cancel the withdrawal. The time-lock is enforced by the vault and cannot
+// be changed retroactively.
+//
+// ### Lock Period Extension New withdrawals will extend the lock period of any existing
+// withdrawals. You can queue the withdrawal to a different `recipient` than the `sender` to
+// avoid this.
+//
+// ExecuteMsg RedeemWithdrawal all queued shares into assets from the vault for withdrawal.
+// After the lock period, the `sender` (must be the `recipient` of the original withdrawal)
+// can redeem the withdrawal.
 type ExecuteMsg struct {
-	DepositFor *RecipientAmount `json:"deposit_for,omitempty"`
-	WithdrawTo *RecipientAmount `json:"withdraw_to,omitempty"`
+	DepositFor         *RecipientAmount `json:"deposit_for,omitempty"`
+	WithdrawTo         *RecipientAmount `json:"withdraw_to,omitempty"`
+	QueueWithdrawalTo  *RecipientAmount `json:"queue_withdrawal_to,omitempty"`
+	RedeemWithdrawalTo *string          `json:"redeem_withdrawal_to,omitempty"`
 }
 
 // This struct is used to represent the recipient and amount fields together.
@@ -61,15 +77,18 @@ type RecipientAmount struct {
 //
 // QueryMsg TotalAssets: get the total assets under vault.
 //
+// QueryMsg QueuedWithdrawal: get the queued withdrawal and unlock timestamp under vault.
+//
 // QueryMsg VaultInfo: get the vault information.
 type QueryMsg struct {
-	Shares          *Shares          `json:"shares,omitempty"`
-	Assets          *Assets          `json:"assets,omitempty"`
-	ConvertToAssets *ConvertToAssets `json:"convert_to_assets,omitempty"`
-	ConvertToShares *ConvertToShares `json:"convert_to_shares,omitempty"`
-	TotalShares     *TotalShares     `json:"total_shares,omitempty"`
-	TotalAssets     *TotalAssets     `json:"total_assets,omitempty"`
-	VaultInfo       *VaultInfo       `json:"vault_info,omitempty"`
+	Shares           *Shares           `json:"shares,omitempty"`
+	Assets           *Assets           `json:"assets,omitempty"`
+	ConvertToAssets  *ConvertToAssets  `json:"convert_to_assets,omitempty"`
+	ConvertToShares  *ConvertToShares  `json:"convert_to_shares,omitempty"`
+	TotalShares      *TotalShares      `json:"total_shares,omitempty"`
+	TotalAssets      *TotalAssets      `json:"total_assets,omitempty"`
+	QueuedWithdrawal *QueuedWithdrawal `json:"queued_withdrawal,omitempty"`
+	VaultInfo        *VaultInfo        `json:"vault_info,omitempty"`
 }
 
 type Assets struct {
@@ -84,6 +103,10 @@ type ConvertToShares struct {
 	Assets string `json:"assets"`
 }
 
+type QueuedWithdrawal struct {
+	Staker string `json:"staker"`
+}
+
 type Shares struct {
 	Staker string `json:"staker"`
 }
@@ -95,6 +118,13 @@ type TotalShares struct {
 }
 
 type VaultInfo struct {
+}
+
+// The response to the `QueuedWithdrawal` query. Not exported. This is just a wrapper around
+// `QueuedWithdrawalInfo`, so that the schema can be generated.
+type QueuedWithdrawalResponse struct {
+	QueuedShares    string `json:"queued_shares"`
+	UnlockTimestamp string `json:"unlock_timestamp"`
 }
 
 type VaultInfoResponse struct {

--- a/modules/cosmwasm-schema/vault-cw20/schema.go
+++ b/modules/cosmwasm-schema/vault-cw20/schema.go
@@ -38,9 +38,25 @@ type InstantiateMsg struct {
 // requested amount to the `recipient`. If the Vault is delegated to an `operator`,
 // withdrawals must be queued. Operator must not be validating any services for instant
 // withdrawals.
+//
+// ExecuteMsg QueueWithdrawal assets from the vault. Sender must have enough shares to queue
+// the requested amount to the `recipient`. Once the withdrawal is queued, the `recipient`
+// can redeem the withdrawal after the lock period. Once the withdrawal is locked, the
+// `sender` cannot cancel the withdrawal. The time-lock is enforced by the vault and cannot
+// be changed retroactively.
+//
+// ### Lock Period Extension New withdrawals will extend the lock period of any existing
+// withdrawals. You can queue the withdrawal to a different `recipient` than the `sender` to
+// avoid this.
+//
+// ExecuteMsg RedeemWithdrawal all queued shares into assets from the vault for withdrawal.
+// After the lock period, the `sender` (must be the `recipient` of the original withdrawal)
+// can redeem the withdrawal.
 type ExecuteMsg struct {
-	DepositFor *RecipientAmount `json:"deposit_for,omitempty"`
-	WithdrawTo *RecipientAmount `json:"withdraw_to,omitempty"`
+	DepositFor         *RecipientAmount `json:"deposit_for,omitempty"`
+	WithdrawTo         *RecipientAmount `json:"withdraw_to,omitempty"`
+	QueueWithdrawalTo  *RecipientAmount `json:"queue_withdrawal_to,omitempty"`
+	RedeemWithdrawalTo *string          `json:"redeem_withdrawal_to,omitempty"`
 }
 
 // This struct is used to represent the recipient and amount fields together.
@@ -61,15 +77,18 @@ type RecipientAmount struct {
 //
 // QueryMsg TotalAssets: get the total assets under vault.
 //
+// QueryMsg QueuedWithdrawal: get the queued withdrawal and unlock timestamp under vault.
+//
 // QueryMsg VaultInfo: get the vault information.
 type QueryMsg struct {
-	Shares          *Shares          `json:"shares,omitempty"`
-	Assets          *Assets          `json:"assets,omitempty"`
-	ConvertToAssets *ConvertToAssets `json:"convert_to_assets,omitempty"`
-	ConvertToShares *ConvertToShares `json:"convert_to_shares,omitempty"`
-	TotalShares     *TotalShares     `json:"total_shares,omitempty"`
-	TotalAssets     *TotalAssets     `json:"total_assets,omitempty"`
-	VaultInfo       *VaultInfo       `json:"vault_info,omitempty"`
+	Shares           *Shares           `json:"shares,omitempty"`
+	Assets           *Assets           `json:"assets,omitempty"`
+	ConvertToAssets  *ConvertToAssets  `json:"convert_to_assets,omitempty"`
+	ConvertToShares  *ConvertToShares  `json:"convert_to_shares,omitempty"`
+	TotalShares      *TotalShares      `json:"total_shares,omitempty"`
+	TotalAssets      *TotalAssets      `json:"total_assets,omitempty"`
+	QueuedWithdrawal *QueuedWithdrawal `json:"queued_withdrawal,omitempty"`
+	VaultInfo        *VaultInfo        `json:"vault_info,omitempty"`
 }
 
 type Assets struct {
@@ -84,6 +103,10 @@ type ConvertToShares struct {
 	Assets string `json:"assets"`
 }
 
+type QueuedWithdrawal struct {
+	Staker string `json:"staker"`
+}
+
 type Shares struct {
 	Staker string `json:"staker"`
 }
@@ -95,6 +118,13 @@ type TotalShares struct {
 }
 
 type VaultInfo struct {
+}
+
+// The response to the `QueuedWithdrawal` query. Not exported. This is just a wrapper around
+// `QueuedWithdrawalInfo`, so that the schema can be generated.
+type QueuedWithdrawalResponse struct {
+	QueuedShares    string `json:"queued_shares"`
+	UnlockTimestamp string `json:"unlock_timestamp"`
 }
 
 type VaultInfoResponse struct {

--- a/modules/cosmwasm-schema/vault-router/schema.go
+++ b/modules/cosmwasm-schema/vault-router/schema.go
@@ -9,6 +9,8 @@ type IsWhitelistedResponse bool
 
 type VaultListResponse []Vault
 
+type WithdrawalLockPeriodResponse string
+
 type InstantiateMsg struct {
 	Owner    string `json:"owner"`
 	Pauser   string `json:"pauser"`
@@ -18,11 +20,15 @@ type InstantiateMsg struct {
 // ExecuteMsg SetVault the vault contract in the router and whitelist (true/false) it. Only
 // the `owner` can call this message.
 //
+// ExecuteMsg SetWithdrawalLockPeriod the lock period for withdrawal. Only the `owner` can
+// call this message.
+//
 // ExecuteMsg TransferOwnership See [`bvs_library::ownership::transfer_ownership`] for more
 // information on this field
 type ExecuteMsg struct {
-	SetVault          *SetVault          `json:"set_vault,omitempty"`
-	TransferOwnership *TransferOwnership `json:"transfer_ownership,omitempty"`
+	SetVault                *SetVault          `json:"set_vault,omitempty"`
+	SetWithdrawalLockPeriod *string            `json:"set_withdrawal_lock_period,omitempty"`
+	TransferOwnership       *TransferOwnership `json:"transfer_ownership,omitempty"`
 }
 
 type SetVault struct {
@@ -42,10 +48,13 @@ type TransferOwnership struct {
 //
 // QueryMsg ListVaults: returns a list of vaults. You can provide `limit` and `start_after`
 // to paginate the results. The max `limit` is 100.
+//
+// QueryMsg WithdrawalLockPeriod: returns the withdrawal lock period.
 type QueryMsg struct {
-	IsWhitelisted *IsWhitelisted `json:"is_whitelisted,omitempty"`
-	IsValidating  *IsValidating  `json:"is_validating,omitempty"`
-	ListVaults    *ListVaults    `json:"list_vaults,omitempty"`
+	IsWhitelisted        *IsWhitelisted        `json:"is_whitelisted,omitempty"`
+	IsValidating         *IsValidating         `json:"is_validating,omitempty"`
+	ListVaults           *ListVaults           `json:"list_vaults,omitempty"`
+	WithdrawalLockPeriod *WithdrawalLockPeriod `json:"withdrawal_lock_period,omitempty"`
 }
 
 type IsValidating struct {
@@ -59,6 +68,9 @@ type IsWhitelisted struct {
 type ListVaults struct {
 	Limit      *int64  `json:"limit"`
 	StartAfter *string `json:"start_after"`
+}
+
+type WithdrawalLockPeriod struct {
 }
 
 // The response to the `ListVaults` query. For pagination, the `start_after` field is the

--- a/packages/cosmwasm-schema/vault-bank.d.ts
+++ b/packages/cosmwasm-schema/vault-bank.d.ts
@@ -33,6 +33,8 @@
  * mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String`
  * instance.
  *
+ * This struct is used to represent a recipient for RedeemWithdrawalTo.
+ *
  * The response to the `Assets` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
  *
@@ -41,6 +43,31 @@
  *
  * The response to the `ConvertToShares` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
+ *
+ * A point in time in nanosecond precision.
+ *
+ * This type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.
+ *
+ * ## Examples
+ *
+ * ``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202);
+ * assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1);
+ * assert_eq!(ts.subsec_nanos(), 202);
+ *
+ * let ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202);
+ * assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```
+ *
+ * A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the
+ * full u64 range can be used for clients that convert JSON numbers to floats, like
+ * JavaScript and jq.
+ *
+ * # Examples
+ *
+ * Use `from` to create instances of this and `u64` to get the value out:
+ *
+ * ``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);
+ *
+ * let b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```
  *
  * The response to the `Shares` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
@@ -95,6 +122,8 @@ type AssetsResponse = string;
  * mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String`
  * instance.
  *
+ * This struct is used to represent a recipient for RedeemWithdrawalTo.
+ *
  * The response to the `Assets` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
  *
@@ -103,6 +132,31 @@ type AssetsResponse = string;
  *
  * The response to the `ConvertToShares` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
+ *
+ * A point in time in nanosecond precision.
+ *
+ * This type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.
+ *
+ * ## Examples
+ *
+ * ``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202);
+ * assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1);
+ * assert_eq!(ts.subsec_nanos(), 202);
+ *
+ * let ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202);
+ * assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```
+ *
+ * A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the
+ * full u64 range can be used for clients that convert JSON numbers to floats, like
+ * JavaScript and jq.
+ *
+ * # Examples
+ *
+ * Use `from` to create instances of this and `u64` to get the value out:
+ *
+ * ``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);
+ *
+ * let b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```
  *
  * The response to the `Shares` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
@@ -157,6 +211,8 @@ type ConvertToAssetsResponse = string;
  * mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String`
  * instance.
  *
+ * This struct is used to represent a recipient for RedeemWithdrawalTo.
+ *
  * The response to the `Assets` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
  *
@@ -165,6 +221,31 @@ type ConvertToAssetsResponse = string;
  *
  * The response to the `ConvertToShares` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
+ *
+ * A point in time in nanosecond precision.
+ *
+ * This type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.
+ *
+ * ## Examples
+ *
+ * ``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202);
+ * assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1);
+ * assert_eq!(ts.subsec_nanos(), 202);
+ *
+ * let ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202);
+ * assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```
+ *
+ * A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the
+ * full u64 range can be used for clients that convert JSON numbers to floats, like
+ * JavaScript and jq.
+ *
+ * # Examples
+ *
+ * Use `from` to create instances of this and `u64` to get the value out:
+ *
+ * ``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);
+ *
+ * let b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```
  *
  * The response to the `Shares` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
@@ -219,6 +300,8 @@ type ConvertToSharesResponse = string;
  * mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String`
  * instance.
  *
+ * This struct is used to represent a recipient for RedeemWithdrawalTo.
+ *
  * The response to the `Assets` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
  *
@@ -227,6 +310,31 @@ type ConvertToSharesResponse = string;
  *
  * The response to the `ConvertToShares` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
+ *
+ * A point in time in nanosecond precision.
+ *
+ * This type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.
+ *
+ * ## Examples
+ *
+ * ``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202);
+ * assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1);
+ * assert_eq!(ts.subsec_nanos(), 202);
+ *
+ * let ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202);
+ * assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```
+ *
+ * A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the
+ * full u64 range can be used for clients that convert JSON numbers to floats, like
+ * JavaScript and jq.
+ *
+ * # Examples
+ *
+ * Use `from` to create instances of this and `u64` to get the value out:
+ *
+ * ``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);
+ *
+ * let b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```
  *
  * The response to the `Shares` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
@@ -281,6 +389,8 @@ type SharesResponse = string;
  * mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String`
  * instance.
  *
+ * This struct is used to represent a recipient for RedeemWithdrawalTo.
+ *
  * The response to the `Assets` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
  *
@@ -289,6 +399,31 @@ type SharesResponse = string;
  *
  * The response to the `ConvertToShares` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
+ *
+ * A point in time in nanosecond precision.
+ *
+ * This type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.
+ *
+ * ## Examples
+ *
+ * ``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202);
+ * assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1);
+ * assert_eq!(ts.subsec_nanos(), 202);
+ *
+ * let ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202);
+ * assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```
+ *
+ * A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the
+ * full u64 range can be used for clients that convert JSON numbers to floats, like
+ * JavaScript and jq.
+ *
+ * # Examples
+ *
+ * Use `from` to create instances of this and `u64` to get the value out:
+ *
+ * ``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);
+ *
+ * let b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```
  *
  * The response to the `Shares` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
@@ -343,6 +478,8 @@ type TotalAssetsResponse = string;
  * mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String`
  * instance.
  *
+ * This struct is used to represent a recipient for RedeemWithdrawalTo.
+ *
  * The response to the `Assets` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
  *
@@ -351,6 +488,31 @@ type TotalAssetsResponse = string;
  *
  * The response to the `ConvertToShares` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
+ *
+ * A point in time in nanosecond precision.
+ *
+ * This type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.
+ *
+ * ## Examples
+ *
+ * ``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202);
+ * assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1);
+ * assert_eq!(ts.subsec_nanos(), 202);
+ *
+ * let ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202);
+ * assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```
+ *
+ * A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the
+ * full u64 range can be used for clients that convert JSON numbers to floats, like
+ * JavaScript and jq.
+ *
+ * # Examples
+ *
+ * Use `from` to create instances of this and `u64` to get the value out:
+ *
+ * ``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);
+ *
+ * let b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```
  *
  * The response to the `Shares` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
@@ -405,10 +567,26 @@ export interface InstantiateMsg {
  * requested amount to the `recipient`. If the Vault is delegated to an `operator`,
  * withdrawals must be queued. Operator must not be validating any services for instant
  * withdrawals.
+ *
+ * ExecuteMsg QueueWithdrawal assets from the vault. Sender must have enough shares to queue
+ * the requested amount to the `recipient`. Once the withdrawal is queued, the `recipient`
+ * can redeem the withdrawal after the lock period. Once the withdrawal is locked, the
+ * `sender` cannot cancel the withdrawal. The time-lock is enforced by the vault and cannot
+ * be changed retroactively.
+ *
+ * ### Lock Period Extension New withdrawals will extend the lock period of any existing
+ * withdrawals. You can queue the withdrawal to a different `recipient` than the `sender` to
+ * avoid this.
+ *
+ * ExecuteMsg RedeemWithdrawal all queued shares into assets from the vault for withdrawal.
+ * After the lock period, the `sender` (must be the `recipient` of the original withdrawal)
+ * can redeem the withdrawal.
  */
 export interface ExecuteMsg {
   deposit_for?: RecipientAmount;
   withdraw_to?: RecipientAmount;
+  queue_withdrawal_to?: RecipientAmount;
+  redeem_withdrawal_to?: string;
 }
 
 /**
@@ -432,6 +610,8 @@ export interface RecipientAmount {
  *
  * QueryMsg TotalAssets: get the total assets under vault.
  *
+ * QueryMsg QueuedWithdrawal: get the queued withdrawal and unlock timestamp under vault.
+ *
  * QueryMsg VaultInfo: get the vault information.
  */
 export interface QueryMsg {
@@ -441,6 +621,7 @@ export interface QueryMsg {
   convert_to_shares?: ConvertToShares;
   total_shares?: TotalShares;
   total_assets?: TotalAssets;
+  queued_withdrawal?: QueuedWithdrawal;
   vault_info?: VaultInfo;
 }
 
@@ -456,6 +637,10 @@ export interface ConvertToShares {
   assets: string;
 }
 
+export interface QueuedWithdrawal {
+  staker: string;
+}
+
 export interface Shares {
   staker: string;
 }
@@ -465,6 +650,15 @@ export interface TotalAssets {}
 export interface TotalShares {}
 
 export interface VaultInfo {}
+
+/**
+ * The response to the `QueuedWithdrawal` query. Not exported. This is just a wrapper around
+ * `QueuedWithdrawalInfo`, so that the schema can be generated.
+ */
+export interface QueuedWithdrawalResponse {
+  queued_shares: string;
+  unlock_timestamp: string;
+}
 
 export interface VaultInfoResponse {
   /**

--- a/packages/cosmwasm-schema/vault-cw20.d.ts
+++ b/packages/cosmwasm-schema/vault-cw20.d.ts
@@ -33,6 +33,8 @@
  * mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String`
  * instance.
  *
+ * This struct is used to represent a recipient for RedeemWithdrawalTo.
+ *
  * The response to the `Assets` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
  *
@@ -41,6 +43,31 @@
  *
  * The response to the `ConvertToShares` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
+ *
+ * A point in time in nanosecond precision.
+ *
+ * This type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.
+ *
+ * ## Examples
+ *
+ * ``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202);
+ * assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1);
+ * assert_eq!(ts.subsec_nanos(), 202);
+ *
+ * let ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202);
+ * assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```
+ *
+ * A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the
+ * full u64 range can be used for clients that convert JSON numbers to floats, like
+ * JavaScript and jq.
+ *
+ * # Examples
+ *
+ * Use `from` to create instances of this and `u64` to get the value out:
+ *
+ * ``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);
+ *
+ * let b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```
  *
  * The response to the `Shares` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
@@ -95,6 +122,8 @@ type AssetsResponse = string;
  * mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String`
  * instance.
  *
+ * This struct is used to represent a recipient for RedeemWithdrawalTo.
+ *
  * The response to the `Assets` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
  *
@@ -103,6 +132,31 @@ type AssetsResponse = string;
  *
  * The response to the `ConvertToShares` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
+ *
+ * A point in time in nanosecond precision.
+ *
+ * This type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.
+ *
+ * ## Examples
+ *
+ * ``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202);
+ * assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1);
+ * assert_eq!(ts.subsec_nanos(), 202);
+ *
+ * let ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202);
+ * assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```
+ *
+ * A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the
+ * full u64 range can be used for clients that convert JSON numbers to floats, like
+ * JavaScript and jq.
+ *
+ * # Examples
+ *
+ * Use `from` to create instances of this and `u64` to get the value out:
+ *
+ * ``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);
+ *
+ * let b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```
  *
  * The response to the `Shares` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
@@ -157,6 +211,8 @@ type ConvertToAssetsResponse = string;
  * mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String`
  * instance.
  *
+ * This struct is used to represent a recipient for RedeemWithdrawalTo.
+ *
  * The response to the `Assets` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
  *
@@ -165,6 +221,31 @@ type ConvertToAssetsResponse = string;
  *
  * The response to the `ConvertToShares` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
+ *
+ * A point in time in nanosecond precision.
+ *
+ * This type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.
+ *
+ * ## Examples
+ *
+ * ``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202);
+ * assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1);
+ * assert_eq!(ts.subsec_nanos(), 202);
+ *
+ * let ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202);
+ * assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```
+ *
+ * A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the
+ * full u64 range can be used for clients that convert JSON numbers to floats, like
+ * JavaScript and jq.
+ *
+ * # Examples
+ *
+ * Use `from` to create instances of this and `u64` to get the value out:
+ *
+ * ``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);
+ *
+ * let b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```
  *
  * The response to the `Shares` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
@@ -219,6 +300,8 @@ type ConvertToSharesResponse = string;
  * mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String`
  * instance.
  *
+ * This struct is used to represent a recipient for RedeemWithdrawalTo.
+ *
  * The response to the `Assets` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
  *
@@ -227,6 +310,31 @@ type ConvertToSharesResponse = string;
  *
  * The response to the `ConvertToShares` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
+ *
+ * A point in time in nanosecond precision.
+ *
+ * This type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.
+ *
+ * ## Examples
+ *
+ * ``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202);
+ * assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1);
+ * assert_eq!(ts.subsec_nanos(), 202);
+ *
+ * let ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202);
+ * assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```
+ *
+ * A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the
+ * full u64 range can be used for clients that convert JSON numbers to floats, like
+ * JavaScript and jq.
+ *
+ * # Examples
+ *
+ * Use `from` to create instances of this and `u64` to get the value out:
+ *
+ * ``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);
+ *
+ * let b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```
  *
  * The response to the `Shares` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
@@ -281,6 +389,8 @@ type SharesResponse = string;
  * mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String`
  * instance.
  *
+ * This struct is used to represent a recipient for RedeemWithdrawalTo.
+ *
  * The response to the `Assets` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
  *
@@ -289,6 +399,31 @@ type SharesResponse = string;
  *
  * The response to the `ConvertToShares` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
+ *
+ * A point in time in nanosecond precision.
+ *
+ * This type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.
+ *
+ * ## Examples
+ *
+ * ``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202);
+ * assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1);
+ * assert_eq!(ts.subsec_nanos(), 202);
+ *
+ * let ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202);
+ * assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```
+ *
+ * A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the
+ * full u64 range can be used for clients that convert JSON numbers to floats, like
+ * JavaScript and jq.
+ *
+ * # Examples
+ *
+ * Use `from` to create instances of this and `u64` to get the value out:
+ *
+ * ``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);
+ *
+ * let b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```
  *
  * The response to the `Shares` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
@@ -343,6 +478,8 @@ type TotalAssetsResponse = string;
  * mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String`
  * instance.
  *
+ * This struct is used to represent a recipient for RedeemWithdrawalTo.
+ *
  * The response to the `Assets` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
  *
@@ -351,6 +488,31 @@ type TotalAssetsResponse = string;
  *
  * The response to the `ConvertToShares` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
+ *
+ * A point in time in nanosecond precision.
+ *
+ * This type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.
+ *
+ * ## Examples
+ *
+ * ``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202);
+ * assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1);
+ * assert_eq!(ts.subsec_nanos(), 202);
+ *
+ * let ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202);
+ * assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```
+ *
+ * A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the
+ * full u64 range can be used for clients that convert JSON numbers to floats, like
+ * JavaScript and jq.
+ *
+ * # Examples
+ *
+ * Use `from` to create instances of this and `u64` to get the value out:
+ *
+ * ``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);
+ *
+ * let b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```
  *
  * The response to the `Shares` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
@@ -405,10 +567,26 @@ export interface InstantiateMsg {
  * requested amount to the `recipient`. If the Vault is delegated to an `operator`,
  * withdrawals must be queued. Operator must not be validating any services for instant
  * withdrawals.
+ *
+ * ExecuteMsg QueueWithdrawal assets from the vault. Sender must have enough shares to queue
+ * the requested amount to the `recipient`. Once the withdrawal is queued, the `recipient`
+ * can redeem the withdrawal after the lock period. Once the withdrawal is locked, the
+ * `sender` cannot cancel the withdrawal. The time-lock is enforced by the vault and cannot
+ * be changed retroactively.
+ *
+ * ### Lock Period Extension New withdrawals will extend the lock period of any existing
+ * withdrawals. You can queue the withdrawal to a different `recipient` than the `sender` to
+ * avoid this.
+ *
+ * ExecuteMsg RedeemWithdrawal all queued shares into assets from the vault for withdrawal.
+ * After the lock period, the `sender` (must be the `recipient` of the original withdrawal)
+ * can redeem the withdrawal.
  */
 export interface ExecuteMsg {
   deposit_for?: RecipientAmount;
   withdraw_to?: RecipientAmount;
+  queue_withdrawal_to?: RecipientAmount;
+  redeem_withdrawal_to?: string;
 }
 
 /**
@@ -432,6 +610,8 @@ export interface RecipientAmount {
  *
  * QueryMsg TotalAssets: get the total assets under vault.
  *
+ * QueryMsg QueuedWithdrawal: get the queued withdrawal and unlock timestamp under vault.
+ *
  * QueryMsg VaultInfo: get the vault information.
  */
 export interface QueryMsg {
@@ -441,6 +621,7 @@ export interface QueryMsg {
   convert_to_shares?: ConvertToShares;
   total_shares?: TotalShares;
   total_assets?: TotalAssets;
+  queued_withdrawal?: QueuedWithdrawal;
   vault_info?: VaultInfo;
 }
 
@@ -456,6 +637,10 @@ export interface ConvertToShares {
   assets: string;
 }
 
+export interface QueuedWithdrawal {
+  staker: string;
+}
+
 export interface Shares {
   staker: string;
 }
@@ -465,6 +650,15 @@ export interface TotalAssets {}
 export interface TotalShares {}
 
 export interface VaultInfo {}
+
+/**
+ * The response to the `QueuedWithdrawal` query. Not exported. This is just a wrapper around
+ * `QueuedWithdrawalInfo`, so that the schema can be generated.
+ */
+export interface QueuedWithdrawalResponse {
+  queued_shares: string;
+  unlock_timestamp: string;
+}
 
 export interface VaultInfoResponse {
   /**

--- a/packages/cosmwasm-schema/vault-router.d.ts
+++ b/packages/cosmwasm-schema/vault-router.d.ts
@@ -19,6 +19,40 @@ type IsValidatingResponse = boolean;
  */
 type IsWhitelistedResponse = boolean;
 
+/**
+ * A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the
+ * full u64 range can be used for clients that convert JSON numbers to floats, like
+ * JavaScript and jq.
+ *
+ * # Examples
+ *
+ * Use `from` to create instances of this and `u64` to get the value out:
+ *
+ * ``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);
+ *
+ * let b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```
+ *
+ * A human readable address.
+ *
+ * In Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no
+ * assumptions should be made other than being UTF-8 encoded and of reasonable length.
+ *
+ * This type represents a validated address. It can be created in the following ways 1. Use
+ * `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3.
+ * Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from
+ * JSON. This must only be done from JSON that was validated before such as a contract's
+ * state. `Addr` must not be used in messages sent by the user because this would result in
+ * unvalidated instances.
+ *
+ * This type is immutable. If you really need to mutate it (Really? Are you sure?), create a
+ * mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String`
+ * instance.
+ *
+ * The response to the `WithdrawalLockPeriod` query. Not exported. This is just a wrapper
+ * around `Uint64`, so that the schema can be generated.
+ */
+type WithdrawalLockPeriodResponse = string;
+
 export interface InstantiateMsg {
   owner: string;
   pauser: string;
@@ -29,11 +63,15 @@ export interface InstantiateMsg {
  * ExecuteMsg SetVault the vault contract in the router and whitelist (true/false) it. Only
  * the `owner` can call this message.
  *
+ * ExecuteMsg SetWithdrawalLockPeriod the lock period for withdrawal. Only the `owner` can
+ * call this message.
+ *
  * ExecuteMsg TransferOwnership See [`bvs_library::ownership::transfer_ownership`] for more
  * information on this field
  */
 export interface ExecuteMsg {
   set_vault?: SetVault;
+  set_withdrawal_lock_period?: string;
   transfer_ownership?: TransferOwnership;
 }
 
@@ -55,11 +93,14 @@ export interface TransferOwnership {
  *
  * QueryMsg ListVaults: returns a list of vaults. You can provide `limit` and `start_after`
  * to paginate the results. The max `limit` is 100.
+ *
+ * QueryMsg WithdrawalLockPeriod: returns the withdrawal lock period.
  */
 export interface QueryMsg {
   is_whitelisted?: IsWhitelisted;
   is_validating?: IsValidating;
   list_vaults?: ListVaults;
+  withdrawal_lock_period?: WithdrawalLockPeriod;
 }
 
 export interface IsValidating {
@@ -74,6 +115,8 @@ export interface ListVaults {
   limit?: number | null;
   start_after?: null | string;
 }
+
+export interface WithdrawalLockPeriod {}
 
 /**
  * The response to the `ListVaults` query. For pagination, the `start_after` field is the


### PR DESCRIPTION
#### What this PR does / why we need it:
In one of other ticket i was working on, I change some type def on bvs-pauser. Tried to generate new schema for that. But turns out it is also generating schemas for a lot of other contract. 


