### PR TITLE
chore: description for bvs-vault-cw20-tokenized

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -354,7 +354,6 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
- "cw-storage-plus",
  "cw2",
  "cw20",
  "cw20-base",

--- a/crates/bvs-vault-cw20-tokenized/Cargo.toml
+++ b/crates/bvs-vault-cw20-tokenized/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 homepage.workspace = true
 documentation.workspace = true
 keywords.workspace = true
+description.workspace = true
 
 include = ["src"]
 
@@ -20,7 +21,6 @@ library = []
 [dependencies]
 cosmwasm-std = { workspace = true }
 cosmwasm-schema = { workspace = true }
-cw-storage-plus = { workspace = true }
 cw2 = { workspace = true }
 cw20-base = { workspace = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix missing `description.workspace = true` for `bvs-vault-cw20-tokenized`.