### PR TITLE
feat: migrate registry REGISTRATION_STATUS to use SnapshotMap

### DIFF
--- a/crates/bvs-registry/src/lib.rs
+++ b/crates/bvs-registry/src/lib.rs
@@ -7,3 +7,4 @@ mod error;
 mod state;
 
 pub use crate::error::ContractError;
+pub use crate::state::RegistrationStatus;

--- a/crates/bvs-registry/src/msg.rs
+++ b/crates/bvs-registry/src/msg.rs
@@ -49,6 +49,13 @@ pub enum QueryMsg {
     #[returns(StatusResponse)]
     Status { service: String, operator: String },
 
+    #[returns(StatusResponse)]
+    StatusAtHeight {
+        service: String,
+        operator: String,
+        height: u64,
+    },
+
     #[returns(IsServiceResponse)]
     IsService(String),
 
@@ -76,6 +83,9 @@ pub struct IsOperatorResponse(pub bool);
 
 #[cw_serde]
 pub struct IsOperatorActiveResponse(pub bool);
+
+#[cw_serde]
+pub struct MigrateMsg {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/bvs-registry/src/msg.rs
+++ b/crates/bvs-registry/src/msg.rs
@@ -47,13 +47,10 @@ pub struct Metadata {
 #[derive(QueryResponses)]
 pub enum QueryMsg {
     #[returns(StatusResponse)]
-    Status { service: String, operator: String },
-
-    #[returns(StatusResponse)]
-    StatusAtHeight {
+    Status {
         service: String,
         operator: String,
-        height: u64,
+        height: Option<u64>,
     },
 
     #[returns(IsServiceResponse)]

--- a/crates/bvs-registry/src/state.rs
+++ b/crates/bvs-registry/src/state.rs
@@ -96,6 +96,11 @@ pub fn get_registration_status(
 }
 
 /// Get the registration status of the Operator to Service at a specific block height
+///
+/// #### Warning
+/// This function will return previous state.
+/// if height is equal to the height of the save operation.
+/// New state will only be available at height + 1
 pub fn get_registration_status_at_height(
     store: &dyn Storage,
     key: (&Operator, &Service),
@@ -108,7 +113,12 @@ pub fn get_registration_status_at_height(
     status.try_into()
 }
 
-/// Set the registration status of the Operator to Service at a specific block height
+/// Set the registration status of the Operator to Service at a specific block height.
+///
+/// #### Warning
+/// This function will only save the state at the end of the block.
+/// So the new state will only be available at height + 1.
+/// This is so that, re-ordering of txs won't cause the state to be inconsistent.
 pub fn set_registration_status(
     store: &mut dyn Storage,
     key: (&Operator, &Service),

--- a/crates/bvs-registry/src/testing.rs
+++ b/crates/bvs-registry/src/testing.rs
@@ -1,6 +1,6 @@
 #![cfg(not(target_arch = "wasm32"))]
 
-use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use bvs_library::testing::TestingContract;
 use cosmwasm_std::{Addr, Empty, Env};
 use cw_multi_test::{App, Contract, ContractWrapper};
@@ -12,13 +12,16 @@ pub struct RegistryContract {
     pub init: InstantiateMsg,
 }
 
-impl TestingContract<InstantiateMsg, ExecuteMsg, QueryMsg> for RegistryContract {
+impl TestingContract<InstantiateMsg, ExecuteMsg, QueryMsg, MigrateMsg> for RegistryContract {
     fn wrapper() -> Box<dyn Contract<Empty>> {
-        Box::new(ContractWrapper::new(
-            crate::contract::execute,
-            crate::contract::instantiate,
-            crate::contract::query,
-        ))
+        Box::new(
+            ContractWrapper::new(
+                crate::contract::execute,
+                crate::contract::instantiate,
+                crate::contract::query,
+            )
+            .with_migrate(crate::contract::migrate),
+        )
     }
 
     fn default_init(app: &mut App, _env: &Env) -> InstantiateMsg {

--- a/crates/bvs-registry/tests/integration_test.rs
+++ b/crates/bvs-registry/tests/integration_test.rs
@@ -451,7 +451,6 @@ fn query_status() {
 }
 
 #[test]
-#[ignore]
 fn migrate_to_v2() {
     let (mut app, registry, ..) = instantiate();
 
@@ -528,7 +527,7 @@ fn migrate_to_v2() {
         let deregister_msg = &ExecuteMsg::DeregisterServiceFromOperator {
             service: service.to_string(),
         };
-        let res = registry
+        registry
             .execute(&mut app, &operator, deregister_msg)
             .unwrap();
 
@@ -544,6 +543,21 @@ fn migrate_to_v2() {
             .unwrap();
         assert_eq!(status, StatusResponse(0));
 
+        // check if state is changed at height + 1
+        let block_info = app.block_info();
+        let status_at_height: StatusResponse = registry
+            .query(
+                &mut app,
+                &QueryMsg::StatusAtHeight {
+                    service: service.to_string(),
+                    operator: operator.to_string(),
+                    height: block_info.height + 1,
+                },
+            )
+            .unwrap();
+        assert_eq!(status_at_height, StatusResponse(0));
+
+        // check old state at height - 10 -> should be active
         let block_info = app.block_info();
         let status_at_height: StatusResponse = registry
             .query(

--- a/crates/bvs-registry/tests/integration_test.rs
+++ b/crates/bvs-registry/tests/integration_test.rs
@@ -519,7 +519,7 @@ fn register_deregister_lifecycle() {
             registry
                 .execute(
                     &mut app,
-                    &curr_service,
+                    curr_service,
                     &ExecuteMsg::RegisterOperatorToService {
                         operator: operator.to_string(),
                     },
@@ -528,7 +528,7 @@ fn register_deregister_lifecycle() {
             registry
                 .execute(
                     &mut app,
-                    &curr_service,
+                    curr_service,
                     &ExecuteMsg::RegisterOperatorToService {
                         operator: operator2.to_string(),
                     },

--- a/crates/bvs-registry/tests/integration_test.rs
+++ b/crates/bvs-registry/tests/integration_test.rs
@@ -200,6 +200,7 @@ fn register_lifecycle_operator_first() {
             &QueryMsg::Status {
                 service: service.to_string(),
                 operator: operator.to_string(),
+                height: None,
             },
         )
         .unwrap();
@@ -232,6 +233,7 @@ fn register_lifecycle_operator_first() {
             &QueryMsg::Status {
                 service: service.to_string(),
                 operator: operator.to_string(),
+                height: None,
             },
         )
         .unwrap();
@@ -293,6 +295,7 @@ fn register_lifecycle_service_first() {
             &QueryMsg::Status {
                 service: service.to_string(),
                 operator: operator.to_string(),
+                height: None,
             },
         )
         .unwrap();
@@ -323,6 +326,7 @@ fn register_lifecycle_service_first() {
             &QueryMsg::Status {
                 service: service.to_string(),
                 operator: operator.to_string(),
+                height: None,
             },
         )
         .unwrap();
@@ -546,6 +550,7 @@ fn register_deregister_lifecycle() {
                     &QueryMsg::Status {
                         service: curr_service.to_string(),
                         operator: operator.to_string(),
+                        height: None,
                     },
                 )
                 .unwrap();
@@ -557,6 +562,7 @@ fn register_deregister_lifecycle() {
                     &QueryMsg::Status {
                         service: curr_service.to_string(),
                         operator: operator2.to_string(),
+                        height: None,
                     },
                 )
                 .unwrap();
@@ -575,10 +581,10 @@ fn register_deregister_lifecycle() {
             let status: StatusResponse = registry
                 .query(
                     &app,
-                    &QueryMsg::StatusAtHeight {
+                    &QueryMsg::Status {
                         service: curr_service.to_string(),
                         operator: operator.to_string(),
-                        height: app.block_info().height - 5,
+                        height: Some(app.block_info().height - 5),
                     },
                 )
                 .unwrap();
@@ -587,10 +593,10 @@ fn register_deregister_lifecycle() {
             let status: StatusResponse = registry
                 .query(
                     &app,
-                    &QueryMsg::StatusAtHeight {
+                    &QueryMsg::Status {
                         service: curr_service.to_string(),
                         operator: operator2.to_string(),
-                        height: app.block_info().height - 5,
+                        height: Some(app.block_info().height - 5),
                     },
                 )
                 .unwrap();
@@ -617,6 +623,7 @@ fn register_deregister_lifecycle() {
                 &QueryMsg::Status {
                     service: service.to_string(),
                     operator: operator.to_string(),
+                    height: None,
                 },
             )
             .unwrap();
@@ -628,6 +635,7 @@ fn register_deregister_lifecycle() {
                 &QueryMsg::Status {
                     service: service2.to_string(),
                     operator: operator.to_string(),
+                    height: None,
                 },
             )
             .unwrap();
@@ -643,10 +651,10 @@ fn register_deregister_lifecycle() {
     let status: StatusResponse = registry
         .query(
             &app,
-            &QueryMsg::StatusAtHeight {
+            &QueryMsg::Status {
                 service: service.to_string(),
                 operator: operator.to_string(),
-                height: app.block_info().height - 5,
+                height: Some(app.block_info().height - 5),
             },
         )
         .unwrap();
@@ -656,10 +664,10 @@ fn register_deregister_lifecycle() {
     let status: StatusResponse = registry
         .query(
             &app,
-            &QueryMsg::StatusAtHeight {
+            &QueryMsg::Status {
                 service: service2.to_string(),
                 operator: operator.to_string(),
-                height: app.block_info().height - 5,
+                height: Some(app.block_info().height - 5),
             },
         )
         .unwrap();
@@ -673,6 +681,7 @@ fn query_status() {
     let query_msg = &QueryMsg::Status {
         service: app.api().addr_make("service/44").to_string(),
         operator: app.api().addr_make("operator/44").to_string(),
+        height: None,
     };
 
     let status: StatusResponse = registry.query(&mut app, query_msg).unwrap();
@@ -732,6 +741,7 @@ fn migrate_to_v2() {
             &QueryMsg::Status {
                 service: service.to_string(),
                 operator: operator.to_string(),
+                height: None,
             },
         )
         .unwrap();
@@ -741,10 +751,10 @@ fn migrate_to_v2() {
     let status_at_height: StatusResponse = registry
         .query(
             &mut app,
-            &QueryMsg::StatusAtHeight {
+            &QueryMsg::Status {
                 service: service.to_string(),
                 operator: operator.to_string(),
-                height: block_info.height - 1,
+                height: Some(block_info.height - 1),
             },
         )
         .unwrap();
@@ -767,6 +777,7 @@ fn migrate_to_v2() {
                 &QueryMsg::Status {
                     service: service.to_string(),
                     operator: operator.to_string(),
+                    height: None,
                 },
             )
             .unwrap();
@@ -777,10 +788,10 @@ fn migrate_to_v2() {
         let status_at_height: StatusResponse = registry
             .query(
                 &mut app,
-                &QueryMsg::StatusAtHeight {
+                &QueryMsg::Status {
                     service: service.to_string(),
                     operator: operator.to_string(),
-                    height: block_info.height + 1,
+                    height: Some(block_info.height + 1),
                 },
             )
             .unwrap();
@@ -791,10 +802,10 @@ fn migrate_to_v2() {
         let status_at_height: StatusResponse = registry
             .query(
                 &mut app,
-                &QueryMsg::StatusAtHeight {
+                &QueryMsg::Status {
                     service: service.to_string(),
                     operator: operator.to_string(),
-                    height: block_info.height - 10,
+                    height: Some(block_info.height - 10),
                 },
             )
             .unwrap();

--- a/modules/cosmwasm-schema/registry/schema.go
+++ b/modules/cosmwasm-schema/registry/schema.go
@@ -64,13 +64,20 @@ type TransferOwnership struct {
 }
 
 type QueryMsg struct {
-	Status           *Status `json:"status,omitempty"`
-	IsService        *string `json:"is_service,omitempty"`
-	IsOperator       *string `json:"is_operator,omitempty"`
-	IsOperatorActive *string `json:"is_operator_active,omitempty"`
+	Status           *Status         `json:"status,omitempty"`
+	StatusAtHeight   *StatusAtHeight `json:"status_at_height,omitempty"`
+	IsService        *string         `json:"is_service,omitempty"`
+	IsOperator       *string         `json:"is_operator,omitempty"`
+	IsOperatorActive *string         `json:"is_operator_active,omitempty"`
 }
 
 type Status struct {
+	Operator string `json:"operator"`
+	Service  string `json:"service"`
+}
+
+type StatusAtHeight struct {
+	Height   int64  `json:"height"`
 	Operator string `json:"operator"`
 	Service  string `json:"service"`
 }

--- a/modules/cosmwasm-schema/registry/schema.go
+++ b/modules/cosmwasm-schema/registry/schema.go
@@ -64,20 +64,14 @@ type TransferOwnership struct {
 }
 
 type QueryMsg struct {
-	Status           *Status         `json:"status,omitempty"`
-	StatusAtHeight   *StatusAtHeight `json:"status_at_height,omitempty"`
-	IsService        *string         `json:"is_service,omitempty"`
-	IsOperator       *string         `json:"is_operator,omitempty"`
-	IsOperatorActive *string         `json:"is_operator_active,omitempty"`
+	Status           *Status `json:"status,omitempty"`
+	IsService        *string `json:"is_service,omitempty"`
+	IsOperator       *string `json:"is_operator,omitempty"`
+	IsOperatorActive *string `json:"is_operator_active,omitempty"`
 }
 
 type Status struct {
-	Operator string `json:"operator"`
-	Service  string `json:"service"`
-}
-
-type StatusAtHeight struct {
-	Height   int64  `json:"height"`
+	Height   *int64 `json:"height"`
 	Operator string `json:"operator"`
 	Service  string `json:"service"`
 }

--- a/packages/cosmwasm-schema/registry.d.ts
+++ b/packages/cosmwasm-schema/registry.d.ts
@@ -67,19 +67,13 @@ export interface TransferOwnership {
 
 export interface QueryMsg {
   status?: Status;
-  status_at_height?: StatusAtHeight;
   is_service?: string;
   is_operator?: string;
   is_operator_active?: string;
 }
 
 export interface Status {
-  operator: string;
-  service: string;
-}
-
-export interface StatusAtHeight {
-  height: number;
+  height?: number | null;
   operator: string;
   service: string;
 }

--- a/packages/cosmwasm-schema/registry.d.ts
+++ b/packages/cosmwasm-schema/registry.d.ts
@@ -67,12 +67,19 @@ export interface TransferOwnership {
 
 export interface QueryMsg {
   status?: Status;
+  status_at_height?: StatusAtHeight;
   is_service?: string;
   is_operator?: string;
   is_operator_active?: string;
 }
 
 export interface Status {
+  operator: string;
+  service: string;
+}
+
+export interface StatusAtHeight {
+  height: number;
   operator: string;
   service: string;
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

To support support look up of registration status at a specific height for Operator <-> Service relationship, migrate from `Map<...>` to `SnapshotMap<...>`. This will allow query of `StatusAtHeight`, given operator, service and blockheight.

Migrating data is not needed as `SnapshotMap` uses `Map` with the same namespace.
https://github.com/CosmWasm/cw-storage-plus/blob/b06e11931a19e9a75204139734176a1c5513943e/src/snapshot/map.rs#L42-L52

This migration will also means that the current state of `REGISTRATION_STATUS` will be the default state when `StatusAtHeight` query is used for height before migration. For instance, migration happens at block 200 and Operator1 and Service1 is in Active status. When queried at height 1, the status of Operator1 and Service1 will be Active.

<!-- remove if not applicable -->
Closes SL-443