### PR TITLE
feat: enable/disable slashing and opt in to slashing

### DIFF
--- a/crates/bvs-library/src/lib.rs
+++ b/crates/bvs-library/src/lib.rs
@@ -6,3 +6,4 @@ pub mod testing;
 pub mod ownership;
 
 pub mod addr;
+pub mod time;

--- a/crates/bvs-library/src/time.rs
+++ b/crates/bvs-library/src/time.rs
@@ -1,0 +1,5 @@
+// helper constants for time represented in seconds
+pub const SECOND: u64 = 1;
+pub const MINUTES: u64 = 60;
+pub const HOURS: u64 = 60 * MINUTES;
+pub const DAYS: u64 = 24 * HOURS;

--- a/crates/bvs-library/src/time.rs
+++ b/crates/bvs-library/src/time.rs
@@ -1,5 +1,5 @@
 // helper constants for time represented in seconds
-pub const SECOND: u64 = 1;
-pub const MINUTES: u64 = 60;
+pub const SECONDS: u64 = 1;
+pub const MINUTES: u64 = 60 * SECONDS;
 pub const HOURS: u64 = 60 * MINUTES;
 pub const DAYS: u64 = 24 * HOURS;

--- a/crates/bvs-registry/src/contract.rs
+++ b/crates/bvs-registry/src/contract.rs
@@ -411,8 +411,8 @@ mod execute {
                         .unwrap_or_default(),
                 )
                 .add_attribute(
-                    "max_slashing_percentage",
-                    slashing_parameters.max_slashing_percentage.to_string(),
+                    "max_slashing_bips",
+                    slashing_parameters.max_slashing_bips.to_string(),
                 )
                 .add_attribute(
                     "resolution_window",
@@ -1319,7 +1319,7 @@ mod tests {
             service_info.clone(),
             SlashingParameters {
                 destination: Some(destination.clone()),
-                max_slashing_percentage: 10,
+                max_slashing_bips: 10,
                 resolution_window: 1000,
             },
         );
@@ -1332,7 +1332,7 @@ mod tests {
             slashing_parameters,
             SlashingParameters {
                 destination: Some(destination.clone()),
-                max_slashing_percentage: 10,
+                max_slashing_bips: 10,
                 resolution_window: 1000,
             }
         );
@@ -1343,7 +1343,7 @@ mod tests {
                 Event::new("SlashingParametersEnabled")
                     .add_attribute("service", service.as_ref())
                     .add_attribute("destination", destination.to_string())
-                    .add_attribute("max_slashing_percentage", "10")
+                    .add_attribute("max_slashing_bips", "10")
                     .add_attribute("resolution_window", "1000")
             ))
         );
@@ -1376,7 +1376,7 @@ mod tests {
             service_info.clone(),
             SlashingParameters {
                 destination: Some(destination.clone()),
-                max_slashing_percentage: 1000,
+                max_slashing_bips: 1000,
                 resolution_window: 1000,
             },
         )
@@ -1402,7 +1402,7 @@ mod tests {
             service_info.clone(),
             SlashingParameters {
                 destination: Some(destination.clone()),
-                max_slashing_percentage: 9999,
+                max_slashing_bips: 9999,
                 resolution_window: 2000,
             },
         )
@@ -1416,7 +1416,7 @@ mod tests {
             slashing_parameters,
             SlashingParameters {
                 destination: Some(destination.clone()),
-                max_slashing_percentage: 9999,
+                max_slashing_bips: 9999,
                 resolution_window: 2000,
             }
         );
@@ -1447,7 +1447,7 @@ mod tests {
             service_info.clone(),
             SlashingParameters {
                 destination: Some(destination.clone()),
-                max_slashing_percentage: 10,
+                max_slashing_bips: 10,
                 resolution_window: 1000,
             },
         );
@@ -1534,7 +1534,7 @@ mod tests {
             message_info(&service, &[]),
             SlashingParameters {
                 destination: Some(operator.clone()),
-                max_slashing_percentage: 1000,
+                max_slashing_bips: 1000,
                 resolution_window: 1000,
             },
         )
@@ -1598,7 +1598,7 @@ mod tests {
             message_info(&service, &[]),
             SlashingParameters {
                 destination: Some(operator.clone()),
-                max_slashing_percentage: 5000,
+                max_slashing_bips: 5000,
                 resolution_window: 1000,
             },
         )
@@ -1880,7 +1880,7 @@ mod tests {
             service_info.clone(),
             SlashingParameters {
                 destination: Some(destination.clone()),
-                max_slashing_percentage: 1000,
+                max_slashing_bips: 1000,
                 resolution_window: 1000,
             },
         )
@@ -1893,7 +1893,7 @@ mod tests {
             slashing_parameters,
             Some(SlashingParameters {
                 destination: Some(destination.clone()),
-                max_slashing_percentage: 1000,
+                max_slashing_bips: 1000,
                 resolution_window: 1000,
             })
         );
@@ -1908,7 +1908,7 @@ mod tests {
             service_info.clone(),
             SlashingParameters {
                 destination: None,
-                max_slashing_percentage: 5000,
+                max_slashing_bips: 5000,
                 resolution_window: 999,
             },
         )
@@ -1924,7 +1924,7 @@ mod tests {
             slashing_parameters,
             Some(SlashingParameters {
                 destination: None,
-                max_slashing_percentage: 5000,
+                max_slashing_bips: 5000,
                 resolution_window: 999,
             })
         );
@@ -1940,7 +1940,7 @@ mod tests {
             slashing_parameters,
             Some(SlashingParameters {
                 destination: Some(destination.clone()),
-                max_slashing_percentage: 1000,
+                max_slashing_bips: 1000,
                 resolution_window: 1000,
             })
         );
@@ -1968,7 +1968,7 @@ mod tests {
             slashing_parameters,
             Some(SlashingParameters {
                 destination: None,
-                max_slashing_percentage: 5000,
+                max_slashing_bips: 5000,
                 resolution_window: 999,
             })
         );

--- a/crates/bvs-registry/src/contract.rs
+++ b/crates/bvs-registry/src/contract.rs
@@ -373,14 +373,14 @@ mod execute {
         }
     }
 
-    /// Enable slashing for a service (info.sender is the service)
+    /// Enable slashing for a service by registering slashing condition into the registry.
     ///
-    /// When slashing is enabled, Active operators are able to opt in the next block.  
-    /// New Operator <-> Service registration will also automatically opt-in the operator to slashing.  
-    /// To update the slashing conditions, the service must call this function again.  
-    /// When slashing condition is updated,
+    /// When slashing is enabled, active operators are able to opt in the next block.
+    /// New Operator <-> Service registration will automatically opt in the operator to slashing.
+    /// To update the slashing condition, the service must call this function again.
+    /// When the slashing condition is updated,
     /// all active operators
-    /// that are already registered to the service will have their opt-in status reset for the new slashing conditions
+    /// that are already registered to the service will have their opt-in status reset for the new slashing condition
     /// and have to manually opt in again.
     pub fn enable_slashing(
         deps: DepsMut,
@@ -418,11 +418,11 @@ mod execute {
         ))
     }
 
-    /// Disable slashing for a service (info.sender is the service)
+    /// Disable slashing for a service by removing slashing condition from the registry.
     ///
     /// When slashing is disabled,
     /// all operators
-    /// that are opted in to slashing will be removed from the slashing registry.  
+    /// that are opted in to the slashing condition will be removed from the slashing registry.
     /// All active operators will remain actively registered to the service.
     pub fn disable_slashing(
         deps: DepsMut,
@@ -445,11 +445,11 @@ mod execute {
             .add_event(Event::new("SlashingRegistryDisabled").add_attribute("service", service)))
     }
 
-    /// Operator opts in to the service's current slashing condition (info.sender is the operator)
+    /// Operator opts in to the service's current slashing condition.
     ///
     /// When slashing is enabled, active operators can opt in to slashing.  
     /// Newly registered operators, after slashing is enabled, will automatically opt in to slashing
