### PR TITLE
chore: document Registration status

### DIFF
--- a/crates/bvs-registry/src/msg.rs
+++ b/crates/bvs-registry/src/msg.rs
@@ -46,6 +46,23 @@ pub struct Metadata {
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {
+    /// QueryMsg Status: Returns the registration status of an operator to a service
+    /// The response is a StatusResponse
+    /// that contains a u8 value that maps to a RegistrationStatus:
+    ///
+    /// - 0: Inactive - Default state when neither the Operator nor the Service has registered,
+    /// or when either has unregistered
+    ///
+    /// - 1: Active - State when both the Operator and Service have registered with each other,
+    /// indicating a fully established relationship
+    ///
+    /// - 2: OperatorRegistered -
+    /// State when only the Operator has registered but the Service hasn't yet,
+    /// indicating a pending registration from the Service side
+    ///
+    /// - 3: ServiceRegistered -
+    /// State when only the Service has registered but the Operator hasn't yet,
+    /// indicating a pending registration from the Operator side
     #[returns(StatusResponse)]
     Status {
         service: String,

--- a/crates/bvs-registry/src/msg.rs
+++ b/crates/bvs-registry/src/msg.rs
@@ -50,17 +50,19 @@ pub enum QueryMsg {
     /// The response is a StatusResponse
     /// that contains a u8 value that maps to a RegistrationStatus:
     ///
-    /// - 0: Inactive - Default state when neither the Operator nor the Service has registered,
+    /// - 0: Inactive:
+    /// Default state when neither the Operator nor the Service has registered,
     /// or when either has unregistered
     ///
-    /// - 1: Active - State when both the Operator and Service have registered with each other,
+    /// - 1: Active:
+    /// State when both the Operator and Service have registered with each other,
     /// indicating a fully established relationship
     ///
-    /// - 2: OperatorRegistered -
+    /// - 2: OperatorRegistered:
     /// State when only the Operator has registered but the Service hasn't yet,
     /// indicating a pending registration from the Service side
     ///
-    /// - 3: ServiceRegistered -
+    /// - 3: ServiceRegistered:
     /// State when only the Service has registered but the Operator hasn't yet,
     /// indicating a pending registration from the Operator side
     #[returns(StatusResponse)]

--- a/crates/bvs-registry/src/state.rs
+++ b/crates/bvs-registry/src/state.rs
@@ -47,9 +47,22 @@ pub fn require_operator_registered(
 /// Becomes Inactive when the Operator or Service have unregistered (default state)
 #[cw_serde]
 pub enum RegistrationStatus {
+    /// Default state when neither the Operator nor the Service has registered,
+    /// or when either the Operator or Service has unregistered
     Inactive = 0,
+
+    /// State when both the Operator and Service have registered with each other,
+    /// indicating a fully established relationship
     Active = 1,
+
+    /// State when only the Operator has registered but the Service hasn't yet registered,
+    /// indicating a pending registration from the Service side
+    /// This is Operator-initiated registration, waiting for Service to finalize
     OperatorRegistered = 2,
+
+    /// State when only the Service has registered but the Operator hasn't yet registered,
+    /// indicating a pending registration from the Operator side
+    /// This is Service-initiated registration, waiting for Operator to finalize
     ServiceRegistered = 3,
 }
 

--- a/modules/cosmwasm-schema/registry/schema.go
+++ b/modules/cosmwasm-schema/registry/schema.go
@@ -63,6 +63,20 @@ type TransferOwnership struct {
 	NewOwner string `json:"new_owner"`
 }
 
+// QueryMsg Status: Returns the registration status of an operator to a service The response
+// is a StatusResponse that contains a u8 value that maps to a RegistrationStatus:
+//
+// - 0: Inactive - Default state when neither the Operator nor the Service has registered,
+// or when either has unregistered
+//
+// - 1: Active - State when both the Operator and Service have registered with each other,
+// indicating a fully established relationship
+//
+// - 2: OperatorRegistered - State when only the Operator has registered but the Service
+// hasn't yet, indicating a pending registration from the Service side
+//
+// - 3: ServiceRegistered - State when only the Service has registered but the Operator
+// hasn't yet, indicating a pending registration from the Operator side
 type QueryMsg struct {
 	Status           *Status `json:"status,omitempty"`
 	IsService        *string `json:"is_service,omitempty"`

--- a/modules/cosmwasm-schema/registry/schema.go
+++ b/modules/cosmwasm-schema/registry/schema.go
@@ -66,16 +66,16 @@ type TransferOwnership struct {
 // QueryMsg Status: Returns the registration status of an operator to a service The response
 // is a StatusResponse that contains a u8 value that maps to a RegistrationStatus:
 //
-// - 0: Inactive - Default state when neither the Operator nor the Service has registered,
-// or when either has unregistered
+// - 0: Inactive: Default state when neither the Operator nor the Service has registered, or
+// when either has unregistered
 //
-// - 1: Active - State when both the Operator and Service have registered with each other,
+// - 1: Active: State when both the Operator and Service have registered with each other,
 // indicating a fully established relationship
 //
-// - 2: OperatorRegistered - State when only the Operator has registered but the Service
+// - 2: OperatorRegistered: State when only the Operator has registered but the Service
 // hasn't yet, indicating a pending registration from the Service side
 //
-// - 3: ServiceRegistered - State when only the Service has registered but the Operator
+// - 3: ServiceRegistered: State when only the Service has registered but the Operator
 // hasn't yet, indicating a pending registration from the Operator side
 type QueryMsg struct {
 	Status           *Status `json:"status,omitempty"`

--- a/packages/cosmwasm-schema/registry.d.ts
+++ b/packages/cosmwasm-schema/registry.d.ts
@@ -69,16 +69,16 @@ export interface TransferOwnership {
  * QueryMsg Status: Returns the registration status of an operator to a service The response
  * is a StatusResponse that contains a u8 value that maps to a RegistrationStatus:
  *
- * - 0: Inactive - Default state when neither the Operator nor the Service has registered,
- * or when either has unregistered
+ * - 0: Inactive: Default state when neither the Operator nor the Service has registered, or
+ * when either has unregistered
  *
- * - 1: Active - State when both the Operator and Service have registered with each other,
+ * - 1: Active: State when both the Operator and Service have registered with each other,
  * indicating a fully established relationship
  *
- * - 2: OperatorRegistered - State when only the Operator has registered but the Service
+ * - 2: OperatorRegistered: State when only the Operator has registered but the Service
  * hasn't yet, indicating a pending registration from the Service side
  *
- * - 3: ServiceRegistered - State when only the Service has registered but the Operator
+ * - 3: ServiceRegistered: State when only the Service has registered but the Operator
  * hasn't yet, indicating a pending registration from the Operator side
  */
 export interface QueryMsg {

--- a/packages/cosmwasm-schema/registry.d.ts
+++ b/packages/cosmwasm-schema/registry.d.ts
@@ -65,6 +65,22 @@ export interface TransferOwnership {
   new_owner: string;
 }
 
+/**
+ * QueryMsg Status: Returns the registration status of an operator to a service The response
+ * is a StatusResponse that contains a u8 value that maps to a RegistrationStatus:
+ *
+ * - 0: Inactive - Default state when neither the Operator nor the Service has registered,
+ * or when either has unregistered
+ *
+ * - 1: Active - State when both the Operator and Service have registered with each other,
+ * indicating a fully established relationship
+ *
+ * - 2: OperatorRegistered - State when only the Operator has registered but the Service
+ * hasn't yet, indicating a pending registration from the Service side
+ *
+ * - 3: ServiceRegistered - State when only the Service has registered but the Operator
+ * hasn't yet, indicating a pending registration from the Operator side
+ */
 export interface QueryMsg {
   status?: Status;
   is_service?: string;


### PR DESCRIPTION
#### What this PR does / why we need it:

Fully document the registration status for extra verbosity.

Closes SL-472