### PR TITLE
chore: remove outdated TODOs

### DIFF
--- a/crates/bvs-library/src/testing/contract.rs
+++ b/crates/bvs-library/src/testing/contract.rs
@@ -136,9 +136,7 @@ impl
     fn new(app: &mut App, env: &Env, msg: Option<cw20_base::msg::InstantiateMsg>) -> Self {
         let init = msg.unwrap_or(Self::default_init(app, env));
         let code_id = Self::store_code(app);
-        let addr = Self::instantiate(app, code_id, "underlying_token", &init);
-        // TODO(fuxingloh): extra label for ease of testing, to remove `underlying_token`.
-        Self::set_contract_addr(app, "cw20", &addr);
+        let addr = Self::instantiate(app, code_id, "cw20", &init);
         Self { addr, init }
     }
 

--- a/crates/bvs-registry/tests/integration_test.rs
+++ b/crates/bvs-registry/tests/integration_test.rs
@@ -335,13 +335,6 @@ fn register_lifecycle_service_first() {
     assert_eq!(status, StatusResponse(1));
 }
 
-// TODO: deregister from service
-// TODO: deregister from operator
-// TODO: already deregistered
-// TODO: already active
-// TODO: operator already registered
-// TODO: service already registered
-
 #[test]
 fn update_metadata_successfully() {
     let (mut app, registry, ..) = instantiate();


### PR DESCRIPTION
#### What this PR does / why we need it:

These TODOs were outdated.