### PR TITLE
chore(release): cargo publish without verification

### DIFF
--- a/crates/bvs-library/package.json
+++ b/crates/bvs-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@satlayer/bvs-library",
   "scripts": {
-    "cargo:publish": "cargo publish"
+    "cargo:publish": "cargo publish --no-verify"
   }
 }

--- a/crates/bvs-pauser/package.json
+++ b/crates/bvs-pauser/package.json
@@ -6,9 +6,6 @@
   ],
   "scripts": {
     "build": "cosmwasm-optimizer --root=../",
-    "cargo:publish": "cargo publish"
-  },
-  "dependencies": {
-    "@satlayer/bvs-library": "workspace:*"
+    "cargo:publish": "cargo publish --no-verify"
   }
 }

--- a/crates/bvs-registry/package.json
+++ b/crates/bvs-registry/package.json
@@ -6,10 +6,6 @@
   ],
   "scripts": {
     "build": "cosmwasm-optimizer --root=../",
-    "cargo:publish": "cargo publish"
-  },
-  "dependencies": {
-    "@satlayer/bvs-library": "workspace:*",
-    "@satlayer/bvs-pauser": "workspace:*"
+    "cargo:publish": "cargo publish --no-verify"
   }
 }

--- a/crates/bvs-vault-cw20/src/contract.rs
+++ b/crates/bvs-vault-cw20/src/contract.rs
@@ -430,6 +430,3 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response
     cw2::ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     Ok(Response::default())
 }
-
-#[cfg(test)]
-mod tests {}

--- a/crates/bvs-vault-cw20/tests/integration_test.rs
+++ b/crates/bvs-vault-cw20/tests/integration_test.rs
@@ -947,14 +947,11 @@ fn test_vault_info() {
 fn test_system_lock_assets() {
     let app = &mut App::default();
     let TestContracts {
-        pauser,
-        registry,
         router,
         cw20,
         vault,
+        ..
     } = TestContracts::init(app);
-    let owner = app.api().addr_make("owner");
-    let denom = "denom";
     let original_deposit_amount: u128 = 100_000_000;
 
     let stakers = [

--- a/crates/bvs-vault-router/package.json
+++ b/crates/bvs-vault-router/package.json
@@ -6,11 +6,6 @@
   ],
   "scripts": {
     "build": "cosmwasm-optimizer --root=../",
-    "cargo:publish": "cargo publish"
-  },
-  "dependencies": {
-    "@satlayer/bvs-library": "workspace:*",
-    "@satlayer/bvs-pauser": "workspace:*",
-    "@satlayer/bvs-registry": "workspace:*"
+    "cargo:publish": "cargo publish --no-verify"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,20 +46,9 @@ importers:
 
   crates/bvs-library: {}
 
-  crates/bvs-pauser:
-    dependencies:
-      '@satlayer/bvs-library':
-        specifier: workspace:*
-        version: link:../bvs-library
+  crates/bvs-pauser: {}
 
-  crates/bvs-registry:
-    dependencies:
-      '@satlayer/bvs-library':
-        specifier: workspace:*
-        version: link:../bvs-library
-      '@satlayer/bvs-pauser':
-        specifier: workspace:*
-        version: link:../bvs-pauser
+  crates/bvs-registry: {}
 
   crates/bvs-rewards: {}
 
@@ -69,17 +58,7 @@ importers:
 
   crates/bvs-vault-factory: {}
 
-  crates/bvs-vault-router:
-    dependencies:
-      '@satlayer/bvs-library':
-        specifier: workspace:*
-        version: link:../bvs-library
-      '@satlayer/bvs-pauser':
-        specifier: workspace:*
-        version: link:../bvs-pauser
-      '@satlayer/bvs-registry':
-        specifier: workspace:*
-        version: link:../bvs-registry
+  crates/bvs-vault-router: {}
 
   docs:
     dependencies:


### PR DESCRIPTION
#### What this PR does / why we need it:

Due to `dev-dependency` circular setup, added `--no-verify` such that cargo publish doesn't build before publishing.