### PR TITLE
chore: private: false for bvs-vault-factory

### DIFF
--- a/crates/bvs-vault-factory/package.json
+++ b/crates/bvs-vault-factory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@satlayer/bvs-vault-factory",
-  "private": true,
+  "private": false,
   "files": [
     "dist"
   ],


### PR DESCRIPTION
#### What this PR does / why we need it:


To deploy `@satlayer/bvs-vault-factory` wasm and schema into NPM.