### PR TITLE
chore: verify cosmwasm-schema has not drifted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,18 +74,19 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        directory:
-          - "crates"
-          - "modules"
-          - "packages"
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
 
-      - run: turbo run build --filter="./${{ matrix.directory }}/*"
+      - run: turbo run build
+
+      - name: Drift Detection
+        uses: tj-actions/verify-changed-files@a1c6acee9df209257a246f2cc6ae8cb6581c1edf # v20
+        with:
+          fail-if-changed: true
+          files: |
+            modules/cosmwasm-schema/*/schema.go
+            packages/cosmwasm-schema/*/*.d.ts
 
   test_plan:
     name: Test [plan]

--- a/examples/squaring/modules/go.mod
+++ b/examples/squaring/modules/go.mod
@@ -1,7 +1,7 @@
 module github.com/satlayer/satlayer-bvs/examples/squaring
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.6
+toolchain go1.24.1
 
 replace github.com/satlayer/satlayer-bvs => ../../../modules

--- a/modules/go.mod
+++ b/modules/go.mod
@@ -1,6 +1,6 @@
 module github.com/satlayer/satlayer-bvs
 
-go 1.23.0
+go 1.24.0
 
 toolchain go1.24.1
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Validate that cosmwasm-schema Types has not drifted.

> This PR also update `go.mod` to the latest version.

