### PR TITLE
chore: allow clippy --fix to run when dirty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
 
-      - run: cargo clippy --fix
+      - run: cargo clippy --fix --allow-dirty
         working-directory: ./crates
 
       - run: cargo clippy -- -Dwarnings


### PR DESCRIPTION
#### What this PR does / why we need it:

Allow clippy to run when it's dirty, ideally we don't need this as we should not have unstagged changes. But this would make DX very difficult.