### PR TITLE
feat: support get vaults by operator in bvs-router

### DIFF
--- a/crates/bvs-vault-router/Cargo.toml
+++ b/crates/bvs-vault-router/Cargo.toml
@@ -34,5 +34,5 @@ bvs-pauser = { workspace = true }
 cw-multi-test = { workspace = true }
 
 [dev-dependencies]
-bvs-vault-bank = { workspace = true }
 bvs-vault-cw20 = { workspace = true }
+bvs-vault-bank = { workspace = true }

--- a/crates/bvs-vault-router/src/contract.rs
+++ b/crates/bvs-vault-router/src/contract.rs
@@ -62,11 +62,12 @@ pub fn execute(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    let old_version = cw2::ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    let old_version =
+        cw2::ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
-    match old_version {
-        1 => migration::migrate_operator_vaults(deps),
-default =>             Ok(Response::default())
+    match old_version.major {
+        1 => migration::map_vaults(deps),
+        _ => Ok(Response::default()),
     }
 }
 

--- a/crates/bvs-vault-router/src/contract.rs
+++ b/crates/bvs-vault-router/src/contract.rs
@@ -787,7 +787,7 @@ mod tests {
 
         // let's test pagination sync this time
         {
-            let mut response1 =
+            let response1 =
                 query::list_vaults_by_operator(deps.as_ref(), operator.clone(), 5, None).unwrap();
             assert_eq!(response1.0.len(), 5);
 

--- a/crates/bvs-vault-router/src/contract.rs
+++ b/crates/bvs-vault-router/src/contract.rs
@@ -66,7 +66,7 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
         cw2::ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
     match old_version.major {
-        1 => migration::map_vaults(deps),
+        1 => migration::migrate_vaults_to_index_operator(deps),
         _ => Ok(Response::default()),
     }
 }
@@ -76,7 +76,7 @@ mod migration {
 
     use super::*;
 
-    pub fn map_vaults(deps: DepsMut) -> Result<Response, ContractError> {
+    pub fn migrate_vaults_to_index_operator(deps: DepsMut) -> Result<Response, ContractError> {
         let vaults = VAULTS
             .keys(deps.storage, None, None, cosmwasm_std::Order::Ascending)
             .collect::<StdResult<Vec<_>>>()?;
@@ -925,7 +925,7 @@ mod tests {
         }
 
         // let's run the migration
-        migration::map_vaults(deps.as_mut()).unwrap();
+        migration::migrate_vaults_to_index_operator(deps.as_mut()).unwrap();
 
         let response =
             query::list_vaults_by_operator(deps.as_ref(), operator1.clone(), 100, None).unwrap();

--- a/crates/bvs-vault-router/src/contract.rs
+++ b/crates/bvs-vault-router/src/contract.rs
@@ -62,14 +62,11 @@ pub fn execute(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    let old_v = cw2::ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    let old_version = cw2::ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
-    match old_v.major == 1 {
-        true => migration::map_vaults(deps),
-        false => {
-            // no-op
-            Ok(Response::default())
-        }
+    match old_version {
+        1 => migration::migrate_operator_vaults(deps),
+default =>             Ok(Response::default())
     }
 }
 

--- a/crates/bvs-vault-router/src/contract.rs
+++ b/crates/bvs-vault-router/src/contract.rs
@@ -371,7 +371,7 @@ mod tests {
     };
     use cosmwasm_std::{
         from_json, Attribute, ContractResult, Event, OwnedDeps, QuerierResult, SystemError,
-        SystemResult, Uint128, Uint64, WasmQuery,
+        SystemResult, Uint64, WasmQuery,
     };
 
     #[test]
@@ -487,15 +487,13 @@ mod tests {
                 .unwrap();
             assert!(!vault.whitelisted);
 
-            let exist = MAPPED_VAULTS
+            MAPPED_VAULTS
                 .may_load(
                     deps.as_ref().storage,
                     (&operator_addr, &vault_contract_addr),
                 )
                 .unwrap()
                 .unwrap();
-
-            assert_eq!(exist, ());
         }
 
         let vault = deps.api.addr_make("vault");

--- a/crates/bvs-vault-router/src/contract.rs
+++ b/crates/bvs-vault-router/src/contract.rs
@@ -75,7 +75,7 @@ mod migration {
 
     pub fn map_vaults(deps: DepsMut) -> Result<Response, ContractError> {
         let vaults = VAULTS
-            .range(deps.storage, None, None, cosmwasm_std::Order::Ascending)
+            .keys(deps.storage, None, None, cosmwasm_std::Order::Ascending)
             .collect::<StdResult<Vec<_>>>()?;
 
         for (vault, _) in vaults {

--- a/crates/bvs-vault-router/src/contract.rs
+++ b/crates/bvs-vault-router/src/contract.rs
@@ -116,7 +116,7 @@ mod execute {
         let vault_info = vault::get_vault_info(deps.as_ref(), &vault)?;
 
         // vault's not connected
-        if whitelisted && vault_info.router != env.contract.address {
+        if vault_info.router != env.contract.address {
             return Err(ContractError::VaultError {
                 msg: "Vault is not connected to the router".to_string(),
             });

--- a/crates/bvs-vault-router/src/contract.rs
+++ b/crates/bvs-vault-router/src/contract.rs
@@ -365,7 +365,7 @@ mod tests {
         message_info, mock_dependencies, mock_env, MockApi, MockQuerier, MockStorage,
     };
     use cosmwasm_std::{
-        from_json, Addr, Attribute, ContractResult, Event, OwnedDeps, QuerierResult, SystemError,
+        from_json, Attribute, ContractResult, Event, OwnedDeps, QuerierResult, SystemError,
         SystemResult, Uint128, Uint64, WasmQuery,
     };
 

--- a/crates/bvs-vault-router/src/contract.rs
+++ b/crates/bvs-vault-router/src/contract.rs
@@ -336,7 +336,7 @@ mod query {
         );
 
         let vaults = items
-            .take(limit.try_into().unwrap())
+            .take(limit as usize)
             .map(|item| {
                 let (k, v) = item?;
                 Ok(Vault {

--- a/crates/bvs-vault-router/src/contract.rs
+++ b/crates/bvs-vault-router/src/contract.rs
@@ -208,7 +208,7 @@ pub mod vault {
         {
             Ok(response) => Ok(response),
             Err(_) => Err(ContractError::VaultError {
-                msg: format!("No such contract: {}", vault.to_string()).to_string(),
+                msg: format!("No such contract: {}", vault).to_string(),
             }),
         }
     }
@@ -487,7 +487,7 @@ mod tests {
                 .may_load(deps.as_ref().storage, &vault_contract_addr)
                 .unwrap()
                 .unwrap();
-            assert_eq!(vault.whitelisted, false);
+            assert!(!vault.whitelisted);
 
             let delegated_service = DELEGATED_SERVICES
                 .may_load(
@@ -497,7 +497,7 @@ mod tests {
                 .unwrap()
                 .unwrap();
 
-            assert_eq!(delegated_service, false);
+            assert!(!delegated_service);
         }
 
         let vault = deps.api.addr_make("vault");
@@ -528,7 +528,7 @@ mod tests {
                 .may_load(deps.as_ref().storage, &vault)
                 .unwrap()
                 .unwrap();
-            assert_eq!(vault.whitelisted, true);
+            assert!(vault.whitelisted);
         }
 
         // whitelist is true and failed to set: No such contract
@@ -546,7 +546,7 @@ mod tests {
             let err = result.unwrap_err();
             assert_eq!(
                 err.to_string(),
-                format!("Vault error: No such contract: {}", empty_vault.to_string())
+                format!("Vault error: No such contract: {}", empty_vault)
             );
         }
 

--- a/crates/bvs-vault-router/src/contract.rs
+++ b/crates/bvs-vault-router/src/contract.rs
@@ -784,6 +784,37 @@ mod tests {
         for i in 0..10 {
             assert_eq!(response.0[i].vault, vaults[i]);
         }
+
+        // let's test pagination sync this time
+        {
+            let mut response1 =
+                query::list_vaults_by_operator(deps.as_ref(), operator.clone(), 5, None).unwrap();
+            assert_eq!(response1.0.len(), 5);
+
+            let next_start_after = response1.0[4].vault.clone();
+
+            let response2 = query::list_vaults_by_operator(
+                deps.as_ref(),
+                operator.clone(),
+                5,
+                Some(next_start_after),
+            )
+            .unwrap();
+
+            assert_eq!(response2.0.len(), 5);
+
+            let mut total_vaults = response1
+                .0
+                .iter()
+                .chain(response2.0.iter())
+                .collect::<Vec<_>>();
+
+            total_vaults.sort_by(|a, b| a.vault.cmp(&b.vault));
+
+            for i in 0..10 {
+                assert_eq!(total_vaults[i].vault, vaults[i]);
+            }
+        }
     }
 
     #[test]

--- a/crates/bvs-vault-router/src/msg.rs
+++ b/crates/bvs-vault-router/src/msg.rs
@@ -10,12 +10,8 @@ pub struct InstantiateMsg {
 
 #[cw_serde]
 pub enum MigrateMsg {
-    MapVaults {
-        /// The operator to vault mapping
-        /// .0 is the operator and .1 is the vault
-        /// In json format it looks like: [["operator1", "vault1"], ["operator2", "vault2"]]
-        map: Vec<(String, String)>,
-    },
+    /// This is a type of payload that trigger the migration of OPERATOR_VAULTS state.
+    MapVaults {},
 }
 
 #[cw_serde]

--- a/crates/bvs-vault-router/src/msg.rs
+++ b/crates/bvs-vault-router/src/msg.rs
@@ -46,6 +46,13 @@ pub enum QueryMsg {
         start_after: Option<String>,
     },
 
+    #[returns(VaultListResponse)]
+    ListVaultsByOperator {
+        operator: String,
+        limit: Option<u32>,
+        start_after: Option<String>,
+    },
+
     /// QueryMsg WithdrawalLockPeriod: returns the withdrawal lock period.
     #[returns(WithdrawalLockPeriodResponse)]
     WithdrawalLockPeriod {},

--- a/crates/bvs-vault-router/src/msg.rs
+++ b/crates/bvs-vault-router/src/msg.rs
@@ -9,6 +9,16 @@ pub struct InstantiateMsg {
 }
 
 #[cw_serde]
+pub enum MigrateMsg {
+    MapVaults {
+        /// The operator to vault mapping
+        /// .0 is the operator and .1 is the vault
+        /// In json format it looks like: [["operator1", "vault1"], ["operator2", "vault2"]]
+        map: Vec<(String, String)>,
+    },
+}
+
+#[cw_serde]
 #[derive(bvs_pauser::api::Display)]
 pub enum ExecuteMsg {
     /// ExecuteMsg SetVault the vault contract in the router and whitelist (true/false) it.

--- a/crates/bvs-vault-router/src/msg.rs
+++ b/crates/bvs-vault-router/src/msg.rs
@@ -2,16 +2,13 @@ use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Uint64};
 
 #[cw_serde]
+pub struct MigrateMsg {}
+
+#[cw_serde]
 pub struct InstantiateMsg {
     pub owner: String,
     pub registry: String,
     pub pauser: String,
-}
-
-#[cw_serde]
-pub enum MigrateMsg {
-    /// This is a type of payload that trigger the migration of OPERATOR_VAULTS state.
-    MapVaults {},
 }
 
 #[cw_serde]

--- a/crates/bvs-vault-router/src/msg.rs
+++ b/crates/bvs-vault-router/src/msg.rs
@@ -56,6 +56,9 @@ pub enum QueryMsg {
         start_after: Option<String>,
     },
 
+    /// QueryMsg ListVaultsByOperator: returns a list of vaults managed by given operator.
+    /// You can provide `limit` and `start_after` to paginate the results.
+    /// The max `limit` is 100.
     #[returns(VaultListResponse)]
     ListVaultsByOperator {
         operator: String,

--- a/crates/bvs-vault-router/src/state.rs
+++ b/crates/bvs-vault-router/src/state.rs
@@ -33,3 +33,6 @@ pub const WITHDRAWAL_LOCK_PERIOD: Item<Uint64> = Item::new("withdrawal_lock_peri
 /// This is used when the withdrawal lock period is not set.
 /// The default value is 7 days.
 pub const DEFAULT_WITHDRAWAL_LOCK_PERIOD: Uint64 = Uint64::new(604800);
+
+/// Operator to its managed vaults
+pub const DELEGATED_SERVICES: Map<(&Addr, &Addr), bool> = Map::new("delegated_services");

--- a/crates/bvs-vault-router/src/state.rs
+++ b/crates/bvs-vault-router/src/state.rs
@@ -34,5 +34,5 @@ pub const WITHDRAWAL_LOCK_PERIOD: Item<Uint64> = Item::new("withdrawal_lock_peri
 /// The default value is 7 days.
 pub const DEFAULT_WITHDRAWAL_LOCK_PERIOD: Uint64 = Uint64::new(604800);
 
-/// Operator to its managed vaults
+/// Operator to its managed vaults. Key = (OperatorAddr, VaultAddr)
 pub const OPERATOR_VAULTS: Map<(&Addr, &Addr), ()> = Map::new("operator_vaults");

--- a/crates/bvs-vault-router/src/state.rs
+++ b/crates/bvs-vault-router/src/state.rs
@@ -35,4 +35,4 @@ pub const WITHDRAWAL_LOCK_PERIOD: Item<Uint64> = Item::new("withdrawal_lock_peri
 pub const DEFAULT_WITHDRAWAL_LOCK_PERIOD: Uint64 = Uint64::new(604800);
 
 /// Operator to its managed vaults
-pub const MAPPED_VAULTS: Map<(&Addr, &Addr), ()> = Map::new("delegated_services");
+pub const OPERATOR_VAULTS: Map<(&Addr, &Addr), ()> = Map::new("delegated_services");

--- a/crates/bvs-vault-router/src/state.rs
+++ b/crates/bvs-vault-router/src/state.rs
@@ -35,4 +35,4 @@ pub const WITHDRAWAL_LOCK_PERIOD: Item<Uint64> = Item::new("withdrawal_lock_peri
 pub const DEFAULT_WITHDRAWAL_LOCK_PERIOD: Uint64 = Uint64::new(604800);
 
 /// Operator to its managed vaults
-pub const OPERATOR_VAULTS: Map<(&Addr, &Addr), ()> = Map::new("delegated_services");
+pub const OPERATOR_VAULTS: Map<(&Addr, &Addr), ()> = Map::new("operator_vaults");

--- a/crates/bvs-vault-router/src/state.rs
+++ b/crates/bvs-vault-router/src/state.rs
@@ -35,4 +35,4 @@ pub const WITHDRAWAL_LOCK_PERIOD: Item<Uint64> = Item::new("withdrawal_lock_peri
 pub const DEFAULT_WITHDRAWAL_LOCK_PERIOD: Uint64 = Uint64::new(604800);
 
 /// Operator to its managed vaults
-pub const DELEGATED_SERVICES: Map<(&Addr, &Addr), bool> = Map::new("delegated_services");
+pub const MAPPED_VAULTS: Map<(&Addr, &Addr), ()> = Map::new("delegated_services");

--- a/crates/bvs-vault-router/tests/integration_test.rs
+++ b/crates/bvs-vault-router/tests/integration_test.rs
@@ -47,10 +47,10 @@ impl TestContracts {
 fn set_vault_whitelist_false_successfully() {
     let (mut app, tc) = TestContracts::init();
     let owner = app.api().addr_make("owner");
-    let vault = app.api().addr_make("vault");
+    let bank_vault = tc.bank_vault.addr();
 
     let msg = &ExecuteMsg::SetVault {
-        vault: vault.to_string(),
+        vault: bank_vault.to_string(),
         whitelisted: false,
     };
 
@@ -62,14 +62,14 @@ fn set_vault_whitelist_false_successfully() {
             Event::new("execute").add_attribute("_contract_address", tc.vault_router.addr.as_str()),
             Event::new("wasm-VaultUpdated")
                 .add_attribute("_contract_address", tc.vault_router.addr.as_str())
-                .add_attribute("vault", vault.to_string())
+                .add_attribute("vault", bank_vault.to_string())
                 .add_attribute("whitelisted", "false"),
         ]
     );
 
     // query is whitelisted
     let msg = QueryMsg::IsWhitelisted {
-        vault: vault.to_string(),
+        vault: bank_vault.to_string(),
     };
     let is_whitelisted: bool = tc.vault_router.query(&mut app, &msg).unwrap();
     assert_eq!(is_whitelisted, false);

--- a/crates/bvs-vault-router/tests/integration_test.rs
+++ b/crates/bvs-vault-router/tests/integration_test.rs
@@ -97,7 +97,10 @@ fn set_vault_whitelist_false_successfully() {
     };
 
     let response: VaultListResponse = tc.vault_router.query(&mut app, &msg).unwrap();
-    assert_eq!(response.0.len(), 1);
+
+    let vault_list = response.0;
+
+    assert_eq!(vault_list[0].vault, bank_vault);
 }
 
 #[test]
@@ -139,7 +142,10 @@ fn set_vault_whitelist_true_bank_vault_successfully() {
     };
 
     let response: VaultListResponse = tc.vault_router.query(&mut app, &msg).unwrap();
-    assert_eq!(response.0.len(), 1);
+
+    let vault_list = response.0;
+
+    assert_eq!(vault_list[0].vault, tc.bank_vault.addr());
 }
 
 #[test]
@@ -182,7 +188,9 @@ fn set_vault_whitelist_true_cw20_vault_successfully() {
 
     let response: VaultListResponse = tc.vault_router.query(&mut app, &msg).unwrap();
 
-    assert_eq!(response.0.len(), 1);
+    let vault_list = response.0;
+
+    assert_eq!(vault_list[0].vault, tc.cw20_vault.addr());
 }
 
 #[test]

--- a/crates/bvs-vault-router/tests/integration_test.rs
+++ b/crates/bvs-vault-router/tests/integration_test.rs
@@ -89,6 +89,15 @@ fn set_vault_whitelist_false_successfully() {
     };
     let response: VaultListResponse = tc.vault_router.query(&mut app, &msg).unwrap();
     assert_eq!(response.0.len(), 1);
+
+    let msg = QueryMsg::ListVaultsByOperator {
+        operator: operator.to_string(),
+        start_after: None,
+        limit: None,
+    };
+
+    let response: VaultListResponse = tc.vault_router.query(&mut app, &msg).unwrap();
+    assert_eq!(response.0.len(), 1);
 }
 
 #[test]
@@ -120,6 +129,17 @@ fn set_vault_whitelist_true_bank_vault_successfully() {
     };
     let is_whitelisted: bool = tc.vault_router.query(&mut app, &msg).unwrap();
     assert!(is_whitelisted);
+
+    let operator = app.api().addr_make("operator");
+
+    let msg = QueryMsg::ListVaultsByOperator {
+        operator: operator.to_string(),
+        start_after: None,
+        limit: None,
+    };
+
+    let response: VaultListResponse = tc.vault_router.query(&mut app, &msg).unwrap();
+    assert_eq!(response.0.len(), 1);
 }
 
 #[test]
@@ -151,6 +171,18 @@ fn set_vault_whitelist_true_cw20_vault_successfully() {
     };
     let is_whitelisted: bool = tc.vault_router.query(&mut app, &msg).unwrap();
     assert!(is_whitelisted);
+
+    let operator = app.api().addr_make("operator");
+
+    let msg = QueryMsg::ListVaultsByOperator {
+        operator: operator.to_string(),
+        start_after: None,
+        limit: None,
+    };
+
+    let response: VaultListResponse = tc.vault_router.query(&mut app, &msg).unwrap();
+
+    assert_eq!(response.0.len(), 1);
 }
 
 #[test]

--- a/crates/bvs-vault-router/tests/integration_test.rs
+++ b/crates/bvs-vault-router/tests/integration_test.rs
@@ -54,7 +54,7 @@ fn set_vault_whitelist_false_successfully() {
         whitelisted: false,
     };
 
-    let response = tc.vault_router.execute(&mut app, &owner, &msg).unwrap();
+    let response = tc.vault_router.execute(&mut app, &owner, msg).unwrap();
 
     assert_eq!(
         response.events,
@@ -72,7 +72,7 @@ fn set_vault_whitelist_false_successfully() {
         vault: bank_vault.to_string(),
     };
     let is_whitelisted: bool = tc.vault_router.query(&mut app, &msg).unwrap();
-    assert_eq!(is_whitelisted, false);
+    assert!(!is_whitelisted);
 
     // query is delegated
     let operator = app.api().addr_make("operator");
@@ -80,7 +80,7 @@ fn set_vault_whitelist_false_successfully() {
         operator: operator.to_string(),
     };
     let is_validating: bool = tc.vault_router.query(&mut app, &msg).unwrap();
-    assert_eq!(is_validating, false);
+    assert!(!is_validating);
 
     // list vaults
     let msg = QueryMsg::ListVaults {
@@ -101,7 +101,7 @@ fn set_vault_whitelist_true_bank_vault_successfully() {
         whitelisted: true,
     };
 
-    let response = tc.vault_router.execute(&mut app, &owner, &msg).unwrap();
+    let response = tc.vault_router.execute(&mut app, &owner, msg).unwrap();
 
     assert_eq!(
         response.events,
@@ -119,7 +119,7 @@ fn set_vault_whitelist_true_bank_vault_successfully() {
         vault: tc.bank_vault.addr().to_string(),
     };
     let is_whitelisted: bool = tc.vault_router.query(&mut app, &msg).unwrap();
-    assert_eq!(is_whitelisted, true);
+    assert!(is_whitelisted);
 }
 
 #[test]
@@ -132,7 +132,7 @@ fn set_vault_whitelist_true_cw20_vault_successfully() {
         whitelisted: true,
     };
 
-    let response = tc.vault_router.execute(&mut app, &owner, &msg).unwrap();
+    let response = tc.vault_router.execute(&mut app, &owner, msg).unwrap();
 
     assert_eq!(
         response.events,
@@ -150,7 +150,7 @@ fn set_vault_whitelist_true_cw20_vault_successfully() {
         vault: tc.cw20_vault.addr().to_string(),
     };
     let is_whitelisted: bool = tc.vault_router.query(&mut app, &msg).unwrap();
-    assert_eq!(is_whitelisted, true);
+    assert!(is_whitelisted);
 }
 
 #[test]
@@ -164,7 +164,7 @@ fn set_withdrawal_lock_period() {
     {
         let msg = &ExecuteMsg::SetWithdrawalLockPeriod(withdrawal_lock_period1);
 
-        let response = tc.vault_router.execute(&mut app, &owner, &msg).unwrap();
+        let response = tc.vault_router.execute(&mut app, &owner, msg).unwrap();
 
         assert_eq!(
             response.events,
@@ -191,7 +191,7 @@ fn set_withdrawal_lock_period() {
     {
         let msg = &ExecuteMsg::SetWithdrawalLockPeriod(withdrawal_lock_period2);
 
-        let response = tc.vault_router.execute(&mut app, &owner, &msg).unwrap();
+        let response = tc.vault_router.execute(&mut app, &owner, msg).unwrap();
 
         assert_eq!(
             response.events,
@@ -230,7 +230,7 @@ fn transfer_ownership_successfully() {
 
     let response = tc
         .vault_router
-        .execute(&mut app, &owner, &transfer_msg)
+        .execute(&mut app, &owner, transfer_msg)
         .unwrap();
 
     assert_eq!(
@@ -256,14 +256,11 @@ fn transfer_ownership_but_not_owner() {
 
     let err = tc
         .vault_router
-        .execute(&mut app, &not_owner, &transfer_msg)
+        .execute(&mut app, &not_owner, transfer_msg)
         .unwrap_err();
 
     assert_eq!(
         err.root_cause().to_string(),
-        ContractError::Ownership {
-            0: OwnershipError::Unauthorized
-        }
-        .to_string()
+        ContractError::Ownership(OwnershipError::Unauthorized).to_string()
     );
 }

--- a/modules/cosmwasm-schema/vault-router/schema.go
+++ b/modules/cosmwasm-schema/vault-router/schema.go
@@ -54,6 +54,7 @@ type QueryMsg struct {
 	IsWhitelisted        *IsWhitelisted        `json:"is_whitelisted,omitempty"`
 	IsValidating         *IsValidating         `json:"is_validating,omitempty"`
 	ListVaults           *ListVaults           `json:"list_vaults,omitempty"`
+	ListVaultsByOperator *ListVaultsByOperator `json:"list_vaults_by_operator,omitempty"`
 	WithdrawalLockPeriod *WithdrawalLockPeriod `json:"withdrawal_lock_period,omitempty"`
 }
 
@@ -67,6 +68,12 @@ type IsWhitelisted struct {
 
 type ListVaults struct {
 	Limit      *int64  `json:"limit"`
+	StartAfter *string `json:"start_after"`
+}
+
+type ListVaultsByOperator struct {
+	Limit      *int64  `json:"limit"`
+	Operator   string  `json:"operator"`
 	StartAfter *string `json:"start_after"`
 }
 

--- a/modules/cosmwasm-schema/vault-router/schema.go
+++ b/modules/cosmwasm-schema/vault-router/schema.go
@@ -49,6 +49,9 @@ type TransferOwnership struct {
 // QueryMsg ListVaults: returns a list of vaults. You can provide `limit` and `start_after`
 // to paginate the results. The max `limit` is 100.
 //
+// QueryMsg ListVaultsByOperator: returns a list of vaults managed by given operator. You
+// can provide `limit` and `start_after` to paginate the results. The max `limit` is 100.
+//
 // QueryMsg WithdrawalLockPeriod: returns the withdrawal lock period.
 type QueryMsg struct {
 	IsWhitelisted        *IsWhitelisted        `json:"is_whitelisted,omitempty"`

--- a/packages/cosmwasm-schema/vault-router.d.ts
+++ b/packages/cosmwasm-schema/vault-router.d.ts
@@ -100,6 +100,7 @@ export interface QueryMsg {
   is_whitelisted?: IsWhitelisted;
   is_validating?: IsValidating;
   list_vaults?: ListVaults;
+  list_vaults_by_operator?: ListVaultsByOperator;
   withdrawal_lock_period?: WithdrawalLockPeriod;
 }
 
@@ -113,6 +114,12 @@ export interface IsWhitelisted {
 
 export interface ListVaults {
   limit?: number | null;
+  start_after?: null | string;
+}
+
+export interface ListVaultsByOperator {
+  limit?: number | null;
+  operator: string;
   start_after?: null | string;
 }
 

--- a/packages/cosmwasm-schema/vault-router.d.ts
+++ b/packages/cosmwasm-schema/vault-router.d.ts
@@ -94,6 +94,9 @@ export interface TransferOwnership {
  * QueryMsg ListVaults: returns a list of vaults. You can provide `limit` and `start_after`
  * to paginate the results. The max `limit` is 100.
  *
+ * QueryMsg ListVaultsByOperator: returns a list of vaults managed by given operator. You
+ * can provide `limit` and `start_after` to paginate the results. The max `limit` is 100.
+ *
  * QueryMsg WithdrawalLockPeriod: returns the withdrawal lock period.
  */
 export interface QueryMsg {


### PR DESCRIPTION
#### What this PR does / why we need it:
Prior to this PR, there's no good way to get all the delegated vault given a particular operator x. 
This PR attempt to provide a query message that given an operator, would return a paginated list of vaults that the specified operator is delegating. 

The most notable in this PR. (Reviewing the codes in order by following order of bullet points is recommended)
- One new state `Map<(&Addr, &Addr), ()>`. Composite key tuple `.0` is ref to operator address and `.1` is ref to vault contract address. And the value is empty tuple.

- Currently the only place this state get mutated is in `setVault()` execute message handler.

- `setVault()` , prior to this PR, do the query msg to the vault only if whitelist is true to check if the vault set its router the same as `env.contract.address`. But introduction of operator to service mapping requires `VaultInfo{}` query regardless of whitelist bool because of the need to grab the operator of the said vault. The changes within `setVault()` are to reflect that. This also make `setVault()` behavior to change in away that all vault prior calling `setVault()` has to be deployed and instantiated. 

- Added a Query Method that return the paginated list of vault belong to the specified operator. The function itself is implemented almost one to one to the original `list_vaults()` func for consistency purpose. Return the same type struct as `list_vaults()`

Besides that, most of the rest of the changes are test, misc, clippy fix like replacement of `assert_eq()` to `assert()` and schema artifacts.

<!-- remove if not applicable -->
Closes SL-412
