### PR TITLE
chore: remove redundant checks for share sufficiency

### DIFF
--- a/crates/bvs-vault-bank/src/contract.rs
+++ b/crates/bvs-vault-bank/src/contract.rs
@@ -149,10 +149,6 @@ mod execute {
             let balance = bank::query_balance(&deps.as_ref(), &env)?;
             let mut vault = offset::VirtualOffset::load(&deps.as_ref(), balance)?;
 
-            if withdraw_shares > vault.total_shares() {
-                return Err(VaultError::insufficient("Insufficient shares to withdraw.").into());
-            }
-
             let assets = vault.shares_to_assets(withdraw_shares)?;
             if assets.is_zero() {
                 return Err(VaultError::zero("Withdraw assets cannot be zero.").into());
@@ -244,10 +240,6 @@ mod execute {
         let (vault, claimed_assets) = {
             let balance = bank::query_balance(&deps.as_ref(), &env)?;
             let mut vault = offset::VirtualOffset::load(&deps.as_ref(), balance)?;
-
-            if queued_shares > vault.total_shares() {
-                return Err(VaultError::insufficient("Insufficient shares to withdraw.").into());
-            }
 
             let assets = vault.shares_to_assets(queued_shares)?;
             if assets.is_zero() {

--- a/crates/bvs-vault-cw20/src/contract.rs
+++ b/crates/bvs-vault-cw20/src/contract.rs
@@ -150,10 +150,6 @@ mod execute {
             let balance = token::query_balance(&deps.as_ref(), &env)?;
             let mut vault = offset::VirtualOffset::load(&deps.as_ref(), balance)?;
 
-            if msg.amount > vault.total_shares() {
-                return Err(VaultError::insufficient("Insufficient shares to withdraw.").into());
-            }
-
             let assets = vault.shares_to_assets(msg.amount)?;
             if assets.is_zero() {
                 return Err(VaultError::zero("Withdraw assets cannot be zero.").into());
@@ -245,10 +241,6 @@ mod execute {
         let (vault, claimed_assets) = {
             let balance = token::query_balance(&deps.as_ref(), &env)?;
             let mut vault = offset::VirtualOffset::load(&deps.as_ref(), balance)?;
-
-            if queued_shares > vault.total_shares() {
-                return Err(VaultError::insufficient("Insufficient shares to withdraw.").into());
-            }
 
             let assets = vault.shares_to_assets(queued_shares)?;
             if assets.is_zero() {


### PR DESCRIPTION
#### What this PR does / why we need it:

Remove redundant check in `withdraw_to` and `redeem_withdrawal_to` in `bvs-vault-bank` and `bvs-vault-cw20`.

<!-- remove if not applicable -->
Closes SL-407