### PR TITLE
chore: use Timestamp type to compute time

### DIFF
--- a/crates/bvs-vault-bank/src/contract.rs
+++ b/crates/bvs-vault-bank/src/contract.rs
@@ -193,9 +193,8 @@ mod execute {
 
         let withdrawal_lock_period: u64 =
             router::get_withdrawal_lock_period(&deps.as_ref())?.into();
-        let current_timestamp = env.block.time.seconds();
-        let unlock_timestamp =
-            Timestamp::from_seconds(withdrawal_lock_period).plus_seconds(current_timestamp);
+        let current_timestamp = env.block.time;
+        let unlock_timestamp = current_timestamp.plus_seconds(withdrawal_lock_period);
 
         let queued_withdrawal_info = QueuedWithdrawalInfo {
             queued_shares: msg.amount,

--- a/crates/bvs-vault-bank/src/contract.rs
+++ b/crates/bvs-vault-bank/src/contract.rs
@@ -784,12 +784,13 @@ mod tests {
         }
 
         let recipient = deps.api.addr_make("recipient");
-        let new_unlock_timestamp = Timestamp::from_seconds(
-            env.block
-                .time
-                .plus_seconds(withdrawal_lock_period.into())
-                .seconds(),
-        );
+        let new_unlock_timestamp = env.block.time.plus_seconds(withdrawal_lock_period.into());
+        // let new_unlock_timestamp = Timestamp::from_seconds(
+        //     env.block
+        //         .time
+        //         .plus_seconds(withdrawal_lock_period.into())
+        //         .seconds(),
+        // );
 
         // queue withdrawal to for the first time
         {

--- a/crates/bvs-vault-bank/src/contract.rs
+++ b/crates/bvs-vault-bank/src/contract.rs
@@ -75,7 +75,7 @@ mod execute {
     use bvs_vault_base::msg::{Amount, Recipient, RecipientAmount};
     use bvs_vault_base::shares::QueuedWithdrawalInfo;
     use bvs_vault_base::{offset, router, shares};
-    use cosmwasm_std::{DepsMut, Env, Event, MessageInfo, Response, StdError, Timestamp};
+    use cosmwasm_std::{DepsMut, Env, Event, MessageInfo, Response, StdError};
 
     /// Deposit an asset (`info.funds`) into the vault through native bank transfer and receive shares.
     ///
@@ -429,7 +429,7 @@ mod tests {
     use cosmwasm_std::testing::{message_info, mock_dependencies, mock_env};
     use cosmwasm_std::{
         coin, coins, from_json, to_json_binary, BankMsg, Coin, ContractResult, CosmosMsg, Event,
-        Response, SystemError, SystemResult, Timestamp, Uint128, Uint64, WasmQuery,
+        Response, SystemError, SystemResult, Uint128, Uint64, WasmQuery,
     };
 
     #[test]
@@ -785,12 +785,6 @@ mod tests {
 
         let recipient = deps.api.addr_make("recipient");
         let new_unlock_timestamp = env.block.time.plus_seconds(withdrawal_lock_period.into());
-        // let new_unlock_timestamp = Timestamp::from_seconds(
-        //     env.block
-        //         .time
-        //         .plus_seconds(withdrawal_lock_period.into())
-        //         .seconds(),
-        // );
 
         // queue withdrawal to for the first time
         {

--- a/crates/bvs-vault-bank/tests/integration_test.rs
+++ b/crates/bvs-vault-bank/tests/integration_test.rs
@@ -710,7 +710,7 @@ fn test_queue_withdrawal_to_successfully() {
     assert_eq!(response.queued_shares, Uint128::new(10000));
     assert_eq!(
         response.unlock_timestamp,
-        Timestamp::from_seconds(1571797519)
+        Timestamp::from_nanos(1571797519879305533)
     );
 }
 

--- a/crates/bvs-vault-cw20-tokenized/src/contract.rs
+++ b/crates/bvs-vault-cw20-tokenized/src/contract.rs
@@ -207,7 +207,7 @@ mod vault_execute {
         shares::{self, QueuedWithdrawalInfo},
     };
     use bvs_vault_cw20::token as UnderlyingToken;
-    use cosmwasm_std::{DepsMut, Env, Event, MessageInfo, Response, Timestamp};
+    use cosmwasm_std::{DepsMut, Env, Event, MessageInfo, Response};
     use cw20_base::contract::execute_burn as receipt_token_burn;
 
     /// This executes a transfer of assets from the `info.sender` to the vault contract.

--- a/crates/bvs-vault-cw20-tokenized/src/contract.rs
+++ b/crates/bvs-vault-cw20-tokenized/src/contract.rs
@@ -345,9 +345,8 @@ mod vault_execute {
 
         let withdrawal_lock_period: u64 =
             router::get_withdrawal_lock_period(&deps.as_ref())?.into();
-        let current_timestamp = env.block.time.seconds();
-        let unlock_timestamp =
-            Timestamp::from_seconds(withdrawal_lock_period).plus_seconds(current_timestamp);
+        let current_timestamp = env.block.time;
+        let unlock_timestamp = current_timestamp.plus_seconds(withdrawal_lock_period);
 
         let new_queued_withdrawal_info = QueuedWithdrawalInfo {
             queued_shares: msg.amount,

--- a/crates/bvs-vault-cw20-tokenized/tests/integration_test.rs
+++ b/crates/bvs-vault-cw20-tokenized/tests/integration_test.rs
@@ -697,7 +697,7 @@ fn test_queue_withdrawal_to_successfully() {
     assert_eq!(response.queued_shares, Uint128::new(10000));
     assert_eq!(
         response.unlock_timestamp,
-        Timestamp::from_seconds(1571797519)
+        Timestamp::from_nanos(1571797519879305533)
     );
 }
 

--- a/crates/bvs-vault-cw20/src/contract.rs
+++ b/crates/bvs-vault-cw20/src/contract.rs
@@ -85,7 +85,7 @@ mod execute {
         offset, router,
         shares::{self, QueuedWithdrawalInfo},
     };
-    use cosmwasm_std::{DepsMut, Env, Event, MessageInfo, Response, Timestamp};
+    use cosmwasm_std::{DepsMut, Env, Event, MessageInfo, Response};
 
     /// This executes a transfer of assets from the `info.sender` to the vault contract.
     ///

--- a/crates/bvs-vault-cw20/src/contract.rs
+++ b/crates/bvs-vault-cw20/src/contract.rs
@@ -202,9 +202,8 @@ mod execute {
 
         let withdrawal_lock_period: u64 =
             router::get_withdrawal_lock_period(&deps.as_ref())?.into();
-        let current_timestamp = env.block.time.seconds();
-        let unlock_timestamp =
-            Timestamp::from_seconds(withdrawal_lock_period).plus_seconds(current_timestamp);
+        let current_timestamp = env.block.time;
+        let unlock_timestamp = current_timestamp.plus_seconds(withdrawal_lock_period);
 
         let new_queued_withdrawal_info = QueuedWithdrawalInfo {
             queued_shares: msg.amount,

--- a/crates/bvs-vault-cw20/tests/integration_test.rs
+++ b/crates/bvs-vault-cw20/tests/integration_test.rs
@@ -612,7 +612,7 @@ fn test_queue_withdrawal_to_successfully() {
     assert_eq!(response.queued_shares, Uint128::new(10000));
     assert_eq!(
         response.unlock_timestamp,
-        Timestamp::from_seconds(1571797519)
+        Timestamp::from_nanos(1571797519879305533)
     );
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Use `Timestamp` to compute unlock timestamp to avoid extra type conversion.

<!-- remove if not applicable -->
Closes SL-480