### PR TITLE
chore: use `pub(crate)` in `state.rs`

### DIFF
--- a/crates/bvs-pauser/src/state.rs
+++ b/crates/bvs-pauser/src/state.rs
@@ -1,3 +1,3 @@
 use cw_storage_plus::Item;
 
-pub const PAUSED: Item<bool> = Item::new("paused");
+pub(crate) const PAUSED: Item<bool> = Item::new("paused");

--- a/crates/bvs-registry/src/state.rs
+++ b/crates/bvs-registry/src/state.rs
@@ -7,7 +7,7 @@ use cw_storage_plus::{Map, SnapshotMap};
 
 /// Mapping of service address to boolean value
 /// indicating if the service is registered with the registry
-pub const SERVICES: Map<&Service, bool> = Map::new("services");
+pub(crate) const SERVICES: Map<&Service, bool> = Map::new("services");
 
 /// Require that the service is registered in the state
 pub fn require_service_registered(
@@ -25,7 +25,7 @@ pub fn require_service_registered(
 
 /// Mapping of operator address to boolean value
 /// indicating if the operator is registered with the registry
-pub const OPERATORS: Map<&Operator, bool> = Map::new("operators");
+pub(crate) const OPERATORS: Map<&Operator, bool> = Map::new("operators");
 
 pub fn require_operator_registered(
     store: &dyn Storage,
@@ -170,7 +170,7 @@ pub fn require_active_registration_status(
 
 /// Stores the active registration count of the operator to services.
 /// This is used to check if the operator is actively registered to any service (> 0)
-pub const OPERATOR_ACTIVE_REGISTRATION_COUNT: Map<&Operator, u64> =
+pub(crate) const OPERATOR_ACTIVE_REGISTRATION_COUNT: Map<&Operator, u64> =
     Map::new("operator_active_registration_count");
 
 /// Check if the operator is actively registered to any service

--- a/crates/bvs-vault-factory/src/state.rs
+++ b/crates/bvs-vault-factory/src/state.rs
@@ -3,8 +3,8 @@ use crate::ContractError;
 use cosmwasm_std::{Addr, StdError, StdResult, Storage};
 use cw_storage_plus::{Item, Map};
 
-pub const ROUTER: Item<Addr> = Item::new("router");
-pub const REGISTRY: Item<Addr> = Item::new("registry");
+pub(crate) const ROUTER: Item<Addr> = Item::new("router");
+pub(crate) const REGISTRY: Item<Addr> = Item::new("registry");
 
 /// Contains the code_ids of the contracts that are allowed to be deployed by the factory.
 /// > Permissioned by owner address of factory contract.
@@ -12,13 +12,16 @@ pub const REGISTRY: Item<Addr> = Item::new("registry");
 /// > the factory contract needs to know the code_id of the contract.
 const CODE_IDS: Map<&u8, u64> = Map::new("code_ids");
 
-pub fn get_code_id(store: &dyn Storage, vault_type: &VaultType) -> Result<u64, ContractError> {
+pub(crate) fn get_code_id(
+    store: &dyn Storage,
+    vault_type: &VaultType,
+) -> Result<u64, ContractError> {
     CODE_IDS
         .load(store, &vault_type.into())
         .map_err(|_| ContractError::CodeIdNotFound {})
 }
 
-pub fn set_code_id(
+pub(crate) fn set_code_id(
     store: &mut dyn Storage,
     vault_type: &VaultType,
     code_id: &u64,

--- a/crates/bvs-vault-router/src/state.rs
+++ b/crates/bvs-vault-router/src/state.rs
@@ -8,10 +8,10 @@ use std::fmt;
 use std::ops::{Deref, DerefMut};
 
 /// Mapping of vault's Addr to Vault
-pub const VAULTS: Map<&Addr, Vault> = Map::new("vaults");
+pub(crate) const VAULTS: Map<&Addr, Vault> = Map::new("vaults");
 
 /// Storage for the router address
-pub const REGISTRY: Item<Addr> = Item::new("registry");
+pub(crate) const REGISTRY: Item<Addr> = Item::new("registry");
 
 #[cw_serde]
 pub struct Vault {
@@ -20,7 +20,7 @@ pub struct Vault {
 
 /// Get the `registry` address
 /// If [`instantiate`] has not been called, it will return an [StdError::NotFound]
-pub fn get_registry(storage: &dyn Storage) -> StdResult<Addr> {
+pub(crate) fn get_registry(storage: &dyn Storage) -> StdResult<Addr> {
     REGISTRY
         .may_load(storage)?
         .ok_or(StdError::not_found("registry"))
@@ -28,19 +28,20 @@ pub fn get_registry(storage: &dyn Storage) -> StdResult<Addr> {
 
 /// Set the `registry` address, called once during `initialization`.
 /// The `registry` is the address where the vault calls
-pub fn set_registry(storage: &mut dyn Storage, registry: &Addr) -> StdResult<()> {
+pub(crate) fn set_registry(storage: &mut dyn Storage, registry: &Addr) -> StdResult<()> {
     REGISTRY.save(storage, registry)?;
     Ok(())
 }
+
 /// Store the withdrawal lock period in seconds.
-pub const WITHDRAWAL_LOCK_PERIOD: Item<Uint64> = Item::new("withdrawal_lock_period");
+pub(crate) const WITHDRAWAL_LOCK_PERIOD: Item<Uint64> = Item::new("withdrawal_lock_period");
 
 /// This is used when the withdrawal lock period is not set.
 /// The default value is 7 days.
 pub const DEFAULT_WITHDRAWAL_LOCK_PERIOD: Uint64 = Uint64::new(604800);
 
 /// Operator to its managed vaults. Key = (OperatorAddr, VaultAddr)
-pub const OPERATOR_VAULTS: Map<(&Addr, &Addr), ()> = Map::new("operator_vaults");
+pub(crate) const OPERATOR_VAULTS: Map<(&Addr, &Addr), ()> = Map::new("operator_vaults");
 
 #[cw_serde]
 pub struct SlashingRequest {
@@ -140,7 +141,7 @@ pub(crate) const SLASHING_REQUEST_IDS: Map<(&Service, &Operator), SlashingReques
 pub(crate) const SLASHING_REQUESTS: Map<SlashingRequestId, SlashingRequest> =
     Map::new("slashing_requests");
 
-pub fn get_active_slashing_requests(
+pub(crate) fn get_active_slashing_requests(
     store: &dyn Storage,
     service: &Service,
     operator: &Operator,
@@ -159,7 +160,7 @@ pub fn get_active_slashing_requests(
     }
 }
 
-pub fn save_slashing_request(
+pub(crate) fn save_slashing_request(
     store: &mut dyn Storage,
     service: &Service,
     operator: &Operator,

--- a/examples/squaring/contract/src/state.rs
+++ b/examples/squaring/contract/src/state.rs
@@ -4,12 +4,12 @@ use cw_storage_plus::{Item, Map};
 
 /// Key = Input
 /// Value = Requester of the computation
-pub const REQUESTS: Map<&i64, Addr> = Map::new("requests");
+pub(crate) const REQUESTS: Map<&i64, Addr> = Map::new("requests");
 
 /// Key = (Input, Operator)
 /// Value = Output
 /// Each Operator writes their own response to the output.
-pub const RESPONSES: Map<(i64, &Addr), i64> = Map::new("responses");
+pub(crate) const RESPONSES: Map<(i64, &Addr), i64> = Map::new("responses");
 
 #[cw_serde]
 pub(crate) struct Config {
@@ -18,4 +18,4 @@ pub(crate) struct Config {
 }
 
 /// Config of the contract.
-pub const CONFIG: Item<Config> = Item::new("config");
+pub(crate) const CONFIG: Item<Config> = Item::new("config");


### PR DESCRIPTION
#### What this PR does / why we need it:

Use `pub(crate) const` and `pub(crate) fn` for most functions and state variables to limit the visibility of these crates.

Closes SL-486

