### PR TITLE
chore: remove clang in cosmwasm-optimizer

### DIFF
--- a/packages/cosmwasm-optimizer/Dockerfile
+++ b/packages/cosmwasm-optimizer/Dockerfile
@@ -6,7 +6,6 @@ FROM cosmwasm/optimizer-arm64:0.16.0 AS arm64
 
 # Select the correct build stage
 FROM ${TARGETARCH:-amd64} AS base
-RUN apk update && apk add clang && apk add binaryen
 RUN mkdir /dist
 
 COPY . /code


### PR DESCRIPTION
#### What this PR does / why we need it:

With the removal of deprecated components/contracts using libraries that is not pure, we don't need clang anymore.

> We will need this to verify contracts on explorers.

Closes SL-470