### PR TITLE
feat: logistics to allow custom handling of slashed collateral

### DIFF
--- a/crates/bvs-vault-bank/src/contract.rs
+++ b/crates/bvs-vault-bank/src/contract.rs
@@ -565,9 +565,7 @@ mod tests {
                 router::set_router(&mut deps.storage, &router).unwrap();
                 deps.querier.update_wasm(move |query| match query {
                     WasmQuery::Smart { .. } => {
-                        return SystemResult::Ok(ContractResult::Ok(
-                            to_json_binary(&true).unwrap(),
-                        ));
+                        SystemResult::Ok(ContractResult::Ok(to_json_binary(&true).unwrap()))
                     }
                     _ => SystemResult::Err(SystemError::Unknown {}),
                 });

--- a/crates/bvs-vault-bank/src/contract.rs
+++ b/crates/bvs-vault-bank/src/contract.rs
@@ -331,6 +331,12 @@ mod execute {
 
         assert_router(deps.storage, &info)?;
 
+        let vault_balance = bank::query_balance(&deps.as_ref(), &env)?;
+
+        if vault_balance < amount.0 {
+            return Err(VaultError::insufficient("Vault balance is less than amount").into());
+        }
+
         let router = router::get_router(deps.storage)?;
 
         let send_msg = bank::bank_send(deps.storage, &router, amount.0)?;

--- a/crates/bvs-vault-bank/src/contract.rs
+++ b/crates/bvs-vault-bank/src/contract.rs
@@ -60,6 +60,11 @@ pub fn execute(
             msg.validate(deps.api)?;
             execute::redeem_withdrawal_to(deps, env, info, msg)
         }
+        ExecuteMsg::TransferAssetCustody(msg) => {
+            msg.validate(deps.api)?;
+            execute::transfer_asset_custody(deps, env, info, msg)
+        }
+        ExecuteMsg::SetSlashable(flag) => execute::set_slashability(deps, info, env, flag),
     }
 }
 
@@ -68,10 +73,11 @@ mod execute {
     use crate::bank::get_denom;
     use crate::error::ContractError;
     use bvs_vault_base::error::VaultError;
-    use bvs_vault_base::msg::{Recipient, RecipientAmount};
+    use bvs_vault_base::msg::{JailDetail, Recipient, RecipientAmount};
+    use bvs_vault_base::router::assert_router;
     use bvs_vault_base::shares::QueuedWithdrawalInfo;
     use bvs_vault_base::{offset, router, shares};
-    use cosmwasm_std::{DepsMut, Env, Event, MessageInfo, Response, StdError, Timestamp};
+    use cosmwasm_std::{DepsMut, Env, Event, MessageInfo, Response, StdError, Timestamp, Uint128};
 
     /// Deposit an asset (`info.funds`) into the vault through native bank transfer and receive shares.
     ///
@@ -269,6 +275,63 @@ mod execute {
             )
             .add_message(send_msg))
     }
+
+    /// In the event of slashing verdict by the slashing contract,
+    /// this function move custody of all or a portion of asset hold by this vault
+    /// to the jail address.
+    /// Jail can be the slashing contract itself or
+    /// a dedicated contract that will handle what to do with slashed asset.
+    pub fn transfer_asset_custody(
+        deps: DepsMut,
+        env: Env,
+        info: MessageInfo,
+        msg: JailDetail,
+    ) -> Result<Response, ContractError> {
+        bvs_vault_base::slashing::assert_slashable(deps.as_ref().storage)?;
+
+        assert_router(deps.storage, &info)?;
+
+        let new_custodian = msg.jail_address;
+
+        let percentage = Uint128::from(msg.percentage);
+
+        let vault_balance = bank::query_balance(&deps.as_ref(), &env)?;
+
+        let percentage_to_balance = vault_balance
+            .checked_mul(percentage)
+            .map_err(StdError::overflow)?
+            .checked_div(Uint128::from(100u128))
+            .map_err(StdError::divide_by_zero)?;
+
+        let send_msg = bank::bank_send(deps.storage, &new_custodian, percentage_to_balance)?;
+
+        let event = Event::new("TransferAssetCustody")
+            .add_attribute("sender", info.sender)
+            .add_attribute("vault", env.contract.address)
+            .add_attribute("jail_address", new_custodian)
+            .add_attribute("percentage", percentage.to_string());
+
+        Ok(Response::new().add_event(event).add_message(send_msg))
+    }
+
+    pub fn set_slashability(
+        deps: DepsMut,
+        info: MessageInfo,
+        env: Env,
+        flag: bool,
+    ) -> Result<Response, ContractError> {
+        assert_router(deps.storage, &info)?;
+
+        bvs_vault_base::slashing::set_slashable(deps.storage, flag)?;
+
+        let event = Event::new("set_slashable")
+            .add_attribute("action", "set_slashable")
+            .add_attribute("sender", info.sender)
+            .add_attribute("vault", env.contract.address)
+            .add_attribute("slashable", flag.to_string());
+
+        Ok(Response::new().add_event(event))
+    }
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
@@ -353,13 +416,15 @@ mod query {
         let vault = offset::VirtualOffset::load(&deps, balance)?;
         let denom = bank::get_denom(deps.storage)?;
         let version = cw2::get_contract_version(deps.storage)?;
+        let slashable = bvs_vault_base::slashing::get_slashable(deps.storage)?;
+
         Ok(VaultInfoResponse {
             total_shares: vault.total_shares(),
             total_assets: vault.total_assets(),
             router: bvs_vault_base::router::get_router(deps.storage)?,
             pauser: bvs_pauser::api::get_pauser(deps.storage)?,
             operator: bvs_vault_base::router::get_operator(deps.storage)?,
-            slashing: false,
+            slashing: slashable,
             asset_id: format!("cosmos:{}/bank:{}", env.block.chain_id, denom.as_str()),
             contract: version.contract,
             version: version.version,
@@ -442,6 +507,67 @@ mod tests {
                 deps.querier.update_wasm(move |query| match query {
                     WasmQuery::Smart { .. } => {
                         SystemResult::Ok(ContractResult::Ok(to_json_binary(&true).unwrap()))
+                    }
+                    _ => SystemResult::Err(SystemError::Unknown {}),
+                });
+            }
+
+            bank::set_denom(&mut deps.storage, "stone").unwrap();
+            deps.querier
+                .bank
+                .update_balance(&env.contract.address, coins(10_000, "stone"));
+        }
+
+        let info = message_info(&sender, &coins(10000, "stone"));
+        let response = execute::deposit_for(
+            deps.as_mut(),
+            env.clone(),
+            info.clone(),
+            RecipientAmount {
+                recipient: sender.clone(),
+                amount: Uint128::new(10_000),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            response,
+            Response::new().add_event(
+                Event::new("DepositFor")
+                    .add_attribute("sender", info.sender.to_string())
+                    .add_attribute("recipient", info.sender.to_string())
+                    .add_attribute("assets", "10000")
+                    .add_attribute("shares", "10000")
+                    .add_attribute("total_shares", "10000"),
+            )
+        );
+
+        // assert total shares increased
+        let total_shares = offset::get_total_shares(&deps.storage).unwrap();
+        assert_eq!(total_shares, Uint128::new(10_000));
+
+        // assert sender shares increased
+        let sender_shares = shares::get_shares(&deps.storage, &sender).unwrap();
+        assert_eq!(sender_shares, Uint128::new(10_000));
+    }
+
+    #[test]
+    fn test_transfer_custody() {
+        let mut deps = mock_dependencies();
+        let env = mock_env();
+
+        let sender = deps.api.addr_make("sender");
+
+        {
+            // For QueryMsg::IsWhitelisted(vault) = true
+            {
+                let router = deps.api.addr_make("vault_router");
+                router::set_router(&mut deps.storage, &router).unwrap();
+                deps.querier.update_wasm(move |query| match query {
+                    WasmQuery::Smart { .. } => {
+                        return SystemResult::Ok(ContractResult::Ok(
+                            to_json_binary(&true).unwrap(),
+                        ));
                     }
                     _ => SystemResult::Err(SystemError::Unknown {}),
                 });

--- a/crates/bvs-vault-bank/tests/integration_test.rs
+++ b/crates/bvs-vault-bank/tests/integration_test.rs
@@ -1124,7 +1124,7 @@ fn test_transfer_asset_custody(slash_percent: u64) {
 
             // what this above two assert mean is
             // the shares are not reduced but the assets are reduced due to vault wise slashing
-            // asset to share in this case is not out of peg with 1:1 ratio
+            // asset to share in this case is out of peg with 1:1 ratio
             // Share are now inflationary
             // And that is intended.
         }

--- a/crates/bvs-vault-base/src/lib.rs
+++ b/crates/bvs-vault-base/src/lib.rs
@@ -12,4 +12,8 @@ pub mod offset;
 /// Accounting module for vaults that tracks staker shares.
 pub mod shares;
 
+/// Contains slashability flag and assertion functions.
+/// Does not contain slashing logic.
+pub mod slashing;
+
 pub use crate::error::VaultError;

--- a/crates/bvs-vault-base/src/msg.rs
+++ b/crates/bvs-vault-base/src/msg.rs
@@ -49,8 +49,33 @@ pub enum VaultExecuteMsg {
     /// The handling of the slashed asset should not concern the vault contract.
     TransferAssetCustody(JailDetail),
 
+    /// ExecuteMsg SystemLockAsset size the asset by absolute amount.
+    /// This message differs from the `TransferAssetCustody` message in that
+    /// the asset is sized by absolute amount.
+    /// The asset is moved to the router contract, instead of supplied arbitrary contract.
+    /// The asset amount is determined by the router base on strategy.
+    /// Callable by the router contract only.
+    SystemLockAsset(LockAmount),
+
     /// ExecuteMsg Pause the vault contract.
     SetSlashable(bool),
+}
+
+#[cw_serde]
+pub struct LockAmount(pub Uint128);
+
+impl LockAmount {
+    /// Validate the amount: [`Uint128`] field.
+    /// The amount must be greater than zero.
+    pub fn validate(&self, _api: &dyn Api) -> Result<(), VaultError> {
+        if self.0.is_zero() {
+            return Err(VaultError::zero("Amount cannot be zero."));
+        }
+        if self.0 < Uint128::zero() {
+            return Err(VaultError::unauthorized("Amount cannot be negative."));
+        }
+        Ok(())
+    }
 }
 
 #[cw_serde]

--- a/crates/bvs-vault-base/src/msg.rs
+++ b/crates/bvs-vault-base/src/msg.rs
@@ -82,8 +82,8 @@ impl JailDetail {
 
         api.addr_validate(self.jail_address.as_str())?;
 
-        // logical to also check if the precentage is not under 0.
-        // But since precentage type is u64, it is not possible to be negative.
+        // logical to also check if the percentage is not under 0.
+        // But since percentage type is u64, it is not possible to be negative.
         // will fail at parsing.
 
         Ok(())

--- a/crates/bvs-vault-base/src/slashing.rs
+++ b/crates/bvs-vault-base/src/slashing.rs
@@ -1,0 +1,75 @@
+use crate::error::VaultError;
+use cosmwasm_std::{StdResult, Storage};
+use cw_storage_plus::Item;
+
+const SLASHABLE: Item<bool> = Item::new("slashable");
+
+pub fn set_slashable(store: &mut dyn Storage, slashable: bool) -> Result<(), VaultError> {
+    // Set the vault as slashable
+    SLASHABLE.save(store, &slashable)?;
+
+    Ok(())
+}
+
+pub fn get_slashable(store: &dyn Storage) -> StdResult<bool> {
+    match SLASHABLE.may_load(store)? {
+        // The vault is slashable
+        Some(true) => Ok(true),
+
+        // The vault is not slashable
+        Some(false) => Ok(false),
+
+        // For some reason the vault do not have slashability flag set.
+        // Then effectively it is not slashable.
+        None => Ok(false),
+    }
+}
+
+pub fn assert_slashable(store: &dyn Storage) -> Result<(), VaultError> {
+    match SLASHABLE.may_load(store)?.ok_or(VaultError::unauthorized(
+        "The vault do not have slashability flag",
+    )) {
+        // The vault is slashable
+        Ok(true) => Ok(()),
+
+        // The vault is not slashable
+        Ok(false) => Err(VaultError::unauthorized("The vault is not slashable")),
+
+        // For some reason the vault do not have slashability flag set.
+        Err(_) => Err(VaultError::unauthorized(
+            "The vault do not have slashability flag",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::router::set_router;
+
+    use super::*;
+    use cosmwasm_std::{
+        testing::{mock_dependencies, mock_env, MockStorage},
+        MessageInfo,
+    };
+    use cw_multi_test::App;
+
+    #[test]
+    fn test_assert_slashable() {
+        let mut store = MockStorage::new();
+
+        // Test that the vault is not slashable
+        assert!(assert_slashable(&store).is_err());
+
+        // Set the vault as slashable
+        SLASHABLE.save(&mut store, &true).unwrap();
+
+        // Test that the vault is slashable
+        assert!(assert_slashable(&store).is_ok());
+
+        // Set the vault as not slashable
+        SLASHABLE.save(&mut store, &false).unwrap();
+
+        // Test that the vault is not slashable
+        assert!(assert_slashable(&store).is_err());
+    }
+}

--- a/crates/bvs-vault-base/src/slashing.rs
+++ b/crates/bvs-vault-base/src/slashing.rs
@@ -12,17 +12,9 @@ pub fn set_slashable(store: &mut dyn Storage, slashable: bool) -> Result<(), Vau
 }
 
 pub fn get_slashable(store: &dyn Storage) -> StdResult<bool> {
-    match SLASHABLE.may_load(store)? {
-        // The vault is slashable
-        Some(true) => Ok(true),
+    let slashable = SLASHABLE.may_load(store)?.unwrap_or(false);
 
-        // The vault is not slashable
-        Some(false) => Ok(false),
-
-        // For some reason the vault do not have slashability flag set.
-        // Then effectively it is not slashable.
-        None => Ok(false),
-    }
+    Ok(slashable)
 }
 
 pub fn assert_slashable(store: &dyn Storage) -> Result<(), VaultError> {

--- a/crates/bvs-vault-base/src/slashing.rs
+++ b/crates/bvs-vault-base/src/slashing.rs
@@ -36,14 +36,9 @@ pub fn assert_slashable(store: &dyn Storage) -> Result<(), VaultError> {
 
 #[cfg(test)]
 mod tests {
-    use crate::router::set_router;
 
     use super::*;
-    use cosmwasm_std::{
-        testing::{mock_dependencies, mock_env, MockStorage},
-        MessageInfo,
-    };
-    use cw_multi_test::App;
+    use cosmwasm_std::testing::MockStorage;
 
     #[test]
     fn test_assert_slashable() {

--- a/crates/bvs-vault-cw20/src/contract.rs
+++ b/crates/bvs-vault-cw20/src/contract.rs
@@ -77,7 +77,6 @@ pub fn execute(
 }
 
 mod execute {
-    use std::error::Error;
 
     use crate::error::ContractError;
     use crate::token;

--- a/crates/bvs-vault-cw20/src/contract.rs
+++ b/crates/bvs-vault-cw20/src/contract.rs
@@ -71,6 +71,7 @@ pub fn execute(
         }
         ExecuteMsg::SetSlashable(flag) => execute::set_slashability(deps, info, env, flag),
         ExecuteMsg::TransferAssetCustody(msg) => {
+            msg.validate(deps.api)?;
             execute::transfer_asset_custody(deps, env, info, msg)
         }
     }
@@ -426,13 +427,14 @@ mod query {
         let vault = offset::VirtualOffset::load(&deps, balance)?;
         let cw20_contract = token::get_cw20_contract(deps.storage)?;
         let version = cw2::get_contract_version(deps.storage)?;
+        let slashable = bvs_vault_base::slashing::get_slashable(deps.storage)?;
         Ok(VaultInfoResponse {
             total_shares: vault.total_shares(),
             total_assets: vault.total_assets(),
             router: bvs_vault_base::router::get_router(deps.storage)?,
             pauser: bvs_pauser::api::get_pauser(deps.storage)?,
             operator: bvs_vault_base::router::get_operator(deps.storage)?,
-            slashing: false,
+            slashing: slashable,
             asset_id: format!(
                 "cosmos:{}/cw20:{}",
                 env.block.chain_id,

--- a/crates/bvs-vault-cw20/tests/integration_test.rs
+++ b/crates/bvs-vault-cw20/tests/integration_test.rs
@@ -473,7 +473,7 @@ fn test_transfer_asset_custody(slash_percent: u64) {
             recipient: staker.clone(),
             amount: Uint128::new(original_stake_amount),
         });
-        cw20.increase_allowance(app, &staker, &vault.addr(), 100e15 as u128);
+        cw20.increase_allowance(app, &staker, vault.addr(), 100e15 as u128);
         cw20.fund(app, &staker, 100e15 as u128);
         vault.execute(app, &staker, &msg).unwrap();
 
@@ -481,16 +481,16 @@ fn test_transfer_asset_custody(slash_percent: u64) {
             let staker_balance = cw20.balance(app, &staker);
             assert_eq!(staker_balance, (100e15 as u128) - (original_stake_amount));
 
-            let contract_balance = cw20.balance(app, &vault.addr());
+            let contract_balance = cw20.balance(app, vault.addr());
             assert_eq!(contract_balance, original_stake_amount * (i + 1));
 
             let query_shares = QueryMsg::Shares {
                 staker: staker.to_string(),
             };
-            let shares: Uint128 = vault.query(&app, &query_shares).unwrap();
+            let shares: Uint128 = vault.query(app, &query_shares).unwrap();
             assert_eq!(shares, Uint128::new(original_stake_amount));
 
-            let total_shares: Uint128 = vault.query(&app, &QueryMsg::TotalShares {}).unwrap();
+            let total_shares: Uint128 = vault.query(app, &QueryMsg::TotalShares {}).unwrap();
             assert_eq!(total_shares, Uint128::new(original_stake_amount * (i + 1)));
         }
     }
@@ -502,7 +502,7 @@ fn test_transfer_asset_custody(slash_percent: u64) {
     }
 
     let jail_address = app.api().addr_make("jail_address");
-    let vault_balance_preslash = cw20.balance(app, &vault.addr());
+    let vault_balance_preslash = cw20.balance(app, vault.addr());
     {
         let msg = ExecuteMsg::TransferAssetCustody(JailDetail {
             jail_address: jail_address.clone(),
@@ -510,7 +510,7 @@ fn test_transfer_asset_custody(slash_percent: u64) {
         });
         vault.execute(app, router.addr(), &msg).unwrap();
 
-        let vault_balance_post_slash = cw20.balance(app, &vault.addr());
+        let vault_balance_post_slash = cw20.balance(app, vault.addr());
 
         let jail_balance = cw20.balance(app, &jail_address);
 
@@ -530,13 +530,13 @@ fn test_transfer_asset_custody(slash_percent: u64) {
             };
 
             // shares of the staker stays the same
-            let shares: Uint128 = vault.query(&app, &get_shares_msg).unwrap();
+            let shares: Uint128 = vault.query(app, &get_shares_msg).unwrap();
             assert_eq!(shares, Uint128::new(original_stake_amount));
 
             let get_assets_msg = QueryMsg::Assets {
                 staker: staker.to_string(),
             };
-            let assets: Uint128 = vault.query(&app, &get_assets_msg).unwrap();
+            let assets: Uint128 = vault.query(app, &get_assets_msg).unwrap();
 
             // assets of the staker is reduced by the slash_percent
             let expected_assets_for_stake_post_slash = Uint128::from(original_stake_amount)

--- a/modules/cosmwasm-schema/vault-bank/schema.go
+++ b/modules/cosmwasm-schema/vault-bank/schema.go
@@ -52,17 +52,37 @@ type InstantiateMsg struct {
 // ExecuteMsg RedeemWithdrawal all queued shares into assets from the vault for withdrawal.
 // After the lock period, the `sender` (must be the `recipient` of the original withdrawal)
 // can redeem the withdrawal.
+//
+// ExecuteMsg TransferCustody release the right to be custodian of all or a portion of
+// asset. In the event of an operator has been convicted of a crime, slash verdict has
+// reached, The asset will be slashed. Asset being slashed will be sent to the jail address.
+// The operator no longer has access to the slashed assets. The slashed assets will then be
+// decided to be burned or allocated for further utility by the jail contract. The handling
+// of the slashed asset should not concern the vault contract.
+//
+// ExecuteMsg Pause the vault contract.
 type ExecuteMsg struct {
-	DepositFor         *RecipientAmount `json:"deposit_for,omitempty"`
-	WithdrawTo         *RecipientAmount `json:"withdraw_to,omitempty"`
-	QueueWithdrawalTo  *RecipientAmount `json:"queue_withdrawal_to,omitempty"`
-	RedeemWithdrawalTo *string          `json:"redeem_withdrawal_to,omitempty"`
+	DepositFor           *RecipientAmount `json:"deposit_for,omitempty"`
+	WithdrawTo           *RecipientAmount `json:"withdraw_to,omitempty"`
+	QueueWithdrawalTo    *RecipientAmount `json:"queue_withdrawal_to,omitempty"`
+	RedeemWithdrawalTo   *string          `json:"redeem_withdrawal_to,omitempty"`
+	TransferAssetCustody *JailDetail      `json:"transfer_asset_custody,omitempty"`
+	SetSlashable         *bool            `json:"set_slashable,omitempty"`
 }
 
 // This struct is used to represent the recipient and amount fields together.
 type RecipientAmount struct {
 	Amount    string `json:"amount"`
 	Recipient string `json:"recipient"`
+}
+
+type JailDetail struct {
+	// The address that will receive the slashed asset. The address is recommended to be a
+	// contract that will handle what to do with slashed asset. The jail contract address will
+	// either simply burn or allocate for further utility is up to the third party project.
+	JailAddress string `json:"jail_address"`
+	// The percentage of asset to be seized.
+	Percentage int64 `json:"percentage"`
 }
 
 // QueryMsg Shares: get the shares of a staker.

--- a/modules/cosmwasm-schema/vault-cw20/schema.go
+++ b/modules/cosmwasm-schema/vault-cw20/schema.go
@@ -61,17 +61,37 @@ type InstantiateMsg struct {
 // ExecuteMsg RedeemWithdrawal all queued shares into assets from the vault for withdrawal.
 // After the lock period, the `sender` (must be the `recipient` of the original withdrawal)
 // can redeem the withdrawal.
+//
+// ExecuteMsg TransferCustody release the right to be custodian of all or a portion of
+// asset. In the event of an operator has been convicted of a crime, slash verdict has
+// reached, The asset will be slashed. Asset being slashed will be sent to the jail address.
+// The operator no longer has access to the slashed assets. The slashed assets will then be
+// decided to be burned or allocated for further utility by the jail contract. The handling
+// of the slashed asset should not concern the vault contract.
+//
+// ExecuteMsg Pause the vault contract.
 type ExecuteMsg struct {
-	DepositFor         *RecipientAmount `json:"deposit_for,omitempty"`
-	WithdrawTo         *RecipientAmount `json:"withdraw_to,omitempty"`
-	QueueWithdrawalTo  *RecipientAmount `json:"queue_withdrawal_to,omitempty"`
-	RedeemWithdrawalTo *string          `json:"redeem_withdrawal_to,omitempty"`
+	DepositFor           *RecipientAmount `json:"deposit_for,omitempty"`
+	WithdrawTo           *RecipientAmount `json:"withdraw_to,omitempty"`
+	QueueWithdrawalTo    *RecipientAmount `json:"queue_withdrawal_to,omitempty"`
+	RedeemWithdrawalTo   *string          `json:"redeem_withdrawal_to,omitempty"`
+	TransferAssetCustody *JailDetail      `json:"transfer_asset_custody,omitempty"`
+	SetSlashable         *bool            `json:"set_slashable,omitempty"`
 }
 
 // This struct is used to represent the recipient and amount fields together.
 type RecipientAmount struct {
 	Amount    string `json:"amount"`
 	Recipient string `json:"recipient"`
+}
+
+type JailDetail struct {
+	// The address that will receive the slashed asset. The address is recommended to be a
+	// contract that will handle what to do with slashed asset. The jail contract address will
+	// either simply burn or allocate for further utility is up to the third party project.
+	JailAddress string `json:"jail_address"`
+	// The percentage of asset to be seized.
+	Percentage int64 `json:"percentage"`
 }
 
 // QueryMsg Shares: get the shares of a staker.

--- a/packages/cosmwasm-schema/vault-bank.d.ts
+++ b/packages/cosmwasm-schema/vault-bank.d.ts
@@ -35,6 +35,10 @@
  *
  * This struct is used to represent a recipient for RedeemWithdrawalTo.
  *
+ * The address that will receive the slashed asset. The address is recommended to be a
+ * contract that will handle what to do with slashed asset. The jail contract address will
+ * either simply burn or allocate for further utility is up to the third party project.
+ *
  * The response to the `Assets` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
  *
@@ -123,6 +127,10 @@ type AssetsResponse = string;
  * instance.
  *
  * This struct is used to represent a recipient for RedeemWithdrawalTo.
+ *
+ * The address that will receive the slashed asset. The address is recommended to be a
+ * contract that will handle what to do with slashed asset. The jail contract address will
+ * either simply burn or allocate for further utility is up to the third party project.
  *
  * The response to the `Assets` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
@@ -213,6 +221,10 @@ type ConvertToAssetsResponse = string;
  *
  * This struct is used to represent a recipient for RedeemWithdrawalTo.
  *
+ * The address that will receive the slashed asset. The address is recommended to be a
+ * contract that will handle what to do with slashed asset. The jail contract address will
+ * either simply burn or allocate for further utility is up to the third party project.
+ *
  * The response to the `Assets` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
  *
@@ -301,6 +313,10 @@ type ConvertToSharesResponse = string;
  * instance.
  *
  * This struct is used to represent a recipient for RedeemWithdrawalTo.
+ *
+ * The address that will receive the slashed asset. The address is recommended to be a
+ * contract that will handle what to do with slashed asset. The jail contract address will
+ * either simply burn or allocate for further utility is up to the third party project.
  *
  * The response to the `Assets` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
@@ -391,6 +407,10 @@ type SharesResponse = string;
  *
  * This struct is used to represent a recipient for RedeemWithdrawalTo.
  *
+ * The address that will receive the slashed asset. The address is recommended to be a
+ * contract that will handle what to do with slashed asset. The jail contract address will
+ * either simply burn or allocate for further utility is up to the third party project.
+ *
  * The response to the `Assets` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
  *
@@ -479,6 +499,10 @@ type TotalAssetsResponse = string;
  * instance.
  *
  * This struct is used to represent a recipient for RedeemWithdrawalTo.
+ *
+ * The address that will receive the slashed asset. The address is recommended to be a
+ * contract that will handle what to do with slashed asset. The jail contract address will
+ * either simply burn or allocate for further utility is up to the third party project.
  *
  * The response to the `Assets` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
@@ -581,12 +605,23 @@ export interface InstantiateMsg {
  * ExecuteMsg RedeemWithdrawal all queued shares into assets from the vault for withdrawal.
  * After the lock period, the `sender` (must be the `recipient` of the original withdrawal)
  * can redeem the withdrawal.
+ *
+ * ExecuteMsg TransferCustody release the right to be custodian of all or a portion of
+ * asset. In the event of an operator has been convicted of a crime, slash verdict has
+ * reached, The asset will be slashed. Asset being slashed will be sent to the jail address.
+ * The operator no longer has access to the slashed assets. The slashed assets will then be
+ * decided to be burned or allocated for further utility by the jail contract. The handling
+ * of the slashed asset should not concern the vault contract.
+ *
+ * ExecuteMsg Pause the vault contract.
  */
 export interface ExecuteMsg {
   deposit_for?: RecipientAmount;
   withdraw_to?: RecipientAmount;
   queue_withdrawal_to?: RecipientAmount;
   redeem_withdrawal_to?: string;
+  transfer_asset_custody?: JailDetail;
+  set_slashable?: boolean;
 }
 
 /**
@@ -595,6 +630,19 @@ export interface ExecuteMsg {
 export interface RecipientAmount {
   amount: string;
   recipient: string;
+}
+
+export interface JailDetail {
+  /**
+   * The address that will receive the slashed asset. The address is recommended to be a
+   * contract that will handle what to do with slashed asset. The jail contract address will
+   * either simply burn or allocate for further utility is up to the third party project.
+   */
+  jail_address: string;
+  /**
+   * The percentage of asset to be seized.
+   */
+  percentage: number;
 }
 
 /**

--- a/packages/cosmwasm-schema/vault-cw20.d.ts
+++ b/packages/cosmwasm-schema/vault-cw20.d.ts
@@ -35,6 +35,10 @@
  *
  * This struct is used to represent a recipient for RedeemWithdrawalTo.
  *
+ * The address that will receive the slashed asset. The address is recommended to be a
+ * contract that will handle what to do with slashed asset. The jail contract address will
+ * either simply burn or allocate for further utility is up to the third party project.
+ *
  * The response to the `Assets` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
  *
@@ -123,6 +127,10 @@ type AssetsResponse = string;
  * instance.
  *
  * This struct is used to represent a recipient for RedeemWithdrawalTo.
+ *
+ * The address that will receive the slashed asset. The address is recommended to be a
+ * contract that will handle what to do with slashed asset. The jail contract address will
+ * either simply burn or allocate for further utility is up to the third party project.
  *
  * The response to the `Assets` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
@@ -213,6 +221,10 @@ type ConvertToAssetsResponse = string;
  *
  * This struct is used to represent a recipient for RedeemWithdrawalTo.
  *
+ * The address that will receive the slashed asset. The address is recommended to be a
+ * contract that will handle what to do with slashed asset. The jail contract address will
+ * either simply burn or allocate for further utility is up to the third party project.
+ *
  * The response to the `Assets` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
  *
@@ -301,6 +313,10 @@ type ConvertToSharesResponse = string;
  * instance.
  *
  * This struct is used to represent a recipient for RedeemWithdrawalTo.
+ *
+ * The address that will receive the slashed asset. The address is recommended to be a
+ * contract that will handle what to do with slashed asset. The jail contract address will
+ * either simply burn or allocate for further utility is up to the third party project.
  *
  * The response to the `Assets` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
@@ -391,6 +407,10 @@ type SharesResponse = string;
  *
  * This struct is used to represent a recipient for RedeemWithdrawalTo.
  *
+ * The address that will receive the slashed asset. The address is recommended to be a
+ * contract that will handle what to do with slashed asset. The jail contract address will
+ * either simply burn or allocate for further utility is up to the third party project.
+ *
  * The response to the `Assets` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
  *
@@ -479,6 +499,10 @@ type TotalAssetsResponse = string;
  * instance.
  *
  * This struct is used to represent a recipient for RedeemWithdrawalTo.
+ *
+ * The address that will receive the slashed asset. The address is recommended to be a
+ * contract that will handle what to do with slashed asset. The jail contract address will
+ * either simply burn or allocate for further utility is up to the third party project.
  *
  * The response to the `Assets` query. Not exported. This is just a wrapper around
  * `Uint128`, so that the schema can be generated.
@@ -590,12 +614,23 @@ export interface InstantiateMsg {
  * ExecuteMsg RedeemWithdrawal all queued shares into assets from the vault for withdrawal.
  * After the lock period, the `sender` (must be the `recipient` of the original withdrawal)
  * can redeem the withdrawal.
+ *
+ * ExecuteMsg TransferCustody release the right to be custodian of all or a portion of
+ * asset. In the event of an operator has been convicted of a crime, slash verdict has
+ * reached, The asset will be slashed. Asset being slashed will be sent to the jail address.
+ * The operator no longer has access to the slashed assets. The slashed assets will then be
+ * decided to be burned or allocated for further utility by the jail contract. The handling
+ * of the slashed asset should not concern the vault contract.
+ *
+ * ExecuteMsg Pause the vault contract.
  */
 export interface ExecuteMsg {
   deposit_for?: RecipientAmount;
   withdraw_to?: RecipientAmount;
   queue_withdrawal_to?: RecipientAmount;
   redeem_withdrawal_to?: string;
+  transfer_asset_custody?: JailDetail;
+  set_slashable?: boolean;
 }
 
 /**
@@ -604,6 +639,19 @@ export interface ExecuteMsg {
 export interface RecipientAmount {
   amount: string;
   recipient: string;
+}
+
+export interface JailDetail {
+  /**
+   * The address that will receive the slashed asset. The address is recommended to be a
+   * contract that will handle what to do with slashed asset. The jail contract address will
+   * either simply burn or allocate for further utility is up to the third party project.
+   */
+  jail_address: string;
+  /**
+   * The percentage of asset to be seized.
+   */
+  percentage: number;
 }
 
 /**


### PR DESCRIPTION
#### What this PR does / why we need it:

# Background
As part of on going custom slashing capabilities effort for satlayer protocol - established that slashing stages can be group into 3 regardless of strategy.  

1. proposal of slash
2. consensus of slash 
3. slash trigger

The change in the PR can be categorized into part of step 3.

# Why we need this PR
However varies slashing strategy may be - eventually the slashing contract may reach a verdict to find an operator guilty of misbehavior, - in that case the staking vaults that hold the actual asset should give up control of the asset. Traditionally slashed asset get burn. But satlayer protocol also want to attempt to allow the custom handling of slashed assets to the partner services. For example - a service will want slashed asset to be used for humanitarian purpose or quiet simply want to burn it. The changes in the PR is to support these custom logic by third parties to happen RATHER than actual handling of what happened to the slashed assets.

# Notable changes
The notable changes in the PR includes 
1. `bvs-vault-base` this module house the  introduction of 3 more execute msg - `SetSlashable` which allow the config to enable slashing for this vault or not -> powered by state defined in `slashing.rs`. `slashing.rs` includes the actual bool state that indicate slashing on/off, getter , setter , assertation functions.`TransferAssetCustody()` Takes which  address to transfer the asset to and how much % of the total asset to be transferred.  Intended to be callable by router. Requires slashing enabled.  There's another spcecial slashing support msg call `SystemLockAsset()` This serve same overall bigger picture as `TransferAssetCustody()` but differs in two aspect -> asset are move to router and the amount is absolute rather than a %. Since the asset are move to the satlayer controlled router contract rather than jail address, it's locked by the system thus `SystemLockAsset()`.  
2. bvs-vault-bank - Actual implementation of above 3 new execute msg for.
3. bvs-vault-cw20 - Actual implementation of above 3 new execute msg for.
5. Integration tests for both vault.

# More clarification regarding jail vault 
In the PR - should reviewer notice jail address in the payload of the `TransferAssetCustody()` -> is simply , an address at which the slashed address are being moved to. Recommended design is this jail address should be a smart contract that will handle the consensus and logic for what's going to happen to the slashed asset. To simply get burn or further utility.

The jail vault can also be the slashing contract itself if it chooses to handle it.

```mermaid
flowchart TD
    A[bvs-slash-x-strategy]
    B[bvs-vault-bank or bvs-vault-cw20]
    C[bvs-jail]
    D[bvs-router]

    A --> |1.Trigger a particular Slash after consensus has reached| D
    D --> |2.Trigger the removal of slashed collateral from the vault, TransferAssetCustody| B
    B --> |3.Transfer the asset using bank transfer or cw transfer to the jail| C
    C --> |4.Jail decided should slashed assets be burnt or further utility| C
```






<!-- remove if not applicable -->
Closes SL-393 , SL-428