### PR TITLE
chore: run `cargo clippy --fix` on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,17 @@ jobs:
 
       - name: Drift Detection
         uses: tj-actions/verify-changed-files@a1c6acee9df209257a246f2cc6ae8cb6581c1edf # v20
+        id: drifted-files
         with:
           fail-if-changed: true
           files: |
             crates/*/**.rs
+
+      - if: steps.drifted-files.outputs.files_changed == 'true'
+        env:
+          CHANGED_FILES: ${{ steps.drifted-files.outputs.changed_files }}
+        run: |
+          echo "Changed files: $CHANGED_FILES"
 
   lint_eslint:
     name: Lint [eslint]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,18 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
 
-      - run: cargo clippy -- -D warnings
+      - run: cargo clippy --fix
         working-directory: ./crates
+
+      - run: cargo clippy -- -Dwarnings
+        working-directory: ./crates
+
+      - name: Drift Detection
+        uses: tj-actions/verify-changed-files@a1c6acee9df209257a246f2cc6ae8cb6581c1edf # v20
+        with:
+          fail-if-changed: true
+          files: |
+            crates/*/**.rs
 
   lint_eslint:
     name: Lint [eslint]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           fail-if-changed: true
           files: |
-            crates/*/**.rs
+            crates/**/*.rs
 
       - if: failure()
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           files: |
             crates/*/**.rs
 
-      - if: steps.drifted-files.outputs.files_changed == 'true'
+      - if: always() && steps.drifted-files.outputs.files_changed == 'true'
         env:
           CHANGED_FILES: ${{ steps.drifted-files.outputs.changed_files }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           files: |
             crates/*/**.rs
 
-      - if: always() && steps.drifted-files.outputs.files_changed == 'true'
+      - if: failure()
         env:
           CHANGED_FILES: ${{ steps.drifted-files.outputs.changed_files }}
         run: |

--- a/crates/bvs-library/src/testing/account.rs
+++ b/crates/bvs-library/src/testing/account.rs
@@ -120,6 +120,6 @@ mod tests {
             &account.public_key.serialize(),
         )
         .unwrap();
-        assert_eq!(verify_res, true);
+        assert!(verify_res);
     }
 }

--- a/crates/bvs-pauser/src/contract.rs
+++ b/crates/bvs-pauser/src/contract.rs
@@ -149,7 +149,7 @@ mod tests {
         )
         .unwrap();
         let value: IsPausedResponse = from_json(&res).unwrap();
-        assert_eq!(false, value.is_paused());
+        assert!(!value.is_paused());
     }
 
     #[test]