-    /// and need to not call this function.
+    /// and don't need to call this function.
     pub fn operator_opt_in_to_slashing(
         deps: DepsMut,
         env: Env,

--- a/crates/bvs-registry/src/error.rs
+++ b/crates/bvs-registry/src/error.rs
@@ -24,8 +24,8 @@ pub enum ContractError {
     #[error("Invalid registration status: {msg}")]
     InvalidRegistrationStatus { msg: String },
 
-    #[error("Invalid slashing registry: {msg}")]
-    InvalidSlashingRegistry { msg: String },
+    #[error("Invalid slashing parameters: {msg}")]
+    InvalidSlashingParameters { msg: String },
 
     #[error("Invalid slashing opt-in: {msg}")]
     InvalidSlashingOptIn { msg: String },

--- a/crates/bvs-registry/src/error.rs
+++ b/crates/bvs-registry/src/error.rs
@@ -23,4 +23,10 @@ pub enum ContractError {
 
     #[error("Invalid registration status: {msg}")]
     InvalidRegistrationStatus { msg: String },
+
+    #[error("Invalid slashing registry: {msg}")]
+    InvalidSlashingRegistry { msg: String },
+
+    #[error("Invalid slashing opt-in: {msg}")]
+    InvalidSlashingOptIn { msg: String },
 }

--- a/crates/bvs-registry/src/lib.rs
+++ b/crates/bvs-registry/src/lib.rs
@@ -8,3 +8,4 @@ mod state;
 
 pub use crate::error::ContractError;
 pub use crate::state::RegistrationStatus;
+pub use crate::state::SlashingParameters;

--- a/crates/bvs-registry/src/msg.rs
+++ b/crates/bvs-registry/src/msg.rs
@@ -1,4 +1,4 @@
-use crate::state::{RegistrationStatus, SlashingRegistry};
+use crate::state::{RegistrationStatus, SlashingParameters};
 use cosmwasm_schema::{cw_serde, QueryResponses};
 
 #[cw_serde]
@@ -31,7 +31,7 @@ pub enum ExecuteMsg {
         service: String,
     },
     EnableSlashing {
-        registry: SlashingRegistry,
+        slashing_parameters: SlashingParameters,
     },
     DisableSlashing {},
     OperatorOptInToSlashing {
@@ -69,8 +69,8 @@ pub enum QueryMsg {
     #[returns(IsOperatorActiveResponse)]
     IsOperatorActive(String),
 
-    #[returns(SlashingRegistryResponse)]
-    SlashingRegistry {
+    #[returns(SlashingParametersResponse)]
+    SlashingParameters {
         service: String,
         height: Option<u64>,
     },
@@ -102,7 +102,7 @@ pub struct IsOperatorResponse(pub bool);
 pub struct IsOperatorActiveResponse(pub bool);
 
 #[cw_serde]
-pub struct SlashingRegistryResponse(pub Option<SlashingRegistry>);
+pub struct SlashingParametersResponse(pub Option<SlashingParameters>);
 
 #[cw_serde]
 pub struct IsOperatorOptedInToSlashingResponse(pub bool);

--- a/crates/bvs-registry/src/msg.rs
+++ b/crates/bvs-registry/src/msg.rs
@@ -1,4 +1,4 @@
-use crate::state::RegistrationStatus;
+use crate::state::{RegistrationStatus, SlashingRegistry};
 use cosmwasm_schema::{cw_serde, QueryResponses};
 
 #[cw_serde]
@@ -28,6 +28,13 @@ pub enum ExecuteMsg {
         service: String,
     },
     DeregisterServiceFromOperator {
+        service: String,
+    },
+    EnableSlashing {
+        registry: SlashingRegistry,
+    },
+    DisableSlashing {},
+    OperatorOptInToSlashing {
         service: String,
     },
     TransferOwnership {
@@ -61,6 +68,19 @@ pub enum QueryMsg {
 
     #[returns(IsOperatorActiveResponse)]
     IsOperatorActive(String),
+
+    #[returns(SlashingRegistryResponse)]
+    SlashingRegistry {
+        service: String,
+        height: Option<u64>,
+    },
+
+    #[returns(IsOperatorOptedInToSlashingResponse)]
+    IsOperatorOptedInToSlashing {
+        service: String,
+        operator: String,
+        height: Option<u64>,
+    },
 }
 
 #[cw_serde]
@@ -80,6 +100,12 @@ pub struct IsOperatorResponse(pub bool);
 
 #[cw_serde]
 pub struct IsOperatorActiveResponse(pub bool);
+
+#[cw_serde]
+pub struct SlashingRegistryResponse(pub Option<SlashingRegistry>);
+
+#[cw_serde]
+pub struct IsOperatorOptedInToSlashingResponse(pub bool);
 
 #[cw_serde]
 pub struct MigrateMsg {}

--- a/crates/bvs-registry/src/state.rs
+++ b/crates/bvs-registry/src/state.rs
@@ -1,5 +1,4 @@
 use crate::error::ContractError;
-use bvs_library::time::{DAYS, MINUTES};
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Api, Env, Order, StdError, StdResult, Storage};
 use cw_storage_plus::{Map, SnapshotMap, Strategy};
@@ -346,6 +345,7 @@ pub fn reset_slashing_opt_in(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bvs_library::time::{DAYS, MINUTES};
     use cosmwasm_std::testing::{mock_dependencies, mock_env};
 
     #[test]

--- a/crates/bvs-registry/src/state.rs
+++ b/crates/bvs-registry/src/state.rs
@@ -1,6 +1,7 @@
 use crate::error::ContractError;
+use bvs_library::time::{DAYS, MINUTES};
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, StdError, StdResult, Storage};
+use cosmwasm_std::{Addr, Api, Env, Order, StdError, StdResult, Storage};
 use cw_storage_plus::{Map, SnapshotMap, Strategy};
 
 type Service = Addr;
@@ -99,7 +100,7 @@ pub fn get_registration_status(
 ///
 /// #### Warning
 /// This function will return previous state.
-/// if height is equal to the height of the save operation.
+/// If height is equal to the height of the save operation.
 /// New state will only be available at height + 1
 pub fn get_registration_status_at_height(
     store: &dyn Storage,
@@ -113,20 +114,47 @@ pub fn get_registration_status_at_height(
     status.try_into()
 }
 
-/// Set the registration status of the Operator to Service at a specific block height.
+/// Set the registration status of the Operator to Service at a current block height
 ///
 /// #### Warning
 /// This function will only save the state at the end of the block.
 /// So the new state will only be available at height + 1.
-/// This is so that, re-ordering of txs won't cause the state to be inconsistent.
+/// This is so that re-ordering of txs won't cause the state to be inconsistent.
 pub fn set_registration_status(
     store: &mut dyn Storage,
+    env: &Env,
     key: (&Operator, &Service),
     status: RegistrationStatus,
-    block_height: u64,
 ) -> StdResult<()> {
-    REGISTRATION_STATUS.save(store, key, &status.into(), block_height)?;
+    let (operator, service) = key;
+    match status {
+        RegistrationStatus::Active => {
+            increase_operator_active_registration_count(store, operator)?;
+            // if service has enabled slashing, opt-in operator to slashing
+            if is_slashing_enabled(store, service, Some(env.block.height))? {
+                opt_in_to_slashing(store, env, service, operator)?;
+            }
+        }
+        RegistrationStatus::Inactive => {
+            decrease_operator_active_registration_count(store, operator)?;
+        }
+        _ => {}
+    }
+
+    REGISTRATION_STATUS.save(store, key, &status.into(), env.block.height)?;
     Ok(())
+}
+
+pub fn require_active_registration_status(
+    store: &dyn Storage,
+    key: (&Operator, &Service),
+) -> Result<(), ContractError> {
+    match get_registration_status(store, key)? {
+        RegistrationStatus::Active => Ok(()),
+        _ => Err(ContractError::InvalidRegistrationStatus {
+            msg: "Operator and service must have active registration.".to_string(),
+        }),
+    }
 }
 
 /// Stores the active registration count of the operator to services.
@@ -167,6 +195,161 @@ pub fn decrease_operator_active_registration_count(
             StdError::generic_err("Decrease operator active registration count failed")
         })
     })
+}
+
+#[cw_serde]
+pub struct SlashingRegistry {
+    /// The address to which the slashed funds will be sent after the slashing is finalized.  
+    /// None, indicates that the slashed funds will be burned.
+    pub destination: Option<Addr>,
+    /// The maximum percentage of the operator's total stake that can be slashed.  
+    /// The value is represented in bips (basis points), where 100 bips = 1%.  
+    /// And the value must be between 0 and 10_000 (inclusive).
+    pub max_slashing_percentage: u16,
+    /// The minimum amount of time (in seconds)
+    /// that the slashing can be delayed before it is executed and finalized.  
+    /// It is recommended to set this value to a maximum of withdrawal delay or less.
+    pub resolution_window: u64,
+}
+
+impl SlashingRegistry {
+    pub fn validate(&self, api: &dyn Api) -> Result<(), ContractError> {
+        if let Some(destination) = &self.destination {
+            api.addr_validate(destination.as_str()).map_err(|_| {
+                ContractError::InvalidSlashingRegistry {
+                    msg: "destination address is invalid".to_string(),
+                }
+            })?;
+        }
+        if self.max_slashing_percentage > 10_000 {
+            return Err(ContractError::InvalidSlashingRegistry {
+                msg: "max_slashing_percentage is over 10_000 bips (100%)".to_string(),
+            });
+        }
+        if self.resolution_window < 15 * MINUTES {
+            return Err(ContractError::InvalidSlashingRegistry {
+                msg: "resolution_window is too short".to_string(),
+            });
+        }
+        if self.resolution_window > 4 * DAYS {
+            return Err(ContractError::InvalidSlashingRegistry {
+                msg: "resolution_window is too long".to_string(),
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Mapping of service to the latest slashing registry.
+///
+/// The presence of the Service key in the map indicates that slashing is enabled for that service.
+pub(crate) const SLASHING_REGISTRY: SnapshotMap<&Service, SlashingRegistry> = SnapshotMap::new(
+    "slashing_registry",
+    "slashing_registry_checkpoint",
+    "slashing_registry_changelog",
+    Strategy::EveryBlock,
+);
+
+/// Returns whether slashing is enabled for the given service at the given height.
+pub fn is_slashing_enabled(
+    store: &dyn Storage,
+    service: &Service,
+    height: Option<u64>,
+) -> StdResult<bool> {
+    let is_enabled = match height {
+        Some(h) => SLASHING_REGISTRY
+            .may_load_at_height(store, service, h)?
+            .is_some(),
+        None => SLASHING_REGISTRY.may_load(store, service)?.is_some(),
+    };
+    Ok(is_enabled)
+}
+
+/// Enable slashing for the given service at current block height
+pub fn enable_slashing(
+    store: &mut dyn Storage,
+    api: &dyn Api,
+    env: &Env,
+    service: &Service,
+    slashing_registry: &SlashingRegistry,
+) -> Result<(), ContractError> {
+    // Validate the slashing registry
+    slashing_registry.validate(api)?;
+
+    // Save the slashing registry to the store
+    SLASHING_REGISTRY.save(store, service, slashing_registry, env.block.height)?;
+    Ok(())
+}
+
+/// Disable slashing for the given service at current block height
+pub fn disable_slashing(store: &mut dyn Storage, env: &Env, service: &Service) -> StdResult<()> {
+    SLASHING_REGISTRY.remove(store, service, env.block.height)?;
+    Ok(())
+}
+
+/// Stores the slashing registry opt-in status for (service, operator) pair.
+///
+/// If value is `true`, operator has opted in to slashing condition for that service at the given height.
+/// If key isn't found, it means the operator hasn't opted in to slashing condition for that service.
+/// The `false` value is not used.
+pub(crate) const SLASHING_REGISTRY_OPT_IN: SnapshotMap<(&Service, &Operator), bool> =
+    SnapshotMap::new(
+        "slashing_registry_opt_in",
+        "slashing_registry_opt_in_checkpoint",
+        "slashing_registry_opt_in_changelog",
+        Strategy::EveryBlock,
+    );
+
+/// Opt-in operator to the current service slashing condition at current height
+pub fn opt_in_to_slashing(
+    store: &mut dyn Storage,
+    env: &Env,
+    service: &Service,
+    operator: &Operator,
+) -> StdResult<()> {
+    SLASHING_REGISTRY_OPT_IN.save(store, (service, operator), &true, env.block.height)?;
+    Ok(())
+}
+
+/// Check if the operator has opted in to slashing for the given service at the given height.
+pub fn is_operator_opted_in_to_slashing(
+    store: &dyn Storage,
+    service: &Service,
+    operator: &Operator,
+    height: Option<u64>,
+) -> StdResult<bool> {
+    let is_opted_in = match height {
+        Some(h) => SLASHING_REGISTRY_OPT_IN
+            .may_load_at_height(store, (service, operator), h)?
+            .is_some(),
+        None => SLASHING_REGISTRY_OPT_IN
+            .may_load(store, (service, operator))?
+            .is_some(),
+    };
+    Ok(is_opted_in)
+}
+
+/// Clears the slashing registry opt-in status for the given service at current block height.
+/// This happens only when a new slashing condition is set/updated.
+pub fn reset_slashing_registry_opt_in(
+    store: &mut dyn Storage,
+    env: &Env,
+    service: &Service,
+) -> Result<(), ContractError> {
+    let operator_keys = SLASHING_REGISTRY_OPT_IN
+        .prefix(service)
+        .range(store, None, None, Order::Ascending)
+        .map(|item| {
+            let (operator, _) = item?;
+            Ok(operator)
+        })
+        .collect::<Vec<StdResult<Operator>>>();
+
+    for operator in operator_keys {
+        let key = (service, &operator?);
+        SLASHING_REGISTRY_OPT_IN.remove(store, key, env.block.height)?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -247,21 +430,15 @@ mod tests {
         let status = get_registration_status(&deps.storage, key).unwrap();
         assert_eq!(status, RegistrationStatus::Inactive);
 
-        set_registration_status(
-            &mut deps.storage,
-            key,
-            RegistrationStatus::Active,
-            env.block.height,
-        )
-        .unwrap();
+        set_registration_status(&mut deps.storage, &env, key, RegistrationStatus::Active).unwrap();
         let status = get_registration_status(&deps.storage, key).unwrap();
         assert_eq!(status, RegistrationStatus::Active);
 
         set_registration_status(
             &mut deps.storage,
+            &env,
             key,
             RegistrationStatus::OperatorRegistered,
-            env.block.height,
         )
         .unwrap();
         let status = get_registration_status(&deps.storage, key).unwrap();
@@ -269,12 +446,228 @@ mod tests {
 
         set_registration_status(
             &mut deps.storage,
+            &env,
             key,
             RegistrationStatus::ServiceRegistered,
-            env.block.height,
         )
         .unwrap();
         let status = get_registration_status(&deps.storage, key).unwrap();
         assert_eq!(status, RegistrationStatus::ServiceRegistered);
+    }
+
+    #[test]
+    fn test_slashing_registry_validate() {
+        let deps = mock_dependencies();
+
+        // NEGATIVE tests
+        {
+            // Invalid destination address
+            let valid_slashing_registry = SlashingRegistry {
+                destination: Some(Addr::unchecked("invalid_address")),
+                max_slashing_percentage: 100,
+                resolution_window: 60 * MINUTES,
+            };
+
+            assert_eq!(
+                valid_slashing_registry.validate(&deps.api).unwrap_err(),
+                ContractError::InvalidSlashingRegistry {
+                    msg: "destination address is invalid".to_string()
+                }
+            );
+        }
+        {
+            // max_slashing_percentage too high
+            let valid_slashing_registry = SlashingRegistry {
+                destination: Some(deps.api.addr_make("destination")),
+                max_slashing_percentage: 10_001,
+                resolution_window: 60 * MINUTES,
+            };
+
+            assert_eq!(
+                valid_slashing_registry.validate(&deps.api).unwrap_err(),
+                ContractError::InvalidSlashingRegistry {
+                    msg: "max_slashing_percentage is over 10_000 bips (100%)".to_string()
+                }
+            );
+        }
+        {
+            // resolution_window too short
+            let valid_slashing_registry = SlashingRegistry {
+                destination: Some(deps.api.addr_make("destination")),
+                max_slashing_percentage: 10_000,
+                resolution_window: 15 * MINUTES - 1,
+            };
+
+            assert_eq!(
+                valid_slashing_registry.validate(&deps.api).unwrap_err(),
+                ContractError::InvalidSlashingRegistry {
+                    msg: "resolution_window is too short".to_string()
+                }
+            );
+        }
+        {
+            // resolution_window too long
+            let valid_slashing_registry = SlashingRegistry {
+                destination: None,
+                max_slashing_percentage: 0,
+                resolution_window: 4 * DAYS + 1,
+            };
+
+            assert_eq!(
+                valid_slashing_registry.validate(&deps.api).unwrap_err(),
+                ContractError::InvalidSlashingRegistry {
+                    msg: "resolution_window is too long".to_string()
+                }
+            );
+        }
+
+        // POSITIVE tests
+        {
+            // Valid slashing registry
+            let valid_slashing_registry = SlashingRegistry {
+                destination: Some(deps.api.addr_make("destination")),
+                max_slashing_percentage: 10_000,
+                resolution_window: 4 * DAYS,
+            };
+
+            assert!(valid_slashing_registry.validate(&deps.api).is_ok());
+        }
+        {
+            // Valid slashing registry with None destination
+            let valid_slashing_registry = SlashingRegistry {
+                destination: None,
+                max_slashing_percentage: 0,
+                resolution_window: 15 * MINUTES,
+            };
+
+            assert!(valid_slashing_registry.validate(&deps.api).is_ok());
+        }
+    }
+
+    #[test]
+    fn test_is_operator_opted_in_to_slashing() {
+        let mut deps = mock_dependencies();
+        let env = mock_env();
+
+        let service = deps.api.addr_make("service");
+        let operator = deps.api.addr_make("operator");
+
+        // assert that the operator is not opted in
+        let res =
+            is_operator_opted_in_to_slashing(&deps.storage, &service, &operator, None).unwrap();
+        assert!(!res);
+
+        SLASHING_REGISTRY_OPT_IN
+            .save(
+                &mut deps.storage,
+                (&service, &operator),
+                &true,
+                env.block.height,
+            )
+            .unwrap();
+
+        // assert that the operator is opted in
+        let res =
+            is_operator_opted_in_to_slashing(&deps.storage, &service, &operator, None).unwrap();
+        assert!(res);
+    }
+
+    #[test]
+    fn test_reset_slashing_registry_opt_in() {
+        let mut deps = mock_dependencies();
+        let mut env = mock_env();
+
+        let service = deps.api.addr_make("service");
+        let service2 = deps.api.addr_make("service2");
+        let operator = deps.api.addr_make("operator");
+        let operator2 = deps.api.addr_make("operator2");
+
+        // set the slashing registry opt-in status
+        {
+            SLASHING_REGISTRY_OPT_IN
+                .save(
+                    &mut deps.storage,
+                    (&service, &operator),
+                    &true,
+                    env.block.height,
+                )
+                .unwrap();
+            SLASHING_REGISTRY_OPT_IN
+                .save(
+                    &mut deps.storage,
+                    (&service, &operator2),
+                    &true,
+                    env.block.height,
+                )
+                .unwrap();
+            SLASHING_REGISTRY_OPT_IN
+                .save(
+                    &mut deps.storage,
+                    (&service2, &operator),
+                    &true,
+                    env.block.height,
+                )
+                .unwrap();
+            SLASHING_REGISTRY_OPT_IN
+                .save(
+                    &mut deps.storage,
+                    (&service2, &operator2),
+                    &true,
+                    env.block.height,
+                )
+                .unwrap();
+        }
+
+        // move the block height forward
+        env.block.height += 10;
+
+        // assert that the operator and operator2 are opted in to service
+        let res =
+            is_operator_opted_in_to_slashing(&deps.storage, &service, &operator, None).unwrap();
+        assert!(res);
+        let res =
+            is_operator_opted_in_to_slashing(&deps.storage, &service, &operator2, None).unwrap();
+        assert!(res);
+
+        // reset the slashing registry opt-in status for service
+        reset_slashing_registry_opt_in(&mut deps.storage, &env, &service).unwrap();
+
+        // move the block height forward
+        env.block.height += 10;
+
+        // assert that the operator and operator2 are not opted in to service
+        let res =
+            is_operator_opted_in_to_slashing(&deps.storage, &service, &operator, None).unwrap();
+        assert!(!res);
+        let res =
+            is_operator_opted_in_to_slashing(&deps.storage, &service, &operator2, None).unwrap();
+        assert!(!res);
+
+        // assert that operator and operator2 are still opted in to service2
+        let res =
+            is_operator_opted_in_to_slashing(&deps.storage, &service2, &operator, None).unwrap();
+        assert!(res);
+        let res =
+            is_operator_opted_in_to_slashing(&deps.storage, &service2, &operator2, None).unwrap();
+        assert!(res);
+
+        // assert that the operator and operator2 are opted in to service at the previous height
+        let res = is_operator_opted_in_to_slashing(
+            &deps.storage,
+            &service,
+            &operator,
+            Some(env.block.height - 10),
+        )
+        .unwrap();
+        assert!(res);
+
+        let res = is_operator_opted_in_to_slashing(
+            &deps.storage,
+            &service,
+            &operator2,
+            Some(env.block.height - 10),
+        )
+        .unwrap();
+        assert!(res);
     }
 }

--- a/crates/bvs-registry/src/state.rs
+++ b/crates/bvs-registry/src/state.rs
@@ -114,7 +114,7 @@ pub fn get_registration_status_at_height(
     status.try_into()
 }
 
-/// Set the registration status of the Operator to Service at a current block height
+/// Set the registration status of the Operator to Service at current block height
 ///
 /// #### Warning
 /// This function will only save the state at the end of the block.

--- a/crates/bvs-registry/tests/integration_test.rs
+++ b/crates/bvs-registry/tests/integration_test.rs
@@ -769,7 +769,7 @@ fn enable_slashing_lifecycle() {
     {
         let slashing_parameters = SlashingParameters {
             destination: Some(burn_address.clone()),
-            max_slashing_percentage: 5000, // 50%
+            max_slashing_bips: 5000, // 50%
             resolution_window: 1000,
         };
         let enable_slashing_msg = &ExecuteMsg::EnableSlashing {
@@ -788,7 +788,7 @@ fn enable_slashing_lifecycle() {
                     .add_attribute("_contract_address", registry.addr.as_str())
                     .add_attribute("service", service.as_str())
                     .add_attribute("destination", burn_address.to_string())
-                    .add_attribute("max_slashing_percentage", "5000")
+                    .add_attribute("max_slashing_bips", "5000")
                     .add_attribute("resolution_window", "1000"),
             ]
         );
@@ -931,7 +931,7 @@ fn enable_slashing_lifecycle() {
     {
         let slashing_parameters = SlashingParameters {
             destination: Some(burn_address.clone()),
-            max_slashing_percentage: 9000, // 90%
+            max_slashing_bips: 9000, // 90%
             resolution_window: 1000,
         };
         let enable_slashing_msg = &ExecuteMsg::EnableSlashing {
@@ -968,7 +968,7 @@ fn enable_slashing_lifecycle() {
             prev_slashing_parameters_res,
             SlashingParameters {
                 destination: Some(burn_address.clone()),
-                max_slashing_percentage: 5000, // 50%
+                max_slashing_bips: 5000, // 50%
                 resolution_window: 1000,
             }
         );

--- a/modules/cosmwasm-schema/registry/schema.go
+++ b/modules/cosmwasm-schema/registry/schema.go
@@ -55,7 +55,7 @@ type EnableSlashingSlashingParameters struct {
 	// The maximum percentage of the operator's total stake that can be slashed. The value is
 	// represented in bips (basis points), where 100 bips = 1%. And the value must be between 0
 	// and 10_000 (inclusive).
-	MaxSlashingPercentage int64 `json:"max_slashing_percentage"`
+	MaxSlashingBips int64 `json:"max_slashing_bips"`
 	// The minimum amount of time (in seconds) that the slashing can be delayed before it is
 	// executed and finalized. Setting this value to a duration less than the queued withdrawal
 	// delay is recommended. To prevent restaker's early withdrawal of their assets from the
@@ -127,7 +127,7 @@ type SlashingParameters struct {
 	// The maximum percentage of the operator's total stake that can be slashed. The value is
 	// represented in bips (basis points), where 100 bips = 1%. And the value must be between 0
 	// and 10_000 (inclusive).
-	MaxSlashingPercentage int64 `json:"max_slashing_percentage"`
+	MaxSlashingBips int64 `json:"max_slashing_bips"`
 	// The minimum amount of time (in seconds) that the slashing can be delayed before it is
 	// executed and finalized. Setting this value to a duration less than the queued withdrawal
 	// delay is recommended. To prevent restaker's early withdrawal of their assets from the

--- a/modules/cosmwasm-schema/registry/schema.go
+++ b/modules/cosmwasm-schema/registry/schema.go
@@ -7,6 +7,8 @@ type IsOperatorResponse bool
 
 type IsOperatorActiveResponse bool
 
+type IsOperatorOptedInToSlashingResponse bool
+
 type IsServiceResponse bool
 
 type StatusResponse int64
@@ -25,6 +27,9 @@ type ExecuteMsg struct {
 	DeregisterOperatorFromService *DeregisterOperatorFromService `json:"deregister_operator_from_service,omitempty"`
 	RegisterServiceToOperator     *RegisterServiceToOperator     `json:"register_service_to_operator,omitempty"`
 	DeregisterServiceFromOperator *DeregisterServiceFromOperator `json:"deregister_service_from_operator,omitempty"`
+	EnableSlashing                *EnableSlashing                `json:"enable_slashing,omitempty"`
+	DisableSlashing               *DisableSlashing               `json:"disable_slashing,omitempty"`
+	OperatorOptInToSlashing       *OperatorOptInToSlashing       `json:"operator_opt_in_to_slashing,omitempty"`
 	TransferOwnership             *TransferOwnership             `json:"transfer_ownership,omitempty"`
 }
 
@@ -33,6 +38,31 @@ type DeregisterOperatorFromService struct {
 }
 
 type DeregisterServiceFromOperator struct {
+	Service string `json:"service"`
+}
+
+type DisableSlashing struct {
+}
+
+type EnableSlashing struct {
+	Registry RegistryClass `json:"registry"`
+}
+
+type RegistryClass struct {
+	// The address to which the slashed funds will be sent after the slashing is finalized.
+	// None, indicates that the slashed funds will be burned.
+	Destination *string `json:"destination"`
+	// The maximum percentage of the operator's total stake that can be slashed. The value is
+	// represented in bips (basis points), where 100 bips = 1%. And the value must be between 0
+	// and 10_000 (inclusive).
+	MaxSlashingPercentage int64 `json:"max_slashing_percentage"`
+	// The minimum amount of time (in seconds) that the slashing can be delayed before it is
+	// executed and finalized. It is recommended to set this value to a maximum of withdrawal
+	// delay or less.
+	ResolutionWindow int64 `json:"resolution_window"`
+}
+
+type OperatorOptInToSlashing struct {
 	Service string `json:"service"`
 }
 
@@ -64,14 +94,41 @@ type TransferOwnership struct {
 }
 
 type QueryMsg struct {
-	Status           *Status `json:"status,omitempty"`
-	IsService        *string `json:"is_service,omitempty"`
-	IsOperator       *string `json:"is_operator,omitempty"`
-	IsOperatorActive *string `json:"is_operator_active,omitempty"`
+	Status                      *Status                      `json:"status,omitempty"`
+	IsService                   *string                      `json:"is_service,omitempty"`
+	IsOperator                  *string                      `json:"is_operator,omitempty"`
+	IsOperatorActive            *string                      `json:"is_operator_active,omitempty"`
+	SlashingRegistry            *SlashingRegistryClass       `json:"slashing_registry,omitempty"`
+	IsOperatorOptedInToSlashing *IsOperatorOptedInToSlashing `json:"is_operator_opted_in_to_slashing,omitempty"`
+}
+
+type IsOperatorOptedInToSlashing struct {
+	Height   *int64 `json:"height"`
+	Operator string `json:"operator"`
+	Service  string `json:"service"`
+}
+
+type SlashingRegistryClass struct {
+	Height  *int64 `json:"height"`
+	Service string `json:"service"`
 }
 
 type Status struct {
 	Height   *int64 `json:"height"`
 	Operator string `json:"operator"`
 	Service  string `json:"service"`
+}
+
+type SlashingRegistry struct {
+	// The address to which the slashed funds will be sent after the slashing is finalized.
+	// None, indicates that the slashed funds will be burned.
+	Destination *string `json:"destination"`
+	// The maximum percentage of the operator's total stake that can be slashed. The value is
+	// represented in bips (basis points), where 100 bips = 1%. And the value must be between 0
+	// and 10_000 (inclusive).
+	MaxSlashingPercentage int64 `json:"max_slashing_percentage"`
+	// The minimum amount of time (in seconds) that the slashing can be delayed before it is
+	// executed and finalized. It is recommended to set this value to a maximum of withdrawal
+	// delay or less.
+	ResolutionWindow int64 `json:"resolution_window"`
 }

--- a/modules/cosmwasm-schema/registry/schema.go
+++ b/modules/cosmwasm-schema/registry/schema.go
@@ -45,10 +45,10 @@ type DisableSlashing struct {
 }
 
 type EnableSlashing struct {
-	Registry RegistryClass `json:"registry"`
+	SlashingParameters EnableSlashingSlashingParameters `json:"slashing_parameters"`
 }
 
-type RegistryClass struct {
+type EnableSlashingSlashingParameters struct {
 	// The address to which the slashed funds will be sent after the slashing is finalized.
 	// None, indicates that the slashed funds will be burned.
 	Destination *string `json:"destination"`
@@ -57,8 +57,9 @@ type RegistryClass struct {
 	// and 10_000 (inclusive).
 	MaxSlashingPercentage int64 `json:"max_slashing_percentage"`
 	// The minimum amount of time (in seconds) that the slashing can be delayed before it is
-	// executed and finalized. It is recommended to set this value to a maximum of withdrawal
-	// delay or less.
+	// executed and finalized. Setting this value to a duration less than the queued withdrawal
+	// delay is recommended. To prevent restaker's early withdrawal of their assets from the
+	// vault due to the impending slash, defeating the purpose of shared security.
 	ResolutionWindow int64 `json:"resolution_window"`
 }
 
@@ -98,7 +99,7 @@ type QueryMsg struct {
 	IsService                   *string                      `json:"is_service,omitempty"`
 	IsOperator                  *string                      `json:"is_operator,omitempty"`
 	IsOperatorActive            *string                      `json:"is_operator_active,omitempty"`
-	SlashingRegistry            *SlashingRegistryClass       `json:"slashing_registry,omitempty"`
+	SlashingParameters          *QueryMsgSlashingParameters  `json:"slashing_parameters,omitempty"`
 	IsOperatorOptedInToSlashing *IsOperatorOptedInToSlashing `json:"is_operator_opted_in_to_slashing,omitempty"`
 }
 
@@ -108,7 +109,7 @@ type IsOperatorOptedInToSlashing struct {
 	Service  string `json:"service"`
 }
 
-type SlashingRegistryClass struct {
+type QueryMsgSlashingParameters struct {
 	Height  *int64 `json:"height"`
 	Service string `json:"service"`
 }
@@ -119,7 +120,7 @@ type Status struct {
 	Service  string `json:"service"`
 }
 
-type SlashingRegistry struct {
+type SlashingParameters struct {
 	// The address to which the slashed funds will be sent after the slashing is finalized.
 	// None, indicates that the slashed funds will be burned.
 	Destination *string `json:"destination"`
@@ -128,7 +129,8 @@ type SlashingRegistry struct {
 	// and 10_000 (inclusive).
 	MaxSlashingPercentage int64 `json:"max_slashing_percentage"`
 	// The minimum amount of time (in seconds) that the slashing can be delayed before it is
-	// executed and finalized. It is recommended to set this value to a maximum of withdrawal
-	// delay or less.
+	// executed and finalized. Setting this value to a duration less than the queued withdrawal
+	// delay is recommended. To prevent restaker's early withdrawal of their assets from the
+	// vault due to the impending slash, defeating the purpose of shared security.
 	ResolutionWindow int64 `json:"resolution_window"`
 }

--- a/packages/cosmwasm-schema/registry.d.ts
+++ b/packages/cosmwasm-schema/registry.d.ts
@@ -56,7 +56,7 @@ export interface SlashingParameters {
    * represented in bips (basis points), where 100 bips = 1%. And the value must be between 0
    * and 10_000 (inclusive).
    */
-  max_slashing_percentage: number;
+  max_slashing_bips: number;
   /**
    * The minimum amount of time (in seconds) that the slashing can be delayed before it is
    * executed and finalized. Setting this value to a duration less than the queued withdrawal
@@ -138,7 +138,7 @@ export interface SlashingParametersResponse {
    * represented in bips (basis points), where 100 bips = 1%. And the value must be between 0
    * and 10_000 (inclusive).
    */
-  max_slashing_percentage: number;
+  max_slashing_bips: number;
   /**
    * The minimum amount of time (in seconds) that the slashing can be delayed before it is
    * executed and finalized. Setting this value to a duration less than the queued withdrawal

--- a/packages/cosmwasm-schema/registry.d.ts
+++ b/packages/cosmwasm-schema/registry.d.ts
@@ -42,10 +42,10 @@ export interface DeregisterServiceFromOperator {
 export interface DisableSlashing {}
 
 export interface EnableSlashing {
-  registry: SlashingRegistry;
+  slashing_parameters: SlashingParameters;
 }
 
-export interface SlashingRegistry {
+export interface SlashingParameters {
   /**
    * The address to which the slashed funds will be sent after the slashing is finalized.
    * None, indicates that the slashed funds will be burned.
@@ -59,8 +59,9 @@ export interface SlashingRegistry {
   max_slashing_percentage: number;
   /**
    * The minimum amount of time (in seconds) that the slashing can be delayed before it is
-   * executed and finalized. It is recommended to set this value to a maximum of withdrawal
-   * delay or less.
+   * executed and finalized. Setting this value to a duration less than the queued withdrawal
+   * delay is recommended. To prevent restaker's early withdrawal of their assets from the
+   * vault due to the impending slash, defeating the purpose of shared security.
    */
   resolution_window: number;
 }
@@ -105,7 +106,7 @@ export interface QueryMsg {
   is_service?: string;
   is_operator?: string;
   is_operator_active?: string;
-  slashing_registry?: SlashingRegistryClass;
+  slashing_parameters?: QueryMsgSlashingParameters;
   is_operator_opted_in_to_slashing?: IsOperatorOptedInToSlashing;
 }
 
@@ -115,7 +116,7 @@ export interface IsOperatorOptedInToSlashing {
   service: string;
 }
 
-export interface SlashingRegistryClass {
+export interface QueryMsgSlashingParameters {
   height?: number | null;
   service: string;
 }
@@ -126,7 +127,7 @@ export interface Status {
   service: string;
 }
 
-export interface SlashingRegistryResponse {
+export interface SlashingParametersResponse {
   /**
    * The address to which the slashed funds will be sent after the slashing is finalized.
    * None, indicates that the slashed funds will be burned.
@@ -140,8 +141,9 @@ export interface SlashingRegistryResponse {
   max_slashing_percentage: number;
   /**
    * The minimum amount of time (in seconds) that the slashing can be delayed before it is
-   * executed and finalized. It is recommended to set this value to a maximum of withdrawal
-   * delay or less.
+   * executed and finalized. Setting this value to a duration less than the queued withdrawal
+   * delay is recommended. To prevent restaker's early withdrawal of their assets from the
+   * vault due to the impending slash, defeating the purpose of shared security.
    */
   resolution_window: number;
 }

--- a/packages/cosmwasm-schema/registry.d.ts
+++ b/packages/cosmwasm-schema/registry.d.ts
@@ -5,6 +5,8 @@ type IsOperatorResponse = boolean;
 
 type IsOperatorActiveResponse = boolean;
 
+type IsOperatorOptedInToSlashingResponse = boolean;
+
 type IsServiceResponse = boolean;
 
 type StatusResponse = number;
@@ -23,6 +25,9 @@ export interface ExecuteMsg {
   deregister_operator_from_service?: DeregisterOperatorFromService;
   register_service_to_operator?: RegisterServiceToOperator;
   deregister_service_from_operator?: DeregisterServiceFromOperator;
+  enable_slashing?: EnableSlashing;
+  disable_slashing?: DisableSlashing;
+  operator_opt_in_to_slashing?: OperatorOptInToSlashing;
   transfer_ownership?: TransferOwnership;
 }
 
@@ -31,6 +36,36 @@ export interface DeregisterOperatorFromService {
 }
 
 export interface DeregisterServiceFromOperator {
+  service: string;
+}
+
+export interface DisableSlashing {}
+
+export interface EnableSlashing {
+  registry: SlashingRegistry;
+}
+
+export interface SlashingRegistry {
+  /**
+   * The address to which the slashed funds will be sent after the slashing is finalized.
+   * None, indicates that the slashed funds will be burned.
+   */
+  destination?: null | string;
+  /**
+   * The maximum percentage of the operator's total stake that can be slashed. The value is
+   * represented in bips (basis points), where 100 bips = 1%. And the value must be between 0
+   * and 10_000 (inclusive).
+   */
+  max_slashing_percentage: number;
+  /**
+   * The minimum amount of time (in seconds) that the slashing can be delayed before it is
+   * executed and finalized. It is recommended to set this value to a maximum of withdrawal
+   * delay or less.
+   */
+  resolution_window: number;
+}
+
+export interface OperatorOptInToSlashing {
   service: string;
 }
 
@@ -70,10 +105,43 @@ export interface QueryMsg {
   is_service?: string;
   is_operator?: string;
   is_operator_active?: string;
+  slashing_registry?: SlashingRegistryClass;
+  is_operator_opted_in_to_slashing?: IsOperatorOptedInToSlashing;
+}
+
+export interface IsOperatorOptedInToSlashing {
+  height?: number | null;
+  operator: string;
+  service: string;
+}
+
+export interface SlashingRegistryClass {
+  height?: number | null;
+  service: string;
 }
 
 export interface Status {
   height?: number | null;
   operator: string;
   service: string;
+}
+
+export interface SlashingRegistryResponse {
+  /**
+   * The address to which the slashed funds will be sent after the slashing is finalized.
+   * None, indicates that the slashed funds will be burned.
+   */
+  destination?: null | string;
+  /**
+   * The maximum percentage of the operator's total stake that can be slashed. The value is
+   * represented in bips (basis points), where 100 bips = 1%. And the value must be between 0
+   * and 10_000 (inclusive).
+   */
+  max_slashing_percentage: number;
+  /**
+   * The minimum amount of time (in seconds) that the slashing can be delayed before it is
+   * executed and finalized. It is recommended to set this value to a maximum of withdrawal
+   * delay or less.
+   */
+  resolution_window: number;
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

Main changes:
- `ExecuteMsg::EnableSlashing` - service enable / update slashing condition
- `ExecuteMsg::DisableSlashing` - service disable slashing condition
- `ExecuteMsg::OperatorOptInToSlashing` - active operator opt in to service slashing condition
- `QueryMsg::SlashingRegistry` - retrieve service's slashing condition
- `QueryMsg::IsOperatorOptedInToSlashing` - check if operator is opted into service slashing condition

Notable changes:

- Introduced small time helper lib in `bvs-library` for more readable time (in seconds)
- Once slashing is enabled, new Operator <-> Service active registration will **AUTOMATICALLY** opt in operator into the slashing condition.
- With SL-471, increasing/decreasing counter is coupled tightly with `set_registration_status` fn.

TODO:

- [x] Integration_test

<!-- remove if not applicable -->
Closes SL-464
Closes SL-471