### PR TITLE
chore: optimize `transfer_owner` to load once

### DIFF
--- a/crates/bvs-library/src/ownership.rs
+++ b/crates/bvs-library/src/ownership.rs
@@ -44,7 +44,7 @@ pub fn transfer_ownership(
 ) -> Result<Response, OwnershipError> {
     assert_owner(storage, &info)?;
 
-    let old_owner = OWNER.load(storage)?;
+    let old_owner = info.sender;
     OWNER.save(storage, &new_owner)?;
     Ok(Response::new().add_event(
         Event::new("TransferredOwnership")


### PR DESCRIPTION
#### What this PR does / why we need it:
In bvs-library transfer ownership func. There's an auth check `assert_owner` that check `info.sender` is the owner of the contract that's in question. In next line, the OWNER state is being loaded again for event emit purposes.  Audit team raise concerns on this redundant loading. 

The fix is simply reuse the `info.sender` as old owner. If the code progress beyond the `assert_owner()` that mean info.sender is indeed the owner the contract and thus info.sender is qualify to be the old owner. 


<!-- remove if not applicable -->
Closes SL-405