@@ -169,7 +169,7 @@ mod tests {
         let method = "any_method".to_string();
 
         let response = query::is_paused(deps.as_ref(), contract.clone(), method.clone()).unwrap();
-        assert_eq!(response.is_paused(), true);
+        assert!(response.is_paused());
 
         let response = query::can_execute(deps.as_ref(), contract, sender, method).unwrap();
         let flag: CanExecuteFlag = response.into();
@@ -195,7 +195,7 @@ mod tests {
 
         {
             let res = query::is_paused(deps.as_ref(), contract.clone(), method.clone()).unwrap();
-            assert_eq!(res.is_paused(), false);
+            assert!(!res.is_paused());
 
             let res = query::can_execute(deps.as_ref(), contract, sender, method).unwrap();
             let flag: CanExecuteFlag = res.into();
@@ -221,7 +221,7 @@ mod tests {
 
         {
             let res = query::is_paused(deps.as_ref(), contract.clone(), method.clone()).unwrap();
-            assert_eq!(res.is_paused(), false);
+            assert!(!res.is_paused());
 
             let res = query::can_execute(deps.as_ref(), contract, sender, method).unwrap();
             let flag: CanExecuteFlag = res.into();
@@ -248,7 +248,7 @@ mod tests {
 
         {
             let res = query::is_paused(deps.as_ref(), contract.clone(), method.clone()).unwrap();
-            assert_eq!(res.is_paused(), true);
+            assert!(res.is_paused());
 
             let res = query::can_execute(deps.as_ref(), contract, sender, method).unwrap();
             let flag: CanExecuteFlag = res.into();
@@ -271,12 +271,12 @@ mod tests {
         execute::pause(deps.as_mut(), info.clone()).unwrap();
 
         let res = query::is_paused(deps.as_ref(), contract.clone(), method.clone()).unwrap();
-        assert_eq!(res.is_paused(), true);
+        assert!(res.is_paused());
 
         execute::pause(deps.as_mut(), info).unwrap();
 
         let res = query::is_paused(deps.as_ref(), contract.clone(), method.clone()).unwrap();
-        assert_eq!(res.is_paused(), true);
+        assert!(res.is_paused());
 
         let sender = deps.api.addr_make("sender");
         let res = query::can_execute(deps.as_ref(), contract, sender, method).unwrap();

--- a/crates/bvs-pauser/src/msg.rs
+++ b/crates/bvs-pauser/src/msg.rs
@@ -94,10 +94,10 @@ mod tests {
     #[test]
     fn test_paused() {
         let msg = IsPausedResponse::new(true);
-        assert_eq!(msg.is_paused(), true);
+        assert!(msg.is_paused());
 
         let msg = IsPausedResponse::new(false);
-        assert_eq!(msg.is_paused(), false);
+        assert!(!msg.is_paused());
     }
 
     /// Test the raw value of the IsPausedResponse
@@ -105,10 +105,10 @@ mod tests {
     #[test]
     fn test_paused_raw() {
         let msg = IsPausedResponse(0);
-        assert_eq!(msg.is_paused(), false);
+        assert!(!msg.is_paused());
 
         let msg = IsPausedResponse(1);
-        assert_eq!(msg.is_paused(), true);
+        assert!(msg.is_paused());
     }
 
     #[test]

--- a/crates/bvs-pauser/tests/integration_tests.rs
+++ b/crates/bvs-pauser/tests/integration_tests.rs
@@ -21,7 +21,7 @@ fn pause_unpause() {
     {
         let owner = app.api().addr_make("owner");
         let msg = &ExecuteMsg::Pause {};
-        let res = contract.execute(&mut app, &owner, &msg).unwrap();
+        let res = contract.execute(&mut app, &owner, msg).unwrap();
 
         assert_eq!(res.events.len(), 2);
         assert_eq!(
@@ -39,7 +39,7 @@ fn pause_unpause() {
             method: "any".to_string(),
         };
         let res: IsPausedResponse = contract.query(&app, &msg).unwrap();
-        assert_eq!(res.is_paused(), true);
+        assert!(res.is_paused());
 
         let msg = QueryMsg::CanExecute {
             contract: app.api().addr_make("caller").to_string(),
@@ -55,7 +55,7 @@ fn pause_unpause() {
     {
         let owner = app.api().addr_make("owner");
         let msg = &ExecuteMsg::Unpause {};
-        let res = contract.execute(&mut app, &owner, &msg).unwrap();
+        let res = contract.execute(&mut app, &owner, msg).unwrap();
 
         assert_eq!(res.events.len(), 2);
 
@@ -74,7 +74,7 @@ fn pause_unpause() {
             method: "any".to_string(),
         };
         let res: IsPausedResponse = contract.query(&app, &msg).unwrap();
-        assert_eq!(res.is_paused(), false);
+        assert!(!res.is_paused());
 
         let msg = QueryMsg::CanExecute {
             contract: app.api().addr_make("caller").to_string(),
@@ -112,7 +112,7 @@ fn unauthorized_pause() {
             method: "any".to_string(),
         };
         let res: IsPausedResponse = contract.query(&app, &msg).unwrap();
-        assert_eq!(res.is_paused(), false);
+        assert!(!res.is_paused());
 
         let msg = QueryMsg::CanExecute {
             contract: app.api().addr_make("caller").to_string(),
@@ -151,7 +151,7 @@ fn unauthorized_unpause() {
         };
         let res: IsPausedResponse = contract.query(&app, &msg).unwrap();
 
-        assert_eq!(res.is_paused(), true);
+        assert!(res.is_paused());
 
         let msg = QueryMsg::CanExecute {
             contract: app.api().addr_make("caller").to_string(),

--- a/crates/bvs-registry/src/state.rs
+++ b/crates/bvs-registry/src/state.rs
@@ -152,7 +152,7 @@ mod tests {
 
         // assert that the operator is not active
         let res = is_operator_active(&deps.storage, &operator).unwrap();
-        assert_eq!(res, false);
+        assert!(!res);
 
         // set the operator active count to 1
         OPERATOR_ACTIVE_REGISTRATION_COUNT
@@ -161,11 +161,11 @@ mod tests {
 
         // assert that the operator is active
         let res = is_operator_active(&deps.storage, &operator).unwrap();
-        assert_eq!(res, true);
+        assert!(res);
 
         // assert that the operator2 is not active
         let res = is_operator_active(&deps.storage, &operator2).unwrap();
-        assert_eq!(res, false);
+        assert!(!res);
     }
 
     #[test]

--- a/crates/bvs-registry/tests/integration_test.rs
+++ b/crates/bvs-registry/tests/integration_test.rs
@@ -30,7 +30,7 @@ fn register_service_successfully() {
     };
 
     let service = app.api().addr_make("service/11111");
-    let response = registry.execute(&mut app, &service, &register_msg).unwrap();
+    let response = registry.execute(&mut app, &service, register_msg).unwrap();
 
     assert_eq!(
         response.events,
@@ -65,7 +65,7 @@ fn register_service_but_paused() {
         .unwrap();
 
     let err = registry
-        .execute(&mut app, &owner, &register_msg)
+        .execute(&mut app, &owner, register_msg)
         .unwrap_err();
 
     assert_eq!(
@@ -86,10 +86,10 @@ fn register_service_but_already_registered() {
     };
 
     let service = app.api().addr_make("service/11111");
-    registry.execute(&mut app, &service, &register_msg).unwrap();
+    registry.execute(&mut app, &service, register_msg).unwrap();
 
     let err = registry
-        .execute(&mut app, &service, &register_msg)
+        .execute(&mut app, &service, register_msg)
         .unwrap_err();
 
     assert_eq!(
@@ -108,7 +108,7 @@ fn operator_register_service_but_service_not_registered() {
     };
 
     let err = registry
-        .execute(&mut app, &operator, &register_msg)
+        .execute(&mut app, &operator, register_msg)
         .unwrap_err();
 
     assert_eq!(
@@ -130,14 +130,14 @@ fn operator_register_service_but_self_not_operator() {
     };
 
     let service = app.api().addr_make("service/11111");
-    registry.execute(&mut app, &service, &register_msg).unwrap();
+    registry.execute(&mut app, &service, register_msg).unwrap();
 
     let register_msg = &ExecuteMsg::RegisterServiceToOperator {
         service: service.to_string(),
     };
 
     let err = registry
-        .execute(&mut app, &not_operator, &register_msg)
+        .execute(&mut app, &not_operator, register_msg)
         .unwrap_err();
 
     assert_eq!(
@@ -159,7 +159,7 @@ fn register_lifecycle_operator_first() {
     };
     let service = app.api().addr_make("service/bvs");
     registry
-        .execute(&mut app, &service, &register_as_service_msg)
+        .execute(&mut app, &service, register_as_service_msg)
         .unwrap();
 
     // Register as Operator
@@ -171,16 +171,14 @@ fn register_lifecycle_operator_first() {
     };
     let operator = app.api().addr_make("operator");
     registry
-        .execute(&mut app, &operator, &register_as_operator_msg)
+        .execute(&mut app, &operator, register_as_operator_msg)
         .unwrap();
 
     // Register Service to Operator
     let register_msg = &ExecuteMsg::RegisterServiceToOperator {
         service: service.to_string(),
     };
-    let res = registry
-        .execute(&mut app, &operator, &register_msg)
-        .unwrap();
+    let res = registry.execute(&mut app, &operator, register_msg).unwrap();
     assert_eq!(
         res.events,
         vec![
@@ -211,7 +209,7 @@ fn register_lifecycle_operator_first() {
         operator: operator.to_string(),
     };
 
-    let res = registry.execute(&mut app, &service, &register_msg).unwrap();
+    let res = registry.execute(&mut app, &service, register_msg).unwrap();
 
     assert_eq!(
         res.events,
@@ -252,7 +250,7 @@ fn register_lifecycle_service_first() {
     };
     let service = app.api().addr_make("service/c4");
     registry
-        .execute(&mut app, &service, &register_as_service_msg)
+        .execute(&mut app, &service, register_as_service_msg)
         .unwrap();
 
     // Register as Operator
@@ -264,7 +262,7 @@ fn register_lifecycle_service_first() {
     };
     let operator = app.api().addr_make("operator");
     registry
-        .execute(&mut app, &operator, &register_as_operator_msg)
+        .execute(&mut app, &operator, register_as_operator_msg)
         .unwrap();
 
     // Register Operator to Service
@@ -272,7 +270,7 @@ fn register_lifecycle_service_first() {
         operator: operator.to_string(),
     };
 
-    let res = registry.execute(&mut app, &service, &register_msg).unwrap();
+    let res = registry.execute(&mut app, &service, register_msg).unwrap();
 
     assert_eq!(
         res.events,
@@ -303,9 +301,7 @@ fn register_lifecycle_service_first() {
     let register_msg = &ExecuteMsg::RegisterServiceToOperator {
         service: service.to_string(),
     };
-    let res = registry
-        .execute(&mut app, &operator, &register_msg)
-        .unwrap();
+    let res = registry.execute(&mut app, &operator, register_msg).unwrap();
     assert_eq!(
         res.events,
         vec![
@@ -351,14 +347,14 @@ fn update_metadata_successfully() {
     };
 
     let service = app.api().addr_make("service/11111");
-    registry.execute(&mut app, &service, &register_msg).unwrap();
+    registry.execute(&mut app, &service, register_msg).unwrap();
 
     let update_msg = &ExecuteMsg::UpdateServiceMetadata(Metadata {
         name: Some("New Service Name".to_string()),
         uri: Some("https://new-service.com".to_string()),
     });
 
-    let response = registry.execute(&mut app, &service, &update_msg).unwrap();
+    let response = registry.execute(&mut app, &service, update_msg).unwrap();
 
     assert_eq!(
         response.events,
@@ -378,7 +374,7 @@ fn update_metadata_successfully() {
         uri: Some("https://new-new-service.com".to_string()),
     });
 
-    let response = registry.execute(&mut app, &service, &update_msg).unwrap();
+    let response = registry.execute(&mut app, &service, update_msg).unwrap();
 
     assert_eq!(
         response.events,
@@ -402,7 +398,7 @@ fn transfer_ownership_successfully() {
         new_owner: new_owner.to_string(),
     };
 
-    let response = registry.execute(&mut app, &owner, &transfer_msg).unwrap();
+    let response = registry.execute(&mut app, &owner, transfer_msg).unwrap();
 
     assert_eq!(
         response.events,
@@ -426,7 +422,7 @@ fn transfer_ownership_but_not_owner() {
     };
 
     let err = registry
-        .execute(&mut app, &not_owner, &transfer_msg)
+        .execute(&mut app, &not_owner, transfer_msg)
         .unwrap_err();
 
     assert_eq!(

--- a/crates/bvs-slash-manager/src/contract.rs
+++ b/crates/bvs-slash-manager/src/contract.rs
@@ -710,7 +710,7 @@ mod tests {
         assert_eq!(event.attributes[2].value, "true");
 
         let is_slasher = SLASHER.load(&deps.storage, &new_slasher).unwrap();
-        assert_eq!(is_slasher, true);
+        assert!(is_slasher);
     }
 
     #[test]
@@ -808,13 +808,13 @@ mod tests {
 
         let response = query_is_validator(deps.as_ref(), validator_addr.clone()).unwrap();
 
-        assert_eq!(response.is_validator, true);
+        assert!(response.is_validator);
 
         let non_existent_validator = deps.api.addr_make("non_existent_validator");
         let response: ValidatorResponse =
             query_is_validator(deps.as_ref(), non_existent_validator.clone()).unwrap();
 
-        assert_eq!(response.is_validator, false);
+        assert!(!response.is_validator);
     }
 
     #[test]
@@ -962,7 +962,7 @@ mod tests {
         assert_eq!(event.attributes.len(), 7);
 
         assert_eq!(event.attributes[0].key, "slash_hash");
-        assert!(event.attributes[0].value.len() > 0);
+        assert!(!event.attributes[0].value.is_empty());
 
         assert_eq!(event.attributes[1].key, "sender");
         assert_eq!(event.attributes[1].value, slasher_addr.to_string());
@@ -1012,7 +1012,7 @@ mod tests {
             deps.api.addr_make("validator1"),
             deps.api.addr_make("validator2"),
         ];
-        let slash_validator_addr = vec![
+        let slash_validator_addr = [
             deps.api.addr_make("validator1"),
             deps.api.addr_make("validator2"),
         ];
@@ -1092,7 +1092,7 @@ mod tests {
         assert_eq!(event.attributes[2].value, "false");
 
         let updated_slash_details = SLASH_DETAILS.load(&deps.storage, &slash_hash).unwrap();
-        assert_eq!(updated_slash_details.status, false);
+        assert!(!updated_slash_details.status);
     }
 
     fn generate_osmosis_public_key_from_private_key(
@@ -1266,7 +1266,7 @@ mod tests {
         assert_eq!(event.attributes[3].value, 1_000_000.to_string());
 
         let updated_slash_details = SLASH_DETAILS.load(&deps.storage, &slash_hash).unwrap();
-        assert_eq!(updated_slash_details.status, false);
+        assert!(!updated_slash_details.status);
     }
 
     #[test]
@@ -1403,17 +1403,13 @@ mod tests {
 
         let mut found_messages = vec![];
         for submsg in res.messages {
-            match submsg.msg {
-                CosmosMsg::Wasm(WasmMsg::Execute { msg, .. }) => {
-                    let parsed: Result<DelegationManagerExecuteMsg, _> = from_json(&msg);
-                    if let Ok(DelegationManagerExecuteMsg::DecreaseDelegatedShares {
-                        shares, ..
-                    }) = parsed
-                    {
-                        found_messages.push(shares);
-                    }
+            if let CosmosMsg::Wasm(WasmMsg::Execute { msg, .. }) = submsg.msg {
+                let parsed: Result<DelegationManagerExecuteMsg, _> = from_json(&msg);
+                if let Ok(DelegationManagerExecuteMsg::DecreaseDelegatedShares { shares, .. }) =
+                    parsed
+                {
+                    found_messages.push(shares);
                 }
-                _ => {}
             }
         }
 
@@ -1429,7 +1425,7 @@ mod tests {
 
         // Total shares = 12.121212e6 + 9.090909e6 + 18.181818e6 + 0.606061e6 = 40e6
 
-        let expected_shares = vec![
+        let expected_shares = [
             Uint128::new(12_121_212),
             Uint128::new(9_090_909),
             Uint128::new(18_181_818),

--- a/crates/bvs-vault-router/tests/integration_test.rs
+++ b/crates/bvs-vault-router/tests/integration_test.rs
@@ -73,7 +73,7 @@ fn set_vault_whitelist_false_successfully() {
         vault: vault.to_string(),
     };
     let is_whitelisted: bool = tc.vault_router.query(&mut app, &msg).unwrap();
-    assert_eq!(is_whitelisted, false);
+    assert!(!is_whitelisted);
 
     // query is delegated
     let operator = app.api().addr_make("operator");
@@ -81,7 +81,7 @@ fn set_vault_whitelist_false_successfully() {
         operator: operator.to_string(),
     };
     let is_validating: bool = tc.vault_router.query(&mut app, &msg).unwrap();
-    assert_eq!(is_validating, false);
+    assert!(!is_validating);
 
     // list vaults
     let msg = QueryMsg::ListVaults {
@@ -135,7 +135,7 @@ fn set_vault_whitelist_true_bank_vault_successfully() {
         vault: tc.bank_vault.addr().to_string(),
     };
     let is_whitelisted: bool = tc.vault_router.query(&mut app, &msg).unwrap();
-    assert_eq!(is_whitelisted, true);
+    assert!(is_whitelisted);
 
     let operator = app.api().addr_make("operator");
 
@@ -177,7 +177,7 @@ fn set_vault_whitelist_true_cw20_vault_successfully() {
         vault: tc.cw20_vault.addr().to_string(),
     };
     let is_whitelisted: bool = tc.vault_router.query(&mut app, &msg).unwrap();
-    assert_eq!(is_whitelisted, true);
+    assert!(is_whitelisted);
 
     let operator = app.api().addr_make("operator");
 


### PR DESCRIPTION
#### What this PR does / why we need it:


Run `cargo clippy --fix` before `cargo clippy -- -D warnings` to ensure what can be automatically fixed should be fixed. For consistency.

Closes SL-437