### PR TITLE
feat: bvs-guardrail

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -227,6 +227,8 @@ dependencies = [
  "cw-utils",
  "cw2",
  "cw3",
+ "cw4",
+ "cw4-group",
  "serde",
  "thiserror 1.0.69",
 ]
@@ -665,6 +667,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw-controllers"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c1804013d21060b994dea28a080f9eab78a3bcb6b617f05e7634b0600bf7b1"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus",
+ "cw-utils",
+ "schemars",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "cw-multi-test"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,6 +780,37 @@ dependencies = [
  "cosmwasm-std",
  "cw-utils",
  "cw20",
+ "schemars",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cw4"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d33f5c8a6b6cd1bd24e212d7f44967697bfa3c4f9cc3f9a8e1c58f5fe5db032d"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "cw4-group"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e60083d0aec9f6d6191c797bb3605835289fd3d875fe516ae5a164c7f8a0ba4e"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-controllers",
+ "cw-storage-plus",
+ "cw-utils",
+ "cw2",
+ "cw4",
  "schemars",
  "serde",
  "thiserror 1.0.69",

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -215,6 +215,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e31ea183f6ee62ac8b8a8cf7feddd766317adfb13ff469de57ce033efd6a790"
 
 [[package]]
+name = "bvs-guardrail"
+version = "0.0.0"
+dependencies = [
+ "bvs-library",
+ "bvs-vault-router",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-multi-test",
+ "cw-storage-plus",
+ "cw-utils",
+ "cw2",
+ "cw3",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "bvs-library"
 version = "0.0.0"
 dependencies = [
@@ -732,6 +749,21 @@ dependencies = [
  "cw20",
  "schemars",
  "semver",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cw3"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5e53c2057526c65d9c88be8b2a564729ebad7a3d87ee97b97665a71446f913a"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-utils",
+ "cw20",
+ "schemars",
  "serde",
  "thiserror 1.0.69",
 ]

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -57,6 +57,8 @@ cw20 = "2.0.0"
 cw20-base = "2.0.0"
 cw-utils = "2.0.0"
 cw3 = "2.0.0"
+cw4 = "2.0.0"
+cw4-group = "2.0.0"
 
 # CosmWasm Libraries & Contracts
 bvs-library = { path = "./bvs-library", version = "0.0.0" }

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -64,6 +64,7 @@ cw4-group = "2.0.0"
 bvs-library = { path = "./bvs-library", version = "0.0.0" }
 bvs-pauser = { path = "./bvs-pauser", features = ["library"], version = "0.0.0" }
 bvs-registry = { path = "./bvs-registry", features = ["library"], version = "0.0.0" }
+bvs-guardrail = { path = "./bvs-guardrail", features = ["library"], version = "0.0.0" }
 
 bvs-vault-router = { path = "./bvs-vault-router", features = ["library"], version = "0.0.0" }
 bvs-vault-base = { path = "./bvs-vault-base", features = ["library"], version = "0.0.0" }

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -15,6 +15,7 @@ members = [
   "bvs-vault-factory",
   # BVS Optional Components
   "bvs-rewards",
+  "bvs-guardrail",
   # BVS CosmWasm Test Components
   "bvs-multi-test",
 ]
@@ -55,6 +56,7 @@ cw2 = "2.0.0"
 cw20 = "2.0.0"
 cw20-base = "2.0.0"
 cw-utils = "2.0.0"
+cw3 = "2.0.0"
 
 # CosmWasm Libraries & Contracts
 bvs-library = { path = "./bvs-library", version = "0.0.0" }

--- a/crates/bvs-guardrail/Cargo.toml
+++ b/crates/bvs-guardrail/Cargo.toml
@@ -23,6 +23,8 @@ cosmwasm-std = { workspace = true }
 cosmwasm-schema = { workspace = true }
 cw2 = { workspace = true }
 cw3 = { workspace = true }
+cw4 = { workspace = true }
+cw4-group = { workspace = true }
 cw-utils = { workspace = true }
 cw-storage-plus = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/bvs-guardrail/Cargo.toml
+++ b/crates/bvs-guardrail/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "bvs-guardrail"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+keywords.workspace = true
+description.workspace = true
+
+include = ["src"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+library = []
+
+[dependencies]
+cosmwasm-std = { workspace = true }
+cosmwasm-schema = { workspace = true }
+cw2 = { workspace = true }
+cw3 = { workspace = true }
+cw-utils = { workspace = true }
+cw-storage-plus = { workspace = true }
+thiserror = { workspace = true }
+serde = { workspace = true }
+
+bvs-library = { workspace = true }
+bvs-vault-router = { workspace = true }
+
+[target."cfg(not(target_arch = \"wasm32\"))".dependencies]
+cw-multi-test = { workspace = true }

--- a/crates/bvs-guardrail/README.md
+++ b/crates/bvs-guardrail/README.md
@@ -1,0 +1,11 @@
+# BVS Guardrail
+
+BVS Guardrail is a smart contract that serves as a final check for the slashing request before it can be finalized.
+
+This contract allows eligible voters to approve or reject slashing requests.
+It is designed
+to ensure
+that slashing requests are only finalized
+if they have been approved by a sufficient number of eligible voters within the specified voting period.
+
+This contract is largely adapted from CW3 multisig specs and implementation.

--- a/crates/bvs-guardrail/README.md
+++ b/crates/bvs-guardrail/README.md
@@ -2,10 +2,19 @@
 
 BVS Guardrail is a smart contract that serves as a final check for the slashing request before it can be finalized.
 
-This contract allows eligible voters to approve or reject slashing requests.
-It is designed
-to ensure
+## Overview
+
+BVS Guardrail implements a voting system based on the [CW3 multisig specification](https://github.com/CosmWasm/cw-plus/blob/main/packages/cw3/README.md) and [CW4 group membership](https://github.com/CosmWasm/cw-plus/blob/main/packages/cw4/README.md).
+It ensures
 that slashing requests are only finalized
 if they have been approved by a sufficient number of eligible voters within the specified voting period.
 
-This contract is largely adapted from CW3 multisig specs and implementation.
+This contract is largely adapted from [cw3-flex-multisig](https://github.com/CosmWasm/cw-plus/tree/main/contracts/cw3-flex-multisig) and [cw4-group](https://github.com/CosmWasm/cw-plus/tree/main/contracts/cw4-group) implementations.
+
+## Usage
+
+The contract is initialized with a set of members (voters) and a threshold configuration that determines how many votes are required for a proposal to pass. Once initialized, authorized members can create and vote on slashing proposals.
+
+Proposals are created when a slashing request is initiated.
+Members can vote on these proposals within a specified voting period.
+If the proposal receives enough votes before the voting period ends, it is considered approved and the slashing request can be finalized.

--- a/crates/bvs-guardrail/package.json
+++ b/crates/bvs-guardrail/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@satlayer/bvs-guardrail",
+  "private": false,
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "cosmwasm-optimizer --root=../"
+  }
+}

--- a/crates/bvs-guardrail/src/bin/schema.rs
+++ b/crates/bvs-guardrail/src/bin/schema.rs
@@ -1,0 +1,10 @@
+use bvs_guardrail::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use cosmwasm_schema::write_api;
+
+fn main() {
+    write_api! {
+        instantiate: InstantiateMsg,
+        execute: ExecuteMsg,
+        query: QueryMsg,
+    }
+}

--- a/crates/bvs-guardrail/src/contract.rs
+++ b/crates/bvs-guardrail/src/contract.rs
@@ -1,0 +1,1095 @@
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+
+use crate::error::ContractError;
+use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use crate::state::{Config, CONFIG, VOTERS};
+use bvs_library::ownership;
+use cosmwasm_std::{to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
+use cw2::set_contract_version;
+
+const CONTRACT_NAME: &str = concat!("crates.io:", env!("CARGO_PKG_NAME"));
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    msg: InstantiateMsg,
+) -> Result<Response, ContractError> {
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    let owner = deps.api.addr_validate(&msg.owner)?;
+    ownership::set_owner(deps.storage, &owner)?;
+
+    if msg.voters.is_empty() {
+        return Err(ContractError::NoVoters {});
+    }
+    let total_weight = msg.voters.iter().map(|v| v.weight).sum();
+
+    msg.threshold.validate(total_weight)?;
+
+    let cfg = Config {
+        threshold: msg.threshold,
+        total_weight,
+    };
+    CONFIG.save(deps.storage, &cfg)?;
+
+    // add all voters
+    for voter in msg.voters.iter() {
+        let key = deps.api.addr_validate(&voter.addr)?;
+        VOTERS.save(deps.storage, &key, &voter.weight)?;
+    }
+
+    // TODO: need to add voters, threshold, total_weight to events ??
+    Ok(Response::new()
+        .add_attribute("method", "instantiate")
+        .add_attribute("owner", owner))
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn execute(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
+    match msg {
+        ExecuteMsg::Propose {
+            slash_request_id,
+            reason,
+            expiration,
+        } => execute::propose(deps, env, info, slash_request_id, reason, expiration),
+        ExecuteMsg::Vote { proposal_id, vote } => execute::vote(deps, env, info, proposal_id, vote),
+        ExecuteMsg::Close { proposal_id } => execute::close(deps, env, info, proposal_id),
+    }
+}
+
+mod execute {
+    use super::*;
+    use crate::state::{BALLOTS, PROPOSALS};
+    use bvs_vault_router::state::SlashingRequestId;
+    use cosmwasm_std::Event;
+    use cw3::{Ballot, Proposal, Status, Vote, Votes};
+    use cw_utils::Expiration;
+
+    pub fn propose(
+        deps: DepsMut,
+        env: Env,
+        info: MessageInfo,
+        slash_request_id: SlashingRequestId,
+        reason: String,
+        expiration: Expiration,
+    ) -> Result<Response, ContractError> {
+        // only members of the multisig can create a proposal
+        let vote_power = VOTERS
+            .may_load(deps.storage, &info.sender)?
+            .ok_or(ContractError::Unauthorized {})?;
+
+        let cfg = CONFIG.load(deps.storage)?;
+
+        // create a proposal
+        let mut prop = Proposal {
+            title: format!("Proposal To Finalize Slash {}", slash_request_id),
+            description: reason,
+            start_height: env.block.height,
+            expires: expiration,
+            msgs: vec![], // no msg to execute
+            status: Status::Open,
+            votes: Votes::yes(vote_power), // proposer will vote yes automatically
+            threshold: cfg.threshold,
+            total_weight: cfg.total_weight,
+            proposer: info.sender.clone(), // proposer is the sender
+            deposit: None,
+        };
+        prop.update_status(&env.block);
+        let proposal_id = slash_request_id;
+
+        // save proposal only if it doesn't exist
+        PROPOSALS.update(deps.storage, proposal_id.clone(), |p| match p {
+            Some(_) => Err(ContractError::ProposalAlreadyExists {}),
+            None => Ok(prop.clone()),
+        })?;
+
+        // Add proposer's yes vote into the ballot
+        let ballot = Ballot {
+            weight: vote_power,
+            vote: Vote::Yes,
+        };
+
+        BALLOTS.save(deps.storage, (proposal_id.clone(), &info.sender), &ballot)?;
+
+        // TODO: these events are different from cw3 specs to be more inlined with our other contracts
+        Ok(Response::new().add_event(
+            Event::new("propose")
+                .add_attribute("sender", info.sender)
+                .add_attribute("proposal_id", proposal_id.to_string())
+                .add_attribute("status", format!("{:?}", prop.status)),
+        ))
+    }
+
+    pub fn vote(
+        deps: DepsMut,
+        env: Env,
+        info: MessageInfo,
+        proposal_id: SlashingRequestId,
+        vote: Vote, // TODO: check if we want to remove abstain and veto votes
+    ) -> Result<Response, ContractError> {
+        // only members of the multisig with weight >= 1 can vote
+        let voter_power = VOTERS.may_load(deps.storage, &info.sender)?;
+        let vote_power = match voter_power {
+            Some(power) if power >= 1 => power,
+            _ => return Err(ContractError::Unauthorized {}),
+        };
+
+        // ensure proposal exists and can be voted on
+        let mut prop = PROPOSALS.load(deps.storage, proposal_id.clone())?;
+        // Allow voting on Passed and Rejected proposals too,
+        if ![Status::Open, Status::Passed, Status::Rejected].contains(&prop.status) {
+            return Err(ContractError::NotOpen {});
+        }
+        // if they are not expired
+        if prop.expires.is_expired(&env.block) {
+            return Err(ContractError::Expired {});
+        }
+
+        // cast vote if no vote previously cast
+        BALLOTS.update(
+            deps.storage,
+            (proposal_id.clone(), &info.sender),
+            |bal| match bal {
+                Some(_) => Err(ContractError::AlreadyVoted {}),
+                None => Ok(Ballot {
+                    weight: vote_power,
+                    vote,
+                }),
+            },
+        )?;
+
+        // update vote tally
+        prop.votes.add_vote(vote, vote_power);
+        prop.update_status(&env.block);
+        PROPOSALS.save(deps.storage, proposal_id.clone(), &prop)?;
+
+        Ok(Response::new().add_event(
+            Event::new("vote")
+                .add_attribute("sender", info.sender)
+                .add_attribute("proposal_id", proposal_id.to_string())
+                .add_attribute("status", format!("{:?}", prop.status))
+                .add_attribute("vote", format!("{:?}", vote)),
+        ))
+    }
+
+    pub fn close(
+        deps: DepsMut,
+        env: Env,
+        info: MessageInfo,
+        proposal_id: SlashingRequestId,
+    ) -> Result<Response, ContractError> {
+        // anyone can trigger this
+
+        let mut prop = PROPOSALS.load(deps.storage, proposal_id.clone())?;
+        if [Status::Executed, Status::Rejected, Status::Passed].contains(&prop.status) {
+            return Err(ContractError::WrongCloseStatus {});
+        }
+        // Avoid closing of Passed due to expiration proposals
+        if prop.current_status(&env.block) == Status::Passed {
+            return Err(ContractError::WrongCloseStatus {});
+        }
+        if !prop.expires.is_expired(&env.block) {
+            return Err(ContractError::NotExpired {});
+        }
+
+        // set it to rejected
+        prop.status = Status::Rejected;
+        PROPOSALS.save(deps.storage, proposal_id.clone(), &prop)?;
+
+        Ok(Response::new().add_event(
+            Event::new("close")
+                .add_attribute("sender", info.sender)
+                .add_attribute("proposal_id", proposal_id.to_string()),
+        ))
+    }
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::Threshold {} => to_json_binary(&query::threshold(deps)?),
+        QueryMsg::Proposal { proposal_id } => {
+            to_json_binary(&query::proposal(deps, env, proposal_id)?)
+        }
+        QueryMsg::Vote { proposal_id, voter } => {
+            to_json_binary(&query::vote(deps, proposal_id, voter)?)
+        }
+        QueryMsg::ListProposals { skip, limit } => {
+            to_json_binary(&query::list_proposals(deps, env, skip, limit)?)
+        }
+        QueryMsg::ListVotes {
+            proposal_id,
+            start_after,
+            limit,
+        } => to_json_binary(&query::list_votes(deps, proposal_id, start_after, limit)?),
+        QueryMsg::Voter { address } => to_json_binary(&query::voter(deps, address)?),
+        QueryMsg::ListVoters { start_after, limit } => {
+            to_json_binary(&query::list_voters(deps, start_after, limit)?)
+        }
+    }
+}
+
+mod query {
+    use super::*;
+    use crate::msg::{
+        ProposalListResponse, ProposalResponse, VoteInfo, VoteListResponse, VoteResponse,
+    };
+    use crate::state::{BALLOTS, PROPOSALS};
+    use bvs_vault_router::state::SlashingRequestId;
+    use cosmwasm_std::{BlockInfo, Deps, Order};
+    use cw3::{Proposal, VoterDetail, VoterListResponse, VoterResponse};
+    use cw_storage_plus::Bound;
+    use cw_utils::ThresholdResponse;
+
+    pub fn threshold(deps: Deps) -> StdResult<ThresholdResponse> {
+        let cfg = CONFIG.load(deps.storage)?;
+        Ok(cfg.threshold.to_response(cfg.total_weight))
+    }
+
+    pub fn proposal(deps: Deps, env: Env, id: SlashingRequestId) -> StdResult<ProposalResponse> {
+        let prop = PROPOSALS.load(deps.storage, id.clone())?;
+        let status = prop.current_status(&env.block);
+        let threshold = prop.threshold.to_response(prop.total_weight);
+        Ok(ProposalResponse {
+            id,
+            title: prop.title,
+            description: prop.description,
+            msgs: prop.msgs,
+            status,
+            expires: prop.expires,
+            deposit: prop.deposit,
+            proposer: prop.proposer,
+            threshold,
+        })
+    }
+
+    // settings for pagination
+    const MAX_LIMIT: u32 = 30;
+    const DEFAULT_LIMIT: u32 = 10;
+
+    pub fn list_proposals(
+        deps: Deps,
+        env: Env,
+        skip: Option<u64>,
+        limit: Option<u32>,
+    ) -> StdResult<ProposalListResponse> {
+        let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
+        let skip = skip.unwrap_or(0) as usize;
+        let proposals = PROPOSALS
+            .range(deps.storage, None, None, Order::Ascending)
+            .skip(skip)
+            .take(limit)
+            .map(|p| map_proposal(&env.block, p))
+            .collect::<StdResult<_>>()?;
+
+        Ok(ProposalListResponse { proposals })
+    }
+
+    fn map_proposal(
+        block: &BlockInfo,
+        item: StdResult<(SlashingRequestId, Proposal)>,
+    ) -> StdResult<ProposalResponse> {
+        item.map(|(id, prop)| {
+            let status = prop.current_status(block);
+            let threshold = prop.threshold.to_response(prop.total_weight);
+            ProposalResponse {
+                id,
+                title: prop.title,
+                description: prop.description,
+                msgs: prop.msgs,
+                status,
+                deposit: prop.deposit,
+                proposer: prop.proposer,
+                expires: prop.expires,
+                threshold,
+            }
+        })
+    }
+
+    pub fn vote(
+        deps: Deps,
+        proposal_id: SlashingRequestId,
+        voter: String,
+    ) -> StdResult<VoteResponse> {
+        let voter = deps.api.addr_validate(&voter)?;
+        let ballot = BALLOTS.may_load(deps.storage, (proposal_id.clone(), &voter))?;
+        let vote = ballot.map(|b| VoteInfo {
+            proposal_id,
+            voter: voter.into(),
+            vote: b.vote,
+            weight: b.weight,
+        });
+        Ok(VoteResponse { vote })
+    }
+
+    pub fn list_votes(
+        deps: Deps,
+        proposal_id: SlashingRequestId,
+        start_after: Option<String>,
+        limit: Option<u32>,
+    ) -> StdResult<VoteListResponse> {
+        let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
+        let start = start_after.map(|s| Bound::ExclusiveRaw(s.into()));
+
+        let votes = BALLOTS
+            .prefix(proposal_id.clone())
+            .range(deps.storage, start, None, Order::Ascending)
+            .take(limit)
+            .map(|item| {
+                item.map(|(addr, ballot)| VoteInfo {
+                    proposal_id: proposal_id.clone(),
+                    voter: addr.into(),
+                    vote: ballot.vote,
+                    weight: ballot.weight,
+                })
+            })
+            .collect::<StdResult<_>>()?;
+
+        Ok(VoteListResponse { votes })
+    }
+
+    pub fn voter(deps: Deps, voter: String) -> StdResult<VoterResponse> {
+        let voter = deps.api.addr_validate(&voter)?;
+        let weight = VOTERS.may_load(deps.storage, &voter)?;
+        Ok(VoterResponse { weight })
+    }
+
+    pub fn list_voters(
+        deps: Deps,
+        start_after: Option<String>,
+        limit: Option<u32>,
+    ) -> StdResult<VoterListResponse> {
+        let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
+        let start = start_after.map(|s| Bound::ExclusiveRaw(s.into()));
+
+        let voters = VOTERS
+            .range(deps.storage, start, None, Order::Ascending)
+            .take(limit)
+            .map(|item| {
+                item.map(|(addr, weight)| VoterDetail {
+                    addr: addr.into(),
+                    weight,
+                })
+            })
+            .collect::<StdResult<_>>()?;
+
+        Ok(VoterListResponse { voters })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::msg::Voter;
+    use crate::state::PROPOSALS;
+    use bvs_vault_router::state::SlashingRequestId;
+    use cosmwasm_std::testing::{message_info, mock_dependencies, mock_env};
+    use cosmwasm_std::{Decimal, Event, Order, StdError};
+    use cw2::{get_contract_version, ContractVersion};
+    use cw3::{Proposal, Status, Vote, Votes};
+    use cw_utils::{Expiration, Threshold};
+
+    /// create a 2-of-4 multisig voter
+    fn setup(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Response, ContractError> {
+        let api_deps = mock_dependencies();
+
+        let owner = api_deps.api.addr_make("owner");
+
+        let voter1 = api_deps.api.addr_make("voter1");
+        let voter2 = api_deps.api.addr_make("voter2");
+        let voter3 = api_deps.api.addr_make("voter3");
+        let voter4 = api_deps.api.addr_make("voter4");
+
+        let instantiate_msg = InstantiateMsg {
+            owner: owner.to_string(),
+            voters: vec![
+                Voter {
+                    addr: voter1.to_string(),
+                    weight: 1,
+                },
+                Voter {
+                    addr: voter2.to_string(),
+                    weight: 1,
+                },
+                Voter {
+                    addr: voter3.to_string(),
+                    weight: 1,
+                },
+                Voter {
+                    addr: voter4.to_string(),
+                    weight: 1,
+                },
+                Voter {
+                    addr: owner.to_string(),
+                    weight: 0,
+                },
+            ],
+            threshold: Threshold::AbsolutePercentage {
+                percentage: Decimal::percent(50), // 50% to pass
+            },
+        };
+        instantiate(deps, env, info, instantiate_msg)
+    }
+
+    #[test]
+    fn test_instantiate() {
+        let mut deps = mock_dependencies();
+        let env = mock_env();
+
+        let owner = deps.api.addr_make("owner");
+        let info = message_info(&owner, &[]);
+
+        let voter1 = deps.api.addr_make("voter1");
+        let voter2 = deps.api.addr_make("voter2");
+        let voter3 = deps.api.addr_make("voter3");
+        let voter4 = deps.api.addr_make("voter4");
+
+        // Negative - no voters passed
+        {
+            let instantiate_msg = InstantiateMsg {
+                owner: owner.to_string(),
+                voters: vec![],
+                threshold: Threshold::AbsolutePercentage {
+                    percentage: Decimal::percent(50),
+                },
+            };
+            let err = instantiate(
+                deps.as_mut(),
+                mock_env(),
+                info.clone(),
+                instantiate_msg.clone(),
+            )
+            .unwrap_err();
+            assert_eq!(err, ContractError::NoVoters {});
+        }
+
+        // Setup
+        setup(deps.as_mut(), env, info).unwrap();
+
+        // Verify
+        assert_eq!(
+            ContractVersion {
+                contract: CONTRACT_NAME.to_string(),
+                version: CONTRACT_VERSION.to_string(),
+            },
+            get_contract_version(&deps.storage).unwrap()
+        );
+
+        // assert config is set
+        let cfg = CONFIG.load(deps.as_ref().storage).unwrap();
+        assert_eq!(
+            cfg,
+            Config {
+                threshold: Threshold::AbsolutePercentage {
+                    percentage: Decimal::percent(50)
+                },
+                total_weight: 4,
+            }
+        );
+
+        // assert voters are set
+        let mut voters = VOTERS
+            .range(deps.as_ref().storage, None, None, Order::Ascending)
+            .collect::<StdResult<Vec<_>>>()
+            .unwrap();
+
+        assert_eq!(
+            voters.sort(),
+            vec![
+                (voter1, 1),
+                (voter2, 1),
+                (voter3, 1),
+                (voter4, 1),
+                (owner, 0)
+            ]
+            .sort()
+        )
+    }
+
+    #[test]
+    fn test_execute_propose() {
+        let mut deps = mock_dependencies();
+        let env = mock_env();
+
+        let owner = deps.api.addr_make("owner");
+        let info = message_info(&owner, &[]);
+        setup(deps.as_mut(), env.clone(), info.clone()).unwrap();
+
+        let slash_request_id = SlashingRequestId::from_hex(
+            "cdb763a239cb5c8d627c5cc85c65aac291680aced9d081ba7595c6d5138fc4fb",
+        )
+        .unwrap();
+        let expiration = Expiration::AtTime(env.block.time.plus_seconds(100));
+        let execute_msg = ExecuteMsg::Propose {
+            slash_request_id: slash_request_id.clone(),
+            reason: "test".to_string(),
+            expiration,
+        };
+
+        // Negative - not a member
+        {
+            let not_voter = deps.api.addr_make("not_voter");
+            let info = message_info(&not_voter, &[]);
+            let err = execute(deps.as_mut(), env.clone(), info, execute_msg.clone()).unwrap_err();
+            assert_eq!(err, ContractError::Unauthorized {});
+        }
+
+        // execute propose successfully
+        let res = execute(
+            deps.as_mut(),
+            env.clone(),
+            info.clone(),
+            execute_msg.clone(),
+        );
+
+        assert_eq!(
+            res,
+            Ok(Response::new().add_event(
+                Event::new("propose")
+                    .add_attribute("sender", info.clone().sender)
+                    .add_attribute("proposal_id", slash_request_id.to_string())
+                    .add_attribute("status", format!("{:?}", Status::Open))
+            ))
+        );
+
+        // assert the proposal is saved
+        let prop = PROPOSALS
+            .load(deps.as_ref().storage, slash_request_id.clone())
+            .unwrap();
+        assert_eq!(
+            prop,
+            Proposal {
+                title:"Proposal To Finalize Slash cdb763a239cb5c8d627c5cc85c65aac291680aced9d081ba7595c6d5138fc4fb".to_string(),
+                description: "test".to_string(),
+                start_height: env.block.height,
+                expires: expiration,
+                msgs: vec![],
+                status: Status::Open,
+                votes: Votes::yes(0),
+                threshold: Threshold::AbsolutePercentage {
+                    percentage: Decimal::percent(50)
+                },
+                total_weight: 4,
+                proposer: owner.clone(),
+                deposit: None,
+            }
+        );
+
+        // Negative - proposal already exists
+        {
+            let err = execute(
+                deps.as_mut(),
+                env.clone(),
+                info.clone(),
+                execute_msg.clone(),
+            )
+            .unwrap_err();
+            assert_eq!(err, ContractError::ProposalAlreadyExists {});
+        }
+    }
+
+    #[test]
+    fn test_execute_vote_passed() {
+        let mut deps = mock_dependencies();
+        let env = mock_env();
+
+        let owner = deps.api.addr_make("owner");
+        let info = message_info(&owner, &[]);
+        let voter1 = deps.api.addr_make("voter1");
+        let voter1_info = message_info(&voter1, &[]);
+        setup(deps.as_mut(), env.clone(), info.clone()).unwrap();
+
+        // execute proposal
+        let slash_request_id = SlashingRequestId::from_hex(
+            "cdb763a239cb5c8d627c5cc85c65aac291680aced9d081ba7595c6d5138fc4fb",
+        )
+        .unwrap();
+        let expiration = Expiration::AtTime(env.block.time.plus_seconds(100));
+        let execute_msg = ExecuteMsg::Propose {
+            slash_request_id: slash_request_id.clone(),
+            reason: "test".to_string(),
+            expiration,
+        };
+        execute(
+            deps.as_mut(),
+            env.clone(),
+            info.clone(),
+            execute_msg.clone(),
+        )
+        .unwrap();
+
+        // Negative - not a member
+        {
+            let not_voter = deps.api.addr_make("not_voter");
+            let info = message_info(&not_voter, &[]);
+            let err = execute(
+                deps.as_mut(),
+                env.clone(),
+                info,
+                ExecuteMsg::Vote {
+                    proposal_id: slash_request_id.clone(),
+                    vote: Vote::Yes,
+                },
+            )
+            .unwrap_err();
+            assert_eq!(err, ContractError::Unauthorized {});
+        }
+
+        // Negative - proposal does not exist
+        {
+            let err = execute(
+                deps.as_mut(),
+                env.clone(),
+                voter1_info.clone(),
+                ExecuteMsg::Vote {
+                    proposal_id: SlashingRequestId::from_hex(
+                        "0ff7a6f403eff632636533660ab53ab35e7ae0fe2e5dacb160aa7d876a412f09",
+                    )
+                    .unwrap(),
+                    vote: Vote::Yes,
+                },
+            )
+            .unwrap_err();
+            assert_eq!(
+                err,
+                ContractError::Std(StdError::not_found("type: cw3::proposal::Proposal; key: [00, 09, 70, 72, 6F, 70, 6F, 73, 61, 6C, 73, 0F, F7, A6, F4, 03, EF, F6, 32, 63, 65, 33, 66, 0A, B5, 3A, B3, 5E, 7A, E0, FE, 2E, 5D, AC, B1, 60, AA, 7D, 87, 6A, 41, 2F, 09]"))
+            );
+        }
+
+        // Negative - owner (proposer) cannot vote due to 0 weight
+        {
+            let err = execute(
+                deps.as_mut(),
+                env.clone(),
+                info.clone(),
+                ExecuteMsg::Vote {
+                    proposal_id: slash_request_id.clone(),
+                    vote: Vote::Yes,
+                },
+            )
+            .unwrap_err();
+            assert_eq!(err, ContractError::Unauthorized {});
+        }
+
+        // execute vote YES successfully for voter1
+        let res = execute(
+            deps.as_mut(),
+            env.clone(),
+            voter1_info.clone(),
+            ExecuteMsg::Vote {
+                proposal_id: slash_request_id.clone(),
+                vote: Vote::Yes,
+            },
+        );
+
+        assert_eq!(
+            res,
+            Ok(Response::new().add_event(
+                Event::new("vote")
+                    .add_attribute("sender", voter1.to_string())
+                    .add_attribute("proposal_id", slash_request_id.to_string())
+                    .add_attribute("status", format!("{:?}", Status::Open))
+                    .add_attribute("vote", format!("{:?}", Vote::Yes))
+            ))
+        );
+
+        // execute vote No for voter2
+        {
+            let voter2 = deps.api.addr_make("voter2");
+            let voter2_info = message_info(&voter2, &[]);
+            execute(
+                deps.as_mut(),
+                env.clone(),
+                voter2_info.clone(),
+                ExecuteMsg::Vote {
+                    proposal_id: slash_request_id.clone(),
+                    vote: Vote::No,
+                },
+            )
+            .unwrap();
+        }
+
+        // check that the proposal status is still open
+        let prop = PROPOSALS
+            .load(deps.as_ref().storage, slash_request_id.clone())
+            .unwrap();
+        assert_eq!(prop.current_status(&env.block), Status::Open);
+
+        // execute vote Abstain for voter3
+        {
+            let voter3 = deps.api.addr_make("voter3");
+            let voter3_info = message_info(&voter3, &[]);
+            let res = execute(
+                deps.as_mut(),
+                env.clone(),
+                voter3_info.clone(),
+                ExecuteMsg::Vote {
+                    proposal_id: slash_request_id.clone(),
+                    vote: Vote::Abstain,
+                },
+            );
+
+            assert_eq!(
+                res,
+                Ok(Response::new().add_event(
+                    Event::new("vote")
+                        .add_attribute("sender", voter3.to_string())
+                        .add_attribute("proposal_id", slash_request_id.to_string())
+                        .add_attribute("status", format!("{:?}", Status::Open))
+                        .add_attribute("vote", format!("{:?}", Vote::Abstain))
+                ))
+            );
+        }
+
+        // check that the proposal status is still open
+        let prop = PROPOSALS
+            .load(deps.as_ref().storage, slash_request_id.clone())
+            .unwrap();
+        assert_eq!(prop.current_status(&env.block), Status::Open);
+
+        // execute vote Yes for voter4 to pass the proposal (>50%)
+        {
+            let voter4 = deps.api.addr_make("voter4");
+            let voter4_info = message_info(&voter4, &[]);
+            let res = execute(
+                deps.as_mut(),
+                env.clone(),
+                voter4_info.clone(),
+                ExecuteMsg::Vote {
+                    proposal_id: slash_request_id.clone(),
+                    vote: Vote::Yes,
+                },
+            );
+
+            assert_eq!(
+                res,
+                Ok(Response::new().add_event(
+                    Event::new("vote")
+                        .add_attribute("sender", voter4.to_string())
+                        .add_attribute("proposal_id", slash_request_id.to_string())
+                        .add_attribute("status", format!("{:?}", Status::Passed))
+                        .add_attribute("vote", format!("{:?}", Vote::Yes))
+                ))
+            );
+        }
+
+        // check that the proposal status is passed
+        let prop = PROPOSALS
+            .load(deps.as_ref().storage, slash_request_id.clone())
+            .unwrap();
+        assert_eq!(prop.current_status(&env.block), Status::Passed);
+    }
+
+    #[test]
+    fn test_execute_vote_rejected() {
+        let mut deps = mock_dependencies();
+        let env = mock_env();
+
+        let owner = deps.api.addr_make("owner");
+        let info = message_info(&owner, &[]);
+        setup(deps.as_mut(), env.clone(), info.clone()).unwrap();
+
+        // execute proposal
+        let slash_request_id = SlashingRequestId::from_hex(
+            "cdb763a239cb5c8d627c5cc85c65aac291680aced9d081ba7595c6d5138fc4fb",
+        )
+        .unwrap();
+        let expiration = Expiration::AtTime(env.block.time.plus_seconds(100));
+        let execute_msg = ExecuteMsg::Propose {
+            slash_request_id: slash_request_id.clone(),
+            reason: "test".to_string(),
+            expiration,
+        };
+        execute(
+            deps.as_mut(),
+            env.clone(),
+            info.clone(),
+            execute_msg.clone(),
+        )
+        .unwrap();
+
+        // execute vote No for voter1
+        let voter1 = deps.api.addr_make("voter1");
+        let voter1_info = message_info(&voter1, &[]);
+        execute(
+            deps.as_mut(),
+            env.clone(),
+            voter1_info.clone(),
+            ExecuteMsg::Vote {
+                proposal_id: slash_request_id.clone(),
+                vote: Vote::No,
+            },
+        )
+        .unwrap();
+
+        // execute vote No for voter2
+        let voter2 = deps.api.addr_make("voter2");
+        let voter2_info = message_info(&voter2, &[]);
+        execute(
+            deps.as_mut(),
+            env.clone(),
+            voter2_info.clone(),
+            ExecuteMsg::Vote {
+                proposal_id: slash_request_id.clone(),
+                vote: Vote::No,
+            },
+        )
+        .unwrap();
+
+        // execute vote No for voter3 to reject the proposal
+        let voter3 = deps.api.addr_make("voter3");
+        let voter3_info = message_info(&voter3, &[]);
+        let res = execute(
+            deps.as_mut(),
+            env.clone(),
+            voter3_info.clone(),
+            ExecuteMsg::Vote {
+                proposal_id: slash_request_id.clone(),
+                vote: Vote::No,
+            },
+        );
+        assert_eq!(
+            res,
+            Ok(Response::new().add_event(
+                Event::new("vote")
+                    .add_attribute("sender", voter3.to_string())
+                    .add_attribute("proposal_id", slash_request_id.to_string())
+                    .add_attribute("status", format!("{:?}", Status::Rejected))
+                    .add_attribute("vote", format!("{:?}", Vote::No))
+            ))
+        );
+
+        // assert that the proposal status is rejected
+        let prop = PROPOSALS
+            .load(deps.as_ref().storage, slash_request_id.clone())
+            .unwrap();
+        assert_eq!(prop.current_status(&env.block), Status::Rejected);
+
+        // voter can still vote on a rejected proposal as long as it is not expired
+        // execute vote Yes for voter4
+        {
+            let voter4 = deps.api.addr_make("voter4");
+            let voter4_info = message_info(&voter4, &[]);
+            let res = execute(
+                deps.as_mut(),
+                env.clone(),
+                voter4_info.clone(),
+                ExecuteMsg::Vote {
+                    proposal_id: slash_request_id.clone(),
+                    vote: Vote::Yes,
+                },
+            );
+            assert_eq!(
+                res,
+                Ok(Response::new().add_event(
+                    Event::new("vote")
+                        .add_attribute("sender", voter4.to_string())
+                        .add_attribute("proposal_id", slash_request_id.to_string())
+                        .add_attribute("status", format!("{:?}", Status::Rejected))
+                        .add_attribute("vote", format!("{:?}", Vote::Yes))
+                ))
+            );
+        }
+    }
+
+    #[test]
+    fn test_execute_close() {
+        let mut deps = mock_dependencies();
+        let mut env = mock_env();
+
+        let owner = deps.api.addr_make("owner");
+        let info = message_info(&owner, &[]);
+        setup(deps.as_mut(), env.clone(), info.clone()).unwrap();
+
+        // execute proposal
+        let slash_request_id = SlashingRequestId::from_hex(
+            "cdb763a239cb5c8d627c5cc85c65aac291680aced9d081ba7595c6d5138fc4fb",
+        )
+        .unwrap();
+        let expiration = Expiration::AtTime(env.block.time.plus_seconds(100));
+        let execute_msg = ExecuteMsg::Propose {
+            slash_request_id: slash_request_id.clone(),
+            reason: "test".to_string(),
+            expiration,
+        };
+        execute(
+            deps.as_mut(),
+            env.clone(),
+            info.clone(),
+            execute_msg.clone(),
+        )
+        .unwrap();
+
+        // execute vote Yes successfully for voter1
+        let voter1 = deps.api.addr_make("voter1");
+        let voter1_info = message_info(&voter1, &[]);
+        let res = execute(
+            deps.as_mut(),
+            env.clone(),
+            voter1_info.clone(),
+            ExecuteMsg::Vote {
+                proposal_id: slash_request_id.clone(),
+                vote: Vote::Yes,
+            },
+        );
+        assert_eq!(
+            res,
+            Ok(Response::new().add_event(
+                Event::new("vote")
+                    .add_attribute("sender", voter1.to_string())
+                    .add_attribute("proposal_id", slash_request_id.to_string())
+                    .add_attribute("status", format!("{:?}", Status::Open))
+                    .add_attribute("vote", format!("{:?}", Vote::Yes))
+            ))
+        );
+
+        // move the env time to expire the proposal
+        env.block.time = env.block.time.plus_seconds(1000);
+
+        // Negative - voters will not be able to vote after expiration
+        {
+            let voter2 = deps.api.addr_make("voter2");
+            let voter2_info = message_info(&voter2, &[]);
+            let err = execute(
+                deps.as_mut(),
+                env.clone(),
+                voter2_info,
+                ExecuteMsg::Vote {
+                    proposal_id: slash_request_id.clone(),
+                    vote: Vote::Yes,
+                },
+            )
+            .unwrap_err();
+            assert_eq!(err, ContractError::Expired {});
+        }
+
+        // execute close successfully
+        let res = execute(
+            deps.as_mut(),
+            env.clone(),
+            info.clone(),
+            ExecuteMsg::Close {
+                proposal_id: slash_request_id.clone(),
+            },
+        );
+        assert_eq!(
+            res,
+            Ok(Response::new().add_event(
+                Event::new("close")
+                    .add_attribute("sender", info.sender)
+                    .add_attribute("proposal_id", slash_request_id.to_string())
+            ))
+        );
+
+        // check that the proposal status is rejected
+        let prop = PROPOSALS
+            .load(deps.as_ref().storage, slash_request_id.clone())
+            .unwrap();
+        assert_eq!(prop.status, Status::Rejected);
+    }
+
+    #[test]
+    fn test_execute_close_on_passed_proposal() {
+        let mut deps = mock_dependencies();
+        let mut env = mock_env();
+
+        let owner = deps.api.addr_make("owner");
+        let info = message_info(&owner, &[]);
+        setup(deps.as_mut(), env.clone(), info.clone()).unwrap();
+
+        // execute proposal
+        let slash_request_id = SlashingRequestId::from_hex(
+            "cdb763a239cb5c8d627c5cc85c65aac291680aced9d081ba7595c6d5138fc4fb",
+        )
+        .unwrap();
+        let expiration = Expiration::AtTime(env.block.time.plus_seconds(100));
+        let execute_msg = ExecuteMsg::Propose {
+            slash_request_id: slash_request_id.clone(),
+            reason: "test".to_string(),
+            expiration,
+        };
+        execute(
+            deps.as_mut(),
+            env.clone(),
+            info.clone(),
+            execute_msg.clone(),
+        )
+        .unwrap();
+
+        // execute vote Yes successfully for voter1, voter2 and voter3 (to pass the proposal)
+        let voter1 = deps.api.addr_make("voter1");
+        let voter1_info = message_info(&voter1, &[]);
+        execute(
+            deps.as_mut(),
+            env.clone(),
+            voter1_info.clone(),
+            ExecuteMsg::Vote {
+                proposal_id: slash_request_id.clone(),
+                vote: Vote::Yes,
+            },
+        )
+        .unwrap();
+
+        let voter2 = deps.api.addr_make("voter2");
+        let voter2_info = message_info(&voter2, &[]);
+        execute(
+            deps.as_mut(),
+            env.clone(),
+            voter2_info.clone(),
+            ExecuteMsg::Vote {
+                proposal_id: slash_request_id.clone(),
+                vote: Vote::Yes,
+            },
+        )
+        .unwrap();
+
+        let voter3 = deps.api.addr_make("voter3");
+        let voter3_info = message_info(&voter3, &[]);
+        execute(
+            deps.as_mut(),
+            env.clone(),
+            voter3_info.clone(),
+            ExecuteMsg::Vote {
+                proposal_id: slash_request_id.clone(),
+                vote: Vote::Yes,
+            },
+        )
+        .unwrap();
+
+        // check that the proposal status is passed
+        let prop = PROPOSALS
+            .load(deps.as_ref().storage, slash_request_id.clone())
+            .unwrap();
+        assert_eq!(prop.current_status(&env.block), Status::Passed);
+
+        // move the env time to expire the proposal
+        env.block.time = env.block.time.plus_seconds(100);
+
+        // execute close failed due to proposal already passed despite expiration
+        let err = execute(
+            deps.as_mut(),
+            env.clone(),
+            info.clone(),
+            ExecuteMsg::Close {
+                proposal_id: slash_request_id.clone(),
+            },
+        )
+        .unwrap_err();
+        assert_eq!(err, ContractError::WrongCloseStatus {});
+
+        // check that the proposal status is still passed
+        let prop = PROPOSALS
+            .load(deps.as_ref().storage, slash_request_id.clone())
+            .unwrap();
+        assert_eq!(prop.status, Status::Passed);
+    }
+}

--- a/crates/bvs-guardrail/src/contract.rs
+++ b/crates/bvs-guardrail/src/contract.rs
@@ -913,9 +913,7 @@ mod tests {
         let proposal_id = SLASHING_REQUEST_TO_PROPOSAL
             .load(deps.as_ref().storage, slash_request_id.clone())
             .unwrap();
-        let prop = PROPOSALS
-            .load(deps.as_ref().storage, proposal_id.clone())
-            .unwrap();
+        let prop = PROPOSALS.load(deps.as_ref().storage, proposal_id).unwrap();
         assert_eq!(prop.current_status(&env.block), Status::Open);
 
         // execute vote Abstain for voter3
@@ -946,9 +944,7 @@ mod tests {
         }
 
         // check that the proposal status is still open
-        let prop = PROPOSALS
-            .load(deps.as_ref().storage, proposal_id.clone())
-            .unwrap();
+        let prop = PROPOSALS.load(deps.as_ref().storage, proposal_id).unwrap();
         assert_eq!(prop.current_status(&env.block), Status::Open);
 
         // execute vote Yes for voter4 to pass the proposal (>50%)
@@ -979,9 +975,7 @@ mod tests {
         }
 
         // check that the proposal status is passed
-        let prop = PROPOSALS
-            .load(deps.as_ref().storage, proposal_id.clone())
-            .unwrap();
+        let prop = PROPOSALS.load(deps.as_ref().storage, proposal_id).unwrap();
         assert_eq!(prop.current_status(&env.block), Status::Passed);
     }
 
@@ -1077,9 +1071,7 @@ mod tests {
         let proposal_id = SLASHING_REQUEST_TO_PROPOSAL
             .load(deps.as_ref().storage, slash_request_id.clone())
             .unwrap();
-        let prop = PROPOSALS
-            .load(deps.as_ref().storage, proposal_id.clone())
-            .unwrap();
+        let prop = PROPOSALS.load(deps.as_ref().storage, proposal_id).unwrap();
         assert_eq!(prop.current_status(&env.block), Status::Rejected);
 
         // voter can still vote on a rejected proposal as long as it is not expired
@@ -1213,9 +1205,7 @@ mod tests {
         let proposal_id = SLASHING_REQUEST_TO_PROPOSAL
             .load(deps.as_ref().storage, slash_request_id.clone())
             .unwrap();
-        let prop = PROPOSALS
-            .load(deps.as_ref().storage, proposal_id.clone())
-            .unwrap();
+        let prop = PROPOSALS.load(deps.as_ref().storage, proposal_id).unwrap();
         assert_eq!(prop.status, Status::Rejected);
     }
 
@@ -1295,9 +1285,7 @@ mod tests {
         let proposal_id = SLASHING_REQUEST_TO_PROPOSAL
             .load(deps.as_ref().storage, slash_request_id.clone())
             .unwrap();
-        let prop = PROPOSALS
-            .load(deps.as_ref().storage, proposal_id.clone())
-            .unwrap();
+        let prop = PROPOSALS.load(deps.as_ref().storage, proposal_id).unwrap();
         assert_eq!(prop.current_status(&env.block), Status::Passed);
 
         // move the env time to expire the proposal
@@ -1316,9 +1304,7 @@ mod tests {
         assert_eq!(err, ContractError::WrongCloseStatus {});
 
         // check that the proposal status is still passed
-        let prop = PROPOSALS
-            .load(deps.as_ref().storage, proposal_id.clone())
-            .unwrap();
+        let prop = PROPOSALS.load(deps.as_ref().storage, proposal_id).unwrap();
         assert_eq!(prop.status, Status::Passed);
     }
 

--- a/crates/bvs-guardrail/src/error.rs
+++ b/crates/bvs-guardrail/src/error.rs
@@ -1,5 +1,5 @@
 use bvs_library::ownership::OwnershipError;
-use cosmwasm_std::StdError;
+use cosmwasm_std::{OverflowError, StdError};
 use cw_utils::ThresholdError;
 use thiserror::Error;
 
@@ -13,6 +13,12 @@ pub enum ContractError {
 
     #[error("{0}")]
     Threshold(#[from] ThresholdError),
+
+    #[error("{0}")]
+    Cw4Group(#[from] cw4_group::ContractError),
+
+    #[error("{0}")]
+    Overflow(#[from] OverflowError),
 
     #[error("Required weight cannot be zero")]
     ZeroWeight {},
@@ -49,4 +55,7 @@ pub enum ContractError {
 
     #[error("Proposal already exists")]
     ProposalAlreadyExists,
+
+    #[error("Proposal does not exist")]
+    ProposalNotFound {},
 }

--- a/crates/bvs-guardrail/src/error.rs
+++ b/crates/bvs-guardrail/src/error.rs
@@ -1,0 +1,52 @@
+use bvs_library::ownership::OwnershipError;
+use cosmwasm_std::StdError;
+use cw_utils::ThresholdError;
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ContractError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+
+    #[error("{0}")]
+    Ownership(#[from] OwnershipError),
+
+    #[error("{0}")]
+    Threshold(#[from] ThresholdError),
+
+    #[error("Required weight cannot be zero")]
+    ZeroWeight {},
+
+    #[error("Not possible to reach required (passing) weight")]
+    UnreachableWeight {},
+
+    #[error("No voters")]
+    NoVoters {},
+
+    #[error("Unauthorized")]
+    Unauthorized {},
+
+    #[error("Proposal is not open")]
+    NotOpen {},
+
+    #[error("Proposal voting period has expired")]
+    Expired {},
+
+    #[error("Proposal must expire before you can close it")]
+    NotExpired {},
+
+    #[error("Wrong expiration option")]
+    WrongExpiration {},
+
+    #[error("Already voted on this proposal")]
+    AlreadyVoted {},
+
+    #[error("Proposal must have passed and not yet been executed")]
+    WrongExecuteStatus {},
+
+    #[error("Cannot close completed or passed proposals")]
+    WrongCloseStatus {},
+
+    #[error("Proposal already exists")]
+    ProposalAlreadyExists,
+}

--- a/crates/bvs-guardrail/src/lib.rs
+++ b/crates/bvs-guardrail/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod contract;
+pub mod error;
+pub mod msg;
+mod state;

--- a/crates/bvs-guardrail/src/lib.rs
+++ b/crates/bvs-guardrail/src/lib.rs
@@ -2,3 +2,4 @@ pub mod contract;
 pub mod error;
 pub mod msg;
 mod state;
+pub mod testing;

--- a/crates/bvs-guardrail/src/msg.rs
+++ b/crates/bvs-guardrail/src/msg.rs
@@ -1,0 +1,112 @@
+use bvs_vault_router::state::SlashingRequestId;
+use cosmwasm_schema::{cw_serde, QueryResponses};
+use cosmwasm_std::{Addr, CosmosMsg, Empty};
+use cw3::{DepositInfo, Status, Vote};
+use cw_utils::{Expiration, Threshold, ThresholdResponse};
+
+#[cw_serde]
+pub struct InstantiateMsg {
+    pub owner: String,
+    pub voters: Vec<Voter>,
+    pub threshold: Threshold,
+}
+
+#[cw_serde]
+pub enum ExecuteMsg {
+    Propose {
+        slash_request_id: SlashingRequestId,
+        reason: String,
+        expiration: Expiration,
+    },
+    Vote {
+        proposal_id: SlashingRequestId,
+        vote: Vote,
+    },
+    Close {
+        proposal_id: SlashingRequestId,
+    },
+}
+
+#[cw_serde]
+#[derive(QueryResponses)]
+pub enum QueryMsg {
+    #[returns(cw_utils::ThresholdResponse)]
+    Threshold {},
+    #[returns(ProposalResponse)]
+    Proposal { proposal_id: SlashingRequestId },
+    #[returns(ProposalListResponse)]
+    ListProposals {
+        skip: Option<u64>,
+        limit: Option<u32>,
+    },
+    #[returns(cw3::VoteResponse)]
+    Vote {
+        proposal_id: SlashingRequestId,
+        voter: String,
+    },
+    #[returns(VoteListResponse)]
+    ListVotes {
+        proposal_id: SlashingRequestId,
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
+    #[returns(cw3::VoterResponse)]
+    Voter { address: String },
+    #[returns(cw3::VoterListResponse)]
+    ListVoters {
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
+}
+
+#[cw_serde]
+pub struct Voter {
+    pub addr: String,
+    pub weight: u64,
+}
+
+/// Adapted from `cw3::ProposalResponse`
+#[cw_serde]
+pub struct ProposalResponse<T = Empty> {
+    pub id: SlashingRequestId,
+    pub title: String,
+    pub description: String,
+    pub msgs: Vec<CosmosMsg<T>>,
+    pub status: Status,
+    pub expires: Expiration,
+    /// This is the threshold that is applied to this proposal. Both
+    /// the rules of the voting contract, as well as the total_weight
+    /// of the voting group may have changed since this time. That
+    /// means that the generic `Threshold{}` query does not provide
+    /// valid information for existing proposals.
+    pub threshold: ThresholdResponse,
+    pub proposer: Addr,
+    pub deposit: Option<DepositInfo>,
+}
+
+/// Adapted from `cw3::ProposalListResponse`
+#[cw_serde]
+pub struct ProposalListResponse<T = Empty> {
+    pub proposals: Vec<ProposalResponse<T>>,
+}
+
+/// Adapted from `cw3::VoteInfo`
+#[cw_serde]
+pub struct VoteInfo {
+    pub proposal_id: SlashingRequestId,
+    pub voter: String,
+    pub vote: Vote,
+    pub weight: u64,
+}
+
+/// Adapted from `cw3::VoteListResponse`
+#[cw_serde]
+pub struct VoteListResponse {
+    pub votes: Vec<VoteInfo>,
+}
+
+/// Adapted from `cw3::VoteResponse`
+#[cw_serde]
+pub struct VoteResponse {
+    pub vote: Option<VoteInfo>,
+}

--- a/crates/bvs-guardrail/src/msg.rs
+++ b/crates/bvs-guardrail/src/msg.rs
@@ -15,16 +15,16 @@ pub struct InstantiateMsg {
 #[cw_serde]
 pub enum ExecuteMsg {
     Propose {
-        slash_request_id: SlashingRequestId,
+        slashing_request_id: SlashingRequestId,
         reason: String,
         expiration: Expiration,
     },
     Vote {
-        slash_request_id: SlashingRequestId,
+        slashing_request_id: SlashingRequestId,
         vote: Vote,
     },
     Close {
-        slash_request_id: SlashingRequestId,
+        slashing_request_id: SlashingRequestId,
     },
     /// apply a diff to the existing members.
     /// remove is applied after add, so if an address is in both, it is removed
@@ -48,11 +48,6 @@ pub enum QueryMsg {
     #[returns(cw3::ProposalListResponse)]
     ListProposals {
         start_after: Option<u64>,
-        limit: Option<u32>,
-    },
-    #[returns(cw3::ProposalListResponse)]
-    ReverseProposals {
-        start_before: Option<u64>,
         limit: Option<u32>,
     },
     #[returns(cw3::VoteResponse)]

--- a/crates/bvs-guardrail/src/msg.rs
+++ b/crates/bvs-guardrail/src/msg.rs
@@ -1,10 +1,9 @@
 use crate::state::ProposalId;
 use bvs_vault_router::state::SlashingRequestId;
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Addr, CosmosMsg, Empty};
-use cw3::{DepositInfo, Status, Vote};
+use cw3::Vote;
 use cw4::Member;
-use cw_utils::{Expiration, Threshold, ThresholdResponse};
+use cw_utils::{Expiration, Threshold};
 
 #[cw_serde]
 pub struct InstantiateMsg {

--- a/crates/bvs-guardrail/src/msg.rs
+++ b/crates/bvs-guardrail/src/msg.rs
@@ -3,13 +3,14 @@ use bvs_vault_router::state::SlashingRequestId;
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cw3::Vote;
 use cw4::Member;
-use cw_utils::{Expiration, Threshold};
+use cw_utils::Threshold;
 
 #[cw_serde]
 pub struct InstantiateMsg {
     pub owner: String,
     pub members: Vec<Member>,
     pub threshold: Threshold,
+    pub default_expiration: u64,
 }
 
 #[cw_serde]
@@ -17,7 +18,6 @@ pub enum ExecuteMsg {
     Propose {
         slashing_request_id: SlashingRequestId,
         reason: String,
-        expiration: Expiration,
     },
     Vote {
         slashing_request_id: SlashingRequestId,

--- a/crates/bvs-guardrail/src/state.rs
+++ b/crates/bvs-guardrail/src/state.rs
@@ -1,0 +1,25 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::Addr;
+
+use bvs_vault_router::state::SlashingRequestId;
+use cw3::{Ballot, Proposal};
+use cw_storage_plus::{Item, Map};
+use cw_utils::Threshold;
+
+#[cw_serde]
+pub struct Config {
+    pub threshold: Threshold,
+    pub total_weight: u64,
+}
+
+/// Stores the configuration of the contract.
+pub const CONFIG: Item<Config> = Item::new("config");
+
+/// Stores the voters' vote for a proposal.
+pub const BALLOTS: Map<(SlashingRequestId, &Addr), Ballot> = Map::new("votes");
+
+/// Stores proposals data.
+pub const PROPOSALS: Map<SlashingRequestId, Proposal> = Map::new("proposals");
+
+/// Stores the valid voters address and their vote weight.
+pub const VOTERS: Map<&Addr, u64> = Map::new("voters");

--- a/crates/bvs-guardrail/src/state.rs
+++ b/crates/bvs-guardrail/src/state.rs
@@ -17,6 +17,8 @@ pub type VotingPower = u64;
 #[cw_serde]
 pub struct Config {
     pub threshold: Threshold,
+    /// the default expiration in seconds for proposals and cannot be changed after contract instantiation.
+    pub default_expiration: u64,
 }
 
 /// Stores the configuration of the contract.

--- a/crates/bvs-guardrail/src/state.rs
+++ b/crates/bvs-guardrail/src/state.rs
@@ -1,14 +1,12 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, StdError, StdResult, Storage};
+use cosmwasm_std::{Addr, StdResult, Storage};
 
-use bvs_library::storage::EVERY_SECOND;
 use bvs_vault_router::state::SlashingRequestId;
 use cw3::{Ballot, Proposal};
 use cw4::{
     MEMBERS_CHANGELOG, MEMBERS_CHECKPOINTS, MEMBERS_KEY, TOTAL_KEY, TOTAL_KEY_CHANGELOG,
     TOTAL_KEY_CHECKPOINTS,
 };
-use cw4_group::ContractError;
 use cw_storage_plus::{Item, Map, SnapshotItem, SnapshotMap, Strategy};
 use cw_utils::Threshold;
 

--- a/crates/bvs-guardrail/src/state.rs
+++ b/crates/bvs-guardrail/src/state.rs
@@ -1,25 +1,79 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::Addr;
+use cosmwasm_std::{Addr, StdError, StdResult, Storage};
 
+use bvs_library::storage::EVERY_SECOND;
 use bvs_vault_router::state::SlashingRequestId;
 use cw3::{Ballot, Proposal};
-use cw_storage_plus::{Item, Map};
+use cw4::{
+    MEMBERS_CHANGELOG, MEMBERS_CHECKPOINTS, MEMBERS_KEY, TOTAL_KEY, TOTAL_KEY_CHANGELOG,
+    TOTAL_KEY_CHECKPOINTS,
+};
+use cw4_group::ContractError;
+use cw_storage_plus::{Item, Map, SnapshotItem, SnapshotMap, Strategy};
 use cw_utils::Threshold;
+
+// aliases for easier readability
+pub type ProposalId = u64;
+pub type VotingPower = u64;
 
 #[cw_serde]
 pub struct Config {
     pub threshold: Threshold,
-    pub total_weight: u64,
 }
 
 /// Stores the configuration of the contract.
 pub const CONFIG: Item<Config> = Item::new("config");
 
-/// Stores the voters' vote for a proposal.
-pub const BALLOTS: Map<(SlashingRequestId, &Addr), Ballot> = Map::new("votes");
+/// Stores the voting records of proposals by every member.
+pub const BALLOTS: Map<(ProposalId, &Addr), Ballot> = Map::new("votes");
 
-/// Stores proposals data.
-pub const PROPOSALS: Map<SlashingRequestId, Proposal> = Map::new("proposals");
+/// Stores the proposals
+pub const PROPOSALS: Map<ProposalId, Proposal> = Map::new("proposals");
 
-/// Stores the valid voters address and their vote weight.
-pub const VOTERS: Map<&Addr, u64> = Map::new("voters");
+/// Stores the proposal count that is used to generate the next unique proposal id.
+pub const PROPOSAL_COUNT: Item<ProposalId> = Item::new("proposal_count");
+
+/// Stores the mapping between the slashing request id and the proposal id.
+pub const SLASHING_REQUEST_TO_PROPOSAL: Map<SlashingRequestId, ProposalId> =
+    Map::new("slashing_request_to_proposal");
+
+/// Stores the total voting power of the group at every block
+pub const TOTAL: SnapshotItem<VotingPower> = SnapshotItem::new(
+    TOTAL_KEY,
+    TOTAL_KEY_CHECKPOINTS,
+    TOTAL_KEY_CHANGELOG,
+    Strategy::EveryBlock,
+);
+
+/// Stores the member and their voting power at every block
+pub const MEMBERS: SnapshotMap<&Addr, VotingPower> = SnapshotMap::new(
+    MEMBERS_KEY,
+    MEMBERS_CHECKPOINTS,
+    MEMBERS_CHANGELOG,
+    Strategy::EveryBlock,
+);
+
+/// Check if this address is a member, and if its weight is >= 1
+/// Returns member's weight in positive case
+pub fn get_voting_power(
+    store: &dyn Storage,
+    member: &Addr,
+    height: impl Into<Option<u64>>,
+) -> StdResult<Option<VotingPower>> {
+    let voting_power = match height.into() {
+        Some(h) => MEMBERS.may_load_at_height(store, member, h)?,
+        None => MEMBERS.may_load(store, member)?,
+    };
+
+    match voting_power {
+        Some(weight) if weight >= 1 => Ok(Some(weight)),
+        _ => Ok(None),
+    }
+}
+
+/// generates the next proposal id
+pub fn next_id(store: &mut dyn Storage) -> StdResult<u64> {
+    let id: u64 = PROPOSAL_COUNT.may_load(store)?.unwrap_or_default() + 1;
+    PROPOSAL_COUNT.save(store, &id)?;
+    Ok(id)
+}

--- a/crates/bvs-guardrail/src/testing.rs
+++ b/crates/bvs-guardrail/src/testing.rs
@@ -1,0 +1,45 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use bvs_library::testing::TestingContract;
+use cosmwasm_std::{Addr, Decimal, Empty, Env};
+use cw_multi_test::{App, Contract, ContractWrapper};
+use cw_utils::Threshold;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct GuardrailContract {
+    pub addr: Addr,
+    pub init: InstantiateMsg,
+}
+
+impl TestingContract<InstantiateMsg, ExecuteMsg, QueryMsg, Empty> for GuardrailContract {
+    fn wrapper() -> Box<dyn Contract<Empty>> {
+        Box::new(ContractWrapper::new(
+            crate::contract::execute,
+            crate::contract::instantiate,
+            crate::contract::query,
+        ))
+    }
+
+    fn default_init(app: &mut App, _env: &Env) -> InstantiateMsg {
+        InstantiateMsg {
+            owner: app.api().addr_make("owner").to_string(),
+            members: vec![],
+            threshold: Threshold::AbsolutePercentage {
+                percentage: Decimal::percent(50),
+            },
+        }
+    }
+
+    fn new(app: &mut App, env: &Env, msg: Option<InstantiateMsg>) -> Self {
+        let init = msg.unwrap_or(Self::default_init(app, env));
+        let code_id = Self::store_code(app);
+        let addr = Self::instantiate(app, code_id, "guardrail", &init);
+        Self { addr, init }
+    }
+
+    fn addr(&self) -> &Addr {
+        &self.addr
+    }
+}

--- a/crates/bvs-guardrail/src/testing.rs
+++ b/crates/bvs-guardrail/src/testing.rs
@@ -29,6 +29,7 @@ impl TestingContract<InstantiateMsg, ExecuteMsg, QueryMsg, Empty> for GuardrailC
             threshold: Threshold::AbsolutePercentage {
                 percentage: Decimal::percent(50),
             },
+            default_expiration: 100,
         }
     }
 

--- a/crates/bvs-guardrail/tests/integration_test.rs
+++ b/crates/bvs-guardrail/tests/integration_test.rs
@@ -258,7 +258,7 @@ fn propose_and_vote_expired() {
         .execute(&mut app, &owner, &proposal_msg)
         .unwrap();
 
-    // Voter1 votes "yes"
+    // Voter1 votes "no"
     let vote_msg = ExecuteMsg::Vote {
         slashing_request_id: slashing_request_id.clone(),
         vote: Vote::No,

--- a/crates/bvs-guardrail/tests/integration_test.rs
+++ b/crates/bvs-guardrail/tests/integration_test.rs
@@ -7,7 +7,7 @@ use cosmwasm_std::{Decimal, Event};
 use cw3::{ProposalResponse, Status, Vote};
 use cw4::Member;
 use cw_multi_test::App;
-use cw_utils::{Expiration, Threshold};
+use cw_utils::Threshold;
 
 struct TestContracts {
     guardrail: GuardrailContract,
@@ -51,6 +51,7 @@ fn instantiate() -> (App, TestContracts) {
         threshold: Threshold::AbsolutePercentage {
             percentage: Decimal::percent(50),
         },
+        default_expiration: 100,
     };
 
     let guardrail = GuardrailContract::new(&mut app, &env, instantiate_msg.into());
@@ -83,7 +84,6 @@ fn propose_and_vote_successfully() {
     let proposal_msg = ExecuteMsg::Propose {
         slashing_request_id: slashing_request_id.clone(),
         reason: "test slashing".to_string(),
-        expiration: Expiration::AtTime(app.block_info().time.plus_seconds(1000)),
     };
 
     let res = tc
@@ -179,7 +179,6 @@ fn propose_and_vote_rejected() {
     let proposal_msg = ExecuteMsg::Propose {
         slashing_request_id: slashing_request_id.clone(),
         reason: "test slashing".to_string(),
-        expiration: Expiration::AtTime(app.block_info().time.plus_seconds(1000)),
     };
     tc.guardrail
         .execute(&mut app, &owner, &proposal_msg)
@@ -252,7 +251,6 @@ fn propose_and_vote_expired() {
     let proposal_msg = ExecuteMsg::Propose {
         slashing_request_id: slashing_request_id.clone(),
         reason: "test slashing".to_string(),
-        expiration: Expiration::AtTime(app.block_info().time.plus_seconds(1000)),
     };
     tc.guardrail
         .execute(&mut app, &owner, &proposal_msg)

--- a/crates/bvs-guardrail/tests/integration_test.rs
+++ b/crates/bvs-guardrail/tests/integration_test.rs
@@ -97,7 +97,7 @@ fn propose_and_vote_successfully() {
             .add_attribute("_contract_address", tc.guardrail.addr.clone())
             .add_attribute("sender", owner)
             .add_attribute("proposal_id", "1")
-            .add_attribute("slash_request_id", slashing_request_id.to_string())
+            .add_attribute("slashing_request_id", slashing_request_id.to_string())
             .add_attribute("status", format!("{:?}", Status::Open))
     );
 
@@ -113,7 +113,7 @@ fn propose_and_vote_successfully() {
             .add_attribute("_contract_address", tc.guardrail.addr.clone())
             .add_attribute("sender", voter1)
             .add_attribute("proposal_id", "1")
-            .add_attribute("slash_request_id", slashing_request_id.to_string())
+            .add_attribute("slashing_request_id", slashing_request_id.to_string())
             .add_attribute("status", format!("{:?}", Status::Open))
             .add_attribute("vote", format!("{:?}", Vote::Yes))
     );

--- a/crates/bvs-guardrail/tests/integration_test.rs
+++ b/crates/bvs-guardrail/tests/integration_test.rs
@@ -1,0 +1,315 @@
+use bvs_guardrail::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use bvs_guardrail::testing::GuardrailContract;
+use bvs_library::testing::TestingContract;
+use bvs_vault_router::state::SlashingRequestId;
+use cosmwasm_std::testing::mock_env;
+use cosmwasm_std::{Decimal, Event};
+use cw3::{ProposalResponse, Status, Vote};
+use cw4::Member;
+use cw_multi_test::App;
+use cw_utils::{Expiration, Threshold};
+
+struct TestContracts {
+    guardrail: GuardrailContract,
+}
+
+fn instantiate() -> (App, TestContracts) {
+    let mut app = App::default();
+    let env = mock_env();
+
+    let owner = app.api().addr_make("owner");
+    let voter1 = app.api().addr_make("voter1");
+    let voter2 = app.api().addr_make("voter2");
+    let voter3 = app.api().addr_make("voter3");
+    let voter4 = app.api().addr_make("voter4");
+
+    // instantiate 2-of-4 multisig voting
+    let instantiate_msg = InstantiateMsg {
+        owner: owner.to_string(),
+        members: vec![
+            Member {
+                addr: voter1.to_string(),
+                weight: 1,
+            },
+            Member {
+                addr: voter2.to_string(),
+                weight: 1,
+            },
+            Member {
+                addr: voter3.to_string(),
+                weight: 1,
+            },
+            Member {
+                addr: voter4.to_string(),
+                weight: 1,
+            },
+            Member {
+                addr: owner.to_string(),
+                weight: 0,
+            },
+        ],
+        threshold: Threshold::AbsolutePercentage {
+            percentage: Decimal::percent(50),
+        },
+    };
+
+    let guardrail = GuardrailContract::new(&mut app, &env, instantiate_msg.into());
+
+    (app, TestContracts { guardrail })
+}
+
+#[test]
+fn propose_and_vote_successfully() {
+    let (mut app, tc) = instantiate();
+
+    // mock the block
+    app.update_block(|block| {
+        block.height += 1;
+        block.time = block.time.plus_seconds(10);
+    });
+
+    let owner = app.api().addr_make("owner");
+    let voter1 = app.api().addr_make("voter1");
+    let voter2 = app.api().addr_make("voter2");
+    let voter3 = app.api().addr_make("voter3");
+    let voter4 = app.api().addr_make("voter4");
+
+    let slashing_request_id = SlashingRequestId::from_hex(
+        "cdb763a239cb5c8d627c5cc85c65aac291680aced9d081ba7595c6d5138fc4fb",
+    )
+    .unwrap();
+
+    // Create a proposal
+    let proposal_msg = ExecuteMsg::Propose {
+        slash_request_id: slashing_request_id.clone(),
+        reason: "test slashing".to_string(),
+        expiration: Expiration::AtTime(app.block_info().time.plus_seconds(1000)),
+    };
+
+    let res = tc
+        .guardrail
+        .execute(&mut app, &owner, &proposal_msg)
+        .unwrap();
+
+    assert_eq!(
+        res.events[1],
+        Event::new("wasm-propose")
+            .add_attribute("_contract_address", tc.guardrail.addr.clone())
+            .add_attribute("sender", owner)
+            .add_attribute("proposal_id", "1")
+            .add_attribute("slash_request_id", slashing_request_id.to_string())
+            .add_attribute("status", format!("{:?}", Status::Open))
+    );
+
+    // Voter1 votes "yes"
+    let vote_msg = ExecuteMsg::Vote {
+        slash_request_id: slashing_request_id.clone(),
+        vote: Vote::Yes,
+    };
+    let res = tc.guardrail.execute(&mut app, &voter1, &vote_msg).unwrap();
+    assert_eq!(
+        res.events[1],
+        Event::new("wasm-vote")
+            .add_attribute("_contract_address", tc.guardrail.addr.clone())
+            .add_attribute("sender", voter1)
+            .add_attribute("proposal_id", "1")
+            .add_attribute("slash_request_id", slashing_request_id.to_string())
+            .add_attribute("status", format!("{:?}", Status::Open))
+            .add_attribute("vote", format!("{:?}", Vote::Yes))
+    );
+
+    // Voter2 votes "no"
+    let vote_msg = ExecuteMsg::Vote {
+        slash_request_id: slashing_request_id.clone(),
+        vote: Vote::No,
+    };
+    tc.guardrail.execute(&mut app, &voter2, &vote_msg).unwrap();
+
+    // Voter3 abstains
+    let vote_msg = ExecuteMsg::Vote {
+        slash_request_id: slashing_request_id.clone(),
+        vote: Vote::Abstain,
+    };
+    tc.guardrail.execute(&mut app, &voter3, &vote_msg).unwrap();
+
+    // check the proposal status is still Open
+    let proposal_status = QueryMsg::ProposalBySlashingRequestId {
+        slashing_request_id: slashing_request_id.clone(),
+    };
+    let proposal: ProposalResponse = tc.guardrail.query(&app, &proposal_status).unwrap();
+    assert_eq!(proposal.status, Status::Open);
+
+    // Voter4 votes "yes" to pass the proposal
+    let vote_msg = ExecuteMsg::Vote {
+        slash_request_id: slashing_request_id.clone(),
+        vote: Vote::Yes,
+    };
+    tc.guardrail.execute(&mut app, &voter4, &vote_msg).unwrap();
+
+    // check the proposal status is Passed
+    let proposal_status = QueryMsg::ProposalBySlashingRequestId {
+        slashing_request_id: slashing_request_id.clone(),
+    };
+    let proposal: ProposalResponse = tc.guardrail.query(&app, &proposal_status).unwrap();
+    assert_eq!(proposal.status, Status::Passed);
+}
+
+#[test]
+fn propose_and_vote_rejected() {
+    let (mut app, tc) = instantiate();
+
+    // mock the block
+    app.update_block(|block| {
+        block.height += 1;
+        block.time = block.time.plus_seconds(10);
+    });
+
+    let owner = app.api().addr_make("owner");
+    let voter1 = app.api().addr_make("voter1");
+    let voter2 = app.api().addr_make("voter2");
+    let voter3 = app.api().addr_make("voter3");
+    let voter4 = app.api().addr_make("voter4");
+
+    let slashing_request_id = SlashingRequestId::from_hex(
+        "cdb763a239cb5c8d627c5cc85c65aac291680aced9d081ba7595c6d5138fc4fb",
+    )
+    .unwrap();
+
+    // Create a proposal
+    let proposal_msg = ExecuteMsg::Propose {
+        slash_request_id: slashing_request_id.clone(),
+        reason: "test slashing".to_string(),
+        expiration: Expiration::AtTime(app.block_info().time.plus_seconds(1000)),
+    };
+    tc.guardrail
+        .execute(&mut app, &owner, &proposal_msg)
+        .unwrap();
+
+    // Voter1 votes "no"
+    let vote_msg = ExecuteMsg::Vote {
+        slash_request_id: slashing_request_id.clone(),
+        vote: Vote::No,
+    };
+    let res = tc.guardrail.execute(&mut app, &voter1, &vote_msg).unwrap();
+
+    // Voter2 votes "no"
+    let vote_msg = ExecuteMsg::Vote {
+        slash_request_id: slashing_request_id.clone(),
+        vote: Vote::No,
+    };
+    tc.guardrail.execute(&mut app, &voter2, &vote_msg).unwrap();
+
+    // Voter3 votes "yes"
+    let vote_msg = ExecuteMsg::Vote {
+        slash_request_id: slashing_request_id.clone(),
+        vote: Vote::Yes,
+    };
+    tc.guardrail.execute(&mut app, &voter3, &vote_msg).unwrap();
+
+    // check the proposal status is still Open
+    let proposal_status = QueryMsg::ProposalBySlashingRequestId {
+        slashing_request_id: slashing_request_id.clone(),
+    };
+    let proposal: ProposalResponse = tc.guardrail.query(&app, &proposal_status).unwrap();
+    assert_eq!(proposal.status, Status::Open);
+
+    // Voter4 votes "no" to reject the proposal
+    let vote_msg = ExecuteMsg::Vote {
+        slash_request_id: slashing_request_id.clone(),
+        vote: Vote::No,
+    };
+    tc.guardrail.execute(&mut app, &voter4, &vote_msg).unwrap();
+
+    // check the proposal status is Rejected
+    let proposal_status = QueryMsg::ProposalBySlashingRequestId {
+        slashing_request_id: slashing_request_id.clone(),
+    };
+    let proposal: ProposalResponse = tc.guardrail.query(&app, &proposal_status).unwrap();
+    assert_eq!(proposal.status, Status::Rejected);
+}
+
+#[test]
+fn propose_and_vote_expired() {
+    let (mut app, tc) = instantiate();
+
+    // mock the block
+    app.update_block(|block| {
+        block.height += 1;
+        block.time = block.time.plus_seconds(10);
+    });
+
+    let owner = app.api().addr_make("owner");
+    let voter1 = app.api().addr_make("voter1");
+    let voter2 = app.api().addr_make("voter2");
+    let voter3 = app.api().addr_make("voter3");
+
+    let slashing_request_id = SlashingRequestId::from_hex(
+        "cdb763a239cb5c8d627c5cc85c65aac291680aced9d081ba7595c6d5138fc4fb",
+    )
+    .unwrap();
+
+    // Create a proposal
+    let proposal_msg = ExecuteMsg::Propose {
+        slash_request_id: slashing_request_id.clone(),
+        reason: "test slashing".to_string(),
+        expiration: Expiration::AtTime(app.block_info().time.plus_seconds(1000)),
+    };
+    tc.guardrail
+        .execute(&mut app, &owner, &proposal_msg)
+        .unwrap();
+
+    // Voter1 votes "yes"
+    let vote_msg = ExecuteMsg::Vote {
+        slash_request_id: slashing_request_id.clone(),
+        vote: Vote::No,
+    };
+    let res = tc.guardrail.execute(&mut app, &voter1, &vote_msg).unwrap();
+
+    // Voter2 votes "no"
+    let vote_msg = ExecuteMsg::Vote {
+        slash_request_id: slashing_request_id.clone(),
+        vote: Vote::No,
+    };
+    tc.guardrail.execute(&mut app, &voter2, &vote_msg).unwrap();
+
+    // move blockchain to past expiry
+    app.update_block(|block| {
+        block.height += 100;
+        block.time = block.time.plus_seconds(1000);
+    });
+
+    // Voter3 votes "yes" - error due to expiry
+    let vote_msg = ExecuteMsg::Vote {
+        slash_request_id: slashing_request_id.clone(),
+        vote: Vote::Yes,
+    };
+    let err = tc
+        .guardrail
+        .execute(&mut app, &voter3, &vote_msg)
+        .unwrap_err();
+    assert_eq!(
+        err.root_cause().to_string(),
+        "Proposal voting period has expired"
+    );
+
+    // check the proposal status is Rejected
+    let proposal_status = QueryMsg::ProposalBySlashingRequestId {
+        slashing_request_id: slashing_request_id.clone(),
+    };
+    let proposal: ProposalResponse = tc.guardrail.query(&app, &proposal_status).unwrap();
+    assert_eq!(proposal.status, Status::Rejected);
+
+    // we can call the "close" execute msg to move the status in the store to Rejected.
+    // the actual status in the store is still Open, but we can close it to Rejected.
+    let close_msg = ExecuteMsg::Close {
+        slash_request_id: slashing_request_id.clone(),
+    };
+    tc.guardrail.execute(&mut app, &owner, &close_msg).unwrap();
+
+    // check the proposal status is Rejected
+    let proposal_status = QueryMsg::ProposalBySlashingRequestId {
+        slashing_request_id: slashing_request_id.clone(),
+    };
+    let proposal: ProposalResponse = tc.guardrail.query(&app, &proposal_status).unwrap();
+    assert_eq!(proposal.status, Status::Rejected);
+}

--- a/crates/bvs-guardrail/tests/integration_test.rs
+++ b/crates/bvs-guardrail/tests/integration_test.rs
@@ -81,7 +81,7 @@ fn propose_and_vote_successfully() {
 
     // Create a proposal
     let proposal_msg = ExecuteMsg::Propose {
-        slash_request_id: slashing_request_id.clone(),
+        slashing_request_id: slashing_request_id.clone(),
         reason: "test slashing".to_string(),
         expiration: Expiration::AtTime(app.block_info().time.plus_seconds(1000)),
     };
@@ -103,7 +103,7 @@ fn propose_and_vote_successfully() {
 
     // Voter1 votes "yes"
     let vote_msg = ExecuteMsg::Vote {
-        slash_request_id: slashing_request_id.clone(),
+        slashing_request_id: slashing_request_id.clone(),
         vote: Vote::Yes,
     };
     let res = tc.guardrail.execute(&mut app, &voter1, &vote_msg).unwrap();
@@ -120,14 +120,14 @@ fn propose_and_vote_successfully() {
 
     // Voter2 votes "no"
     let vote_msg = ExecuteMsg::Vote {
-        slash_request_id: slashing_request_id.clone(),
+        slashing_request_id: slashing_request_id.clone(),
         vote: Vote::No,
     };
     tc.guardrail.execute(&mut app, &voter2, &vote_msg).unwrap();
 
     // Voter3 abstains
     let vote_msg = ExecuteMsg::Vote {
-        slash_request_id: slashing_request_id.clone(),
+        slashing_request_id: slashing_request_id.clone(),
         vote: Vote::Abstain,
     };
     tc.guardrail.execute(&mut app, &voter3, &vote_msg).unwrap();
@@ -141,7 +141,7 @@ fn propose_and_vote_successfully() {
 
     // Voter4 votes "yes" to pass the proposal
     let vote_msg = ExecuteMsg::Vote {
-        slash_request_id: slashing_request_id.clone(),
+        slashing_request_id: slashing_request_id.clone(),
         vote: Vote::Yes,
     };
     tc.guardrail.execute(&mut app, &voter4, &vote_msg).unwrap();
@@ -177,7 +177,7 @@ fn propose_and_vote_rejected() {
 
     // Create a proposal
     let proposal_msg = ExecuteMsg::Propose {
-        slash_request_id: slashing_request_id.clone(),
+        slashing_request_id: slashing_request_id.clone(),
         reason: "test slashing".to_string(),
         expiration: Expiration::AtTime(app.block_info().time.plus_seconds(1000)),
     };
@@ -187,21 +187,21 @@ fn propose_and_vote_rejected() {
 
     // Voter1 votes "no"
     let vote_msg = ExecuteMsg::Vote {
-        slash_request_id: slashing_request_id.clone(),
+        slashing_request_id: slashing_request_id.clone(),
         vote: Vote::No,
     };
     let res = tc.guardrail.execute(&mut app, &voter1, &vote_msg).unwrap();
 
     // Voter2 votes "no"
     let vote_msg = ExecuteMsg::Vote {
-        slash_request_id: slashing_request_id.clone(),
+        slashing_request_id: slashing_request_id.clone(),
         vote: Vote::No,
     };
     tc.guardrail.execute(&mut app, &voter2, &vote_msg).unwrap();
 
     // Voter3 votes "yes"
     let vote_msg = ExecuteMsg::Vote {
-        slash_request_id: slashing_request_id.clone(),
+        slashing_request_id: slashing_request_id.clone(),
         vote: Vote::Yes,
     };
     tc.guardrail.execute(&mut app, &voter3, &vote_msg).unwrap();
@@ -215,7 +215,7 @@ fn propose_and_vote_rejected() {
 
     // Voter4 votes "no" to reject the proposal
     let vote_msg = ExecuteMsg::Vote {
-        slash_request_id: slashing_request_id.clone(),
+        slashing_request_id: slashing_request_id.clone(),
         vote: Vote::No,
     };
     tc.guardrail.execute(&mut app, &voter4, &vote_msg).unwrap();
@@ -250,7 +250,7 @@ fn propose_and_vote_expired() {
 
     // Create a proposal
     let proposal_msg = ExecuteMsg::Propose {
-        slash_request_id: slashing_request_id.clone(),
+        slashing_request_id: slashing_request_id.clone(),
         reason: "test slashing".to_string(),
         expiration: Expiration::AtTime(app.block_info().time.plus_seconds(1000)),
     };
@@ -260,14 +260,14 @@ fn propose_and_vote_expired() {
 
     // Voter1 votes "yes"
     let vote_msg = ExecuteMsg::Vote {
-        slash_request_id: slashing_request_id.clone(),
+        slashing_request_id: slashing_request_id.clone(),
         vote: Vote::No,
     };
     let res = tc.guardrail.execute(&mut app, &voter1, &vote_msg).unwrap();
 
     // Voter2 votes "no"
     let vote_msg = ExecuteMsg::Vote {
-        slash_request_id: slashing_request_id.clone(),
+        slashing_request_id: slashing_request_id.clone(),
         vote: Vote::No,
     };
     tc.guardrail.execute(&mut app, &voter2, &vote_msg).unwrap();
@@ -280,7 +280,7 @@ fn propose_and_vote_expired() {
 
     // Voter3 votes "yes" - error due to expiry
     let vote_msg = ExecuteMsg::Vote {
-        slash_request_id: slashing_request_id.clone(),
+        slashing_request_id: slashing_request_id.clone(),
         vote: Vote::Yes,
     };
     let err = tc
@@ -302,7 +302,7 @@ fn propose_and_vote_expired() {
     // we can call the "close" execute msg to move the status in the store to Rejected.
     // the actual status in the store is still Open, but we can close it to Rejected.
     let close_msg = ExecuteMsg::Close {
-        slash_request_id: slashing_request_id.clone(),
+        slashing_request_id: slashing_request_id.clone(),
     };
     tc.guardrail.execute(&mut app, &owner, &close_msg).unwrap();
 

--- a/crates/bvs-vault-router/src/state.rs
+++ b/crates/bvs-vault-router/src/state.rs
@@ -107,7 +107,7 @@ impl SlashingRequestId {
         Ok(<[u8; 32]>::from(hasher.finalize()).into())
     }
 
-    /// Returns the hex string representation of the slashing request id
+    /// Create a SlashingRequestId from its hex string representation
     pub fn from_hex(hex: &str) -> StdResult<Self> {
         let bytes = HexBinary::from_hex(hex)?;
         if bytes.len() != 32 {

--- a/crates/bvs-vault-router/src/state.rs
+++ b/crates/bvs-vault-router/src/state.rs
@@ -2,7 +2,7 @@ use crate::msg::RequestSlashingPayload;
 use bvs_library::addr::{Operator, Service};
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{to_json_vec, Addr, HexBinary, StdError, StdResult, Storage, Timestamp, Uint64};
-use cw_storage_plus::{Item, Key, KeyDeserialize, Map, PrimaryKey};
+use cw_storage_plus::{Item, Key, KeyDeserialize, Map, Prefixer, PrimaryKey};
 use sha3::Digest;
 use std::fmt;
 use std::ops::{Deref, DerefMut};
@@ -106,6 +106,15 @@ impl SlashingRequestId {
 
         Ok(<[u8; 32]>::from(hasher.finalize()).into())
     }
+
+    /// Returns the hex string representation of the slashing request id
+    pub fn from_hex(hex: &str) -> StdResult<Self> {
+        let bytes = HexBinary::from_hex(hex)?;
+        if bytes.len() != 32 {
+            return Err(StdError::generic_err("Invalid hex length"));
+        }
+        Ok(SlashingRequestId(bytes))
+    }
 }
 
 impl fmt::Display for SlashingRequestId {
@@ -147,6 +156,12 @@ impl PrimaryKey<'_> for SlashingRequestId {
     type SuperSuffix = Self;
 
     fn key(&self) -> Vec<Key> {
+        vec![Key::Ref(self.0.as_slice())]
+    }
+}
+
+impl Prefixer<'_> for SlashingRequestId {
+    fn prefix(&self) -> Vec<Key> {
         vec![Key::Ref(self.0.as_slice())]
     }
 }

--- a/crates/bvs-vault-router/src/state.rs
+++ b/crates/bvs-vault-router/src/state.rs
@@ -2,7 +2,7 @@ use crate::msg::RequestSlashingPayload;
 use bvs_library::addr::{Operator, Service};
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{to_json_vec, Addr, HexBinary, StdError, StdResult, Storage, Timestamp, Uint64};
-use cw_storage_plus::{Item, Key, KeyDeserialize, Map, Prefixer, PrimaryKey};
+use cw_storage_plus::{Item, Key, KeyDeserialize, Map, PrimaryKey};
 use sha3::Digest;
 use std::fmt;
 use std::ops::{Deref, DerefMut};
@@ -156,12 +156,6 @@ impl PrimaryKey<'_> for SlashingRequestId {
     type SuperSuffix = Self;
 
     fn key(&self) -> Vec<Key> {
-        vec![Key::Ref(self.0.as_slice())]
-    }
-}
-
-impl Prefixer<'_> for SlashingRequestId {
-    fn prefix(&self) -> Vec<Key> {
         vec![Key::Ref(self.0.as_slice())]
     }
 }

--- a/crates/crates.iml
+++ b/crates/crates.iml
@@ -35,6 +35,7 @@
       <sourceFolder url="file://$MODULE_DIR$/bvs-multi-test/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/bvs-vault-bank-tokenized/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/bvs-vault-bank-tokenized/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/bvs-guardrail/tests" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
       <excludePattern pattern=".turbo" />
       <excludePattern pattern="Cargo.lock" />

--- a/crates/crates.iml
+++ b/crates/crates.iml
@@ -31,6 +31,7 @@
       <sourceFolder url="file://$MODULE_DIR$/bvs-registry/tests" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/bvs-rewards/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/bvs-rewards/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/bvs-guardrail/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/bvs-multi-test/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/bvs-vault-bank-tokenized/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/bvs-vault-bank-tokenized/tests" isTestSource="true" />

--- a/docs/app/contracts/_meta.ts
+++ b/docs/app/contracts/_meta.ts
@@ -11,6 +11,7 @@ const meta: MetaRecord = {
   "vault-base": {},
   rewards: {},
   registry: {},
+  guardrail: {},
   pauser: {},
   library: {},
 };

--- a/docs/app/contracts/guardrail/page.md
+++ b/docs/app/contracts/guardrail/page.md
@@ -1,0 +1,1 @@
+../../../../crates/bvs-guardrail/README.md

--- a/modules/cosmwasm-schema/generate.mjs
+++ b/modules/cosmwasm-schema/generate.mjs
@@ -45,6 +45,7 @@ async function generate(schema) {
 const packages = [
   "@satlayer/bvs-pauser",
   "@satlayer/bvs-registry",
+  "@satlayer/bvs-guardrail",
   "@satlayer/bvs-vault-router",
   "@satlayer/bvs-vault-cw20",
   "@satlayer/bvs-vault-cw20-tokenized",

--- a/modules/cosmwasm-schema/guardrail/schema.go
+++ b/modules/cosmwasm-schema/guardrail/schema.go
@@ -1,0 +1,924 @@
+// This file was automatically generated from guardrail/schema.json.
+// DO NOT MODIFY IT BY HAND.
+
+package guardrail
+
+type InstantiateMsg struct {
+	Members   []MemberElement `json:"members"`
+	Owner     string          `json:"owner"`
+	Threshold Threshold       `json:"threshold"`
+}
+
+// A group member has a weight associated with them. This may all be equal, or may have
+// meaning in the app that makes use of the group (eg. voting power)
+type MemberElement struct {
+	Addr   string `json:"addr"`
+	Weight int64  `json:"weight"`
+}
+
+// This defines the different ways tallies can happen.
+//
+// The total_weight used for calculating success as well as the weights of each individual
+// voter used in tallying should be snapshotted at the beginning of the block at which the
+// proposal starts (this is likely the responsibility of a correct cw4 implementation). See
+// also `ThresholdResponse` in the cw3 spec.
+//
+// Declares that a fixed weight of Yes votes is needed to pass. See
+// `ThresholdResponse.AbsoluteCount` in the cw3 spec for details.
+//
+// Declares a percentage of the total weight that must cast Yes votes in order for a
+// proposal to pass. See `ThresholdResponse.AbsolutePercentage` in the cw3 spec for
+// details.
+//
+// Declares a `quorum` of the total votes that must participate in the election in order for
+// the vote to be considered at all. See `ThresholdResponse.ThresholdQuorum` in the cw3 spec
+// for details.
+type Threshold struct {
+	AbsoluteCount      *ThresholdAbsoluteCount      `json:"absolute_count,omitempty"`
+	AbsolutePercentage *ThresholdAbsolutePercentage `json:"absolute_percentage,omitempty"`
+	ThresholdQuorum    *ThresholdThresholdQuorum    `json:"threshold_quorum,omitempty"`
+}
+
+type ThresholdAbsoluteCount struct {
+	Weight int64 `json:"weight"`
+}
+
+type ThresholdAbsolutePercentage struct {
+	Percentage string `json:"percentage"`
+}
+
+type ThresholdThresholdQuorum struct {
+	Quorum    string `json:"quorum"`
+	Threshold string `json:"threshold"`
+}
+
+// apply a diff to the existing members. remove is applied after add, so if an address is in
+// both, it is removed
+type ExecuteMsg struct {
+	Propose       *Propose        `json:"propose,omitempty"`
+	Vote          *ExecuteMsgVote `json:"vote,omitempty"`
+	Close         *Close          `json:"close,omitempty"`
+	UpdateMembers *UpdateMembers  `json:"update_members,omitempty"`
+}
+
+type Close struct {
+	SlashRequestID string `json:"slash_request_id"`
+}
+
+type Propose struct {
+	Expiration     ProposeExpiration `json:"expiration"`
+	Reason         string            `json:"reason"`
+	SlashRequestID string            `json:"slash_request_id"`
+}
+
+// Expiration represents a point in time when some event happens. It can compare with a
+// BlockInfo and will return is_expired() == true once the condition is hit (and for every
+// block in the future)
+//
+// AtHeight will expire when `env.block.height` >= height
+//
+// AtTime will expire when `env.block.time` >= time
+//
+// Never will never expire. Used to express the empty variant
+type ProposeExpiration struct {
+	AtHeight *int64       `json:"at_height,omitempty"`
+	AtTime   *string      `json:"at_time,omitempty"`
+	Never    *PurpleNever `json:"never,omitempty"`
+}
+
+type PurpleNever struct {
+}
+
+type UpdateMembers struct {
+	Add    []AddElement `json:"add"`
+	Remove []string     `json:"remove"`
+}
+
+// A group member has a weight associated with them. This may all be equal, or may have
+// meaning in the app that makes use of the group (eg. voting power)
+type AddElement struct {
+	Addr   string `json:"addr"`
+	Weight int64  `json:"weight"`
+}
+
+type ExecuteMsgVote struct {
+	SlashRequestID string `json:"slash_request_id"`
+	Vote           Vote   `json:"vote"`
+}
+
+type QueryMsg struct {
+	Threshold                   *ThresholdClass              `json:"threshold,omitempty"`
+	Proposal                    *Proposal                    `json:"proposal,omitempty"`
+	ProposalBySlashingRequestID *ProposalBySlashingRequestID `json:"proposal_by_slashing_request_id,omitempty"`
+	ListProposals               *ListProposals               `json:"list_proposals,omitempty"`
+	ReverseProposals            *ReverseProposals            `json:"reverse_proposals,omitempty"`
+	Vote                        *QueryMsgVote                `json:"vote,omitempty"`
+	VoteBySlashingRequestID     *VoteBySlashingRequestID     `json:"vote_by_slashing_request_id,omitempty"`
+	ListVotes                   *ListVotes                   `json:"list_votes,omitempty"`
+	Voter                       *Voter                       `json:"voter,omitempty"`
+	ListVoters                  *ListVoters                  `json:"list_voters,omitempty"`
+}
+
+type ListProposals struct {
+	Limit      *int64 `json:"limit"`
+	StartAfter *int64 `json:"start_after"`
+}
+
+type ListVoters struct {
+	Limit      *int64  `json:"limit"`
+	StartAfter *string `json:"start_after"`
+}
+
+type ListVotes struct {
+	Limit      *int64  `json:"limit"`
+	ProposalID int64   `json:"proposal_id"`
+	StartAfter *string `json:"start_after"`
+}
+
+type Proposal struct {
+	ProposalID int64 `json:"proposal_id"`
+}
+
+type ProposalBySlashingRequestID struct {
+	SlashingRequestID string `json:"slashing_request_id"`
+}
+
+type ReverseProposals struct {
+	Limit       *int64 `json:"limit"`
+	StartBefore *int64 `json:"start_before"`
+}
+
+type ThresholdClass struct {
+	Height *int64 `json:"height"`
+}
+
+type QueryMsgVote struct {
+	ProposalID int64  `json:"proposal_id"`
+	Voter      string `json:"voter"`
+}
+
+type VoteBySlashingRequestID struct {
+	SlashingRequestID string `json:"slashing_request_id"`
+	Voter             string `json:"voter"`
+}
+
+type Voter struct {
+	Address string `json:"address"`
+	Height  *int64 `json:"height"`
+}
+
+type ProposalListResponseForEmpty struct {
+	Proposals []ProposalElement `json:"proposals"`
+}
+
+// Note, if you are storing custom messages in the proposal, the querier needs to know what
+// possible custom message types those are in order to parse the response
+type ProposalElement struct {
+	Deposit     *ProposalDepositInfo        `json:"deposit"`
+	Description string                      `json:"description"`
+	Expires     ProposalExpiration          `json:"expires"`
+	ID          int64                       `json:"id"`
+	Msgs        []ProposalCosmosMsgForEmpty `json:"msgs"`
+	Proposer    string                      `json:"proposer"`
+	Status      Status                      `json:"status"`
+	// This is the threshold that is applied to this proposal. Both the rules of the voting
+	// contract, as well as the total_weight of the voting group may have changed since this
+	// time. That means that the generic `Threshold{}` query does not provide valid information
+	// for existing proposals.
+	Threshold ProposalThresholdResponse `json:"threshold"`
+	Title     string                    `json:"title"`
+}
+
+// Information about the deposit required to create a proposal.
+type ProposalDepositInfo struct {
+	// The number tokens required for payment.
+	Amount string `json:"amount"`
+	// The denom of the deposit payment.
+	Denom PurpleDenom `json:"denom"`
+	// Should failed proposals have their deposits refunded?
+	RefundFailedProposals bool `json:"refund_failed_proposals"`
+}
+
+// The denom of the deposit payment.
+type PurpleDenom struct {
+	Native *string `json:"native,omitempty"`
+	Cw20   *string `json:"cw20,omitempty"`
+}
+
+// Expiration represents a point in time when some event happens. It can compare with a
+// BlockInfo and will return is_expired() == true once the condition is hit (and for every
+// block in the future)
+//
+// AtHeight will expire when `env.block.height` >= height
+//
+// AtTime will expire when `env.block.time` >= time
+//
+// Never will never expire. Used to express the empty variant
+type ProposalExpiration struct {
+	AtHeight *int64       `json:"at_height,omitempty"`
+	AtTime   *string      `json:"at_time,omitempty"`
+	Never    *FluffyNever `json:"never,omitempty"`
+}
+
+type FluffyNever struct {
+}
+
+// `CosmosMsg::Any` is the replaces the "stargate message" – a message wrapped in a
+// [protobuf Any](https://protobuf.dev/programming-guides/proto3/#any) that is supported by
+// the chain. It behaves the same as `CosmosMsg::Stargate` but has a better name and
+// slightly improved syntax.
+//
+// This is feature-gated at compile time with `cosmwasm_2_0` because a chain running
+// CosmWasm < 2.0 cannot process this.
+type ProposalCosmosMsgForEmpty struct {
+	Bank   *PurpleBankMsg `json:"bank,omitempty"`
+	Custom *PurpleEmpty   `json:"custom,omitempty"`
+	Any    *PurpleAnyMsg  `json:"any,omitempty"`
+	WASM   *PurpleWASMMsg `json:"wasm,omitempty"`
+}
+
+// A message encoded the same way as a protobuf
+// [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto).
+// This is the same structure as messages in `TxBody` from
+// [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)
+type PurpleAnyMsg struct {
+	TypeURL string `json:"type_url"`
+	Value   string `json:"value"`
+}
+
+// The message types of the bank module.
+//
+// See https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto
+//
+// Sends native tokens from the contract to the given address.
+//
+// This is translated to a
+// [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28).
+// `from_address` is automatically filled with the current contract's address.
+//
+// This will burn the given coins from the contract's account. There is no Cosmos SDK
+// message that performs this, but it can be done by calling the bank keeper. Important if a
+// contract controls significant token supply that must be retired.
+type PurpleBankMsg struct {
+	Send *PurpleSend `json:"send,omitempty"`
+	Burn *PurpleBurn `json:"burn,omitempty"`
+}
+
+type PurpleBurn struct {
+	Amount []PurpleCoin `json:"amount"`
+}
+
+type PurpleCoin struct {
+	Amount string `json:"amount"`
+	Denom  string `json:"denom"`
+}
+
+type PurpleSend struct {
+	Amount    []PurpleCoin `json:"amount"`
+	ToAddress string       `json:"to_address"`
+}
+
+// An empty struct that serves as a placeholder in different places, such as contracts that
+// don't set a custom message.
+//
+// It is designed to be expressible in correct JSON and JSON Schema but contains no
+// meaningful data. Previously we used enums without cases, but those cannot represented as
+// valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)
+type PurpleEmpty struct {
+}
+
+// The message types of the wasm module.
+//
+// See https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto
+//
+// Dispatches a call to another contract at a known address (with known ABI).
+//
+// This is translated to a
+// [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78).
+// `sender` is automatically filled with the current contract's address.
+//
+// Instantiates a new contracts from previously uploaded Wasm code.
+//
+// The contract address is non-predictable. But it is guaranteed that when emitting the same
+// Instantiate message multiple times, multiple instances on different addresses will be
+// generated. See also Instantiate2.
+//
+// This is translated to a
+// [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71).
+// `sender` is automatically filled with the current contract's address.
+//
+// Instantiates a new contracts from previously uploaded Wasm code using a predictable
+// address derivation algorithm implemented in [`cosmwasm_std::instantiate2_address`].
+//
+// This is translated to a
+// [MsgInstantiateContract2](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L73-L96).
+// `sender` is automatically filled with the current contract's address. `fix_msg` is
+// automatically set to false.
+//
+// Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to
+// customize behavior.
+//
+// Only the contract admin (as defined in wasmd), if any, is able to make this call.
+//
+// This is translated to a
+// [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96).
+// `sender` is automatically filled with the current contract's address.
+//
+// Sets a new admin (for migrate) on the given contract. Fails if this contract is not
+// currently admin of the target contract.
+//
+// Clears the admin on the given contract, so no more migration possible. Fails if this
+// contract is not currently admin of the target contract.
+type PurpleWASMMsg struct {
+	Execute      *PurpleExecute      `json:"execute,omitempty"`
+	Instantiate  *PurpleInstantiate  `json:"instantiate,omitempty"`
+	Instantiate2 *PurpleInstantiate2 `json:"instantiate2,omitempty"`
+	Migrate      *PurpleMigrate      `json:"migrate,omitempty"`
+	UpdateAdmin  *PurpleUpdateAdmin  `json:"update_admin,omitempty"`
+	ClearAdmin   *PurpleClearAdmin   `json:"clear_admin,omitempty"`
+}
+
+type PurpleClearAdmin struct {
+	ContractAddr string `json:"contract_addr"`
+}
+
+type PurpleExecute struct {
+	ContractAddr string       `json:"contract_addr"`
+	Funds        []PurpleCoin `json:"funds"`
+	// msg is the json-encoded ExecuteMsg struct (as raw Binary)
+	Msg string `json:"msg"`
+}
+
+type PurpleInstantiate struct {
+	Admin  *string      `json:"admin"`
+	CodeID int64        `json:"code_id"`
+	Funds  []PurpleCoin `json:"funds"`
+	// A human-readable label for the contract.
+	//
+	// Valid values should: - not be empty - not be bigger than 128 bytes (or some
+	// chain-specific limit) - not start / end with whitespace
+	Label string `json:"label"`
+	// msg is the JSON-encoded InstantiateMsg struct (as raw Binary)
+	Msg string `json:"msg"`
+}
+
+type PurpleInstantiate2 struct {
+	Admin  *string      `json:"admin"`
+	CodeID int64        `json:"code_id"`
+	Funds  []PurpleCoin `json:"funds"`
+	// A human-readable label for the contract.
+	//
+	// Valid values should: - not be empty - not be bigger than 128 bytes (or some
+	// chain-specific limit) - not start / end with whitespace
+	Label string `json:"label"`
+	// msg is the JSON-encoded InstantiateMsg struct (as raw Binary)
+	Msg  string `json:"msg"`
+	Salt string `json:"salt"`
+}
+
+type PurpleMigrate struct {
+	ContractAddr string `json:"contract_addr"`
+	// msg is the json-encoded MigrateMsg struct that will be passed to the new code
+	Msg string `json:"msg"`
+	// the code_id of the new logic to place in the given contract
+	NewCodeID int64 `json:"new_code_id"`
+}
+
+type PurpleUpdateAdmin struct {
+	Admin        string `json:"admin"`
+	ContractAddr string `json:"contract_addr"`
+}
+
+// This is the threshold that is applied to this proposal. Both the rules of the voting
+// contract, as well as the total_weight of the voting group may have changed since this
+// time. That means that the generic `Threshold{}` query does not provide valid information
+// for existing proposals.
+//
+// This defines the different ways tallies can happen. Every contract should support a
+// subset of these, ideally all.
+//
+// The total_weight used for calculating success as well as the weights of each individual
+// voter used in tallying should be snapshotted at the beginning of the block at which the
+// proposal starts (this is likely the responsibility of a correct cw4 implementation).
+//
+// Declares that a fixed weight of yes votes is needed to pass. It does not matter how many
+// no votes are cast, or how many do not vote, as long as `weight` yes votes are cast.
+//
+// This is the simplest format and usually suitable for small multisigs of trusted parties,
+// like 3 of 5. (weight: 3, total_weight: 5)
+//
+// A proposal of this type can pass early as soon as the needed weight of yes votes has been
+// cast.
+//
+// Declares a percentage of the total weight that must cast Yes votes, in order for a
+// proposal to pass. The passing weight is computed over the total weight minus the weight
+// of the abstained votes.
+//
+// This is useful for similar circumstances as `AbsoluteCount`, where we have a relatively
+// small set of voters, and participation is required. It is understood that if the voting
+// set (group) changes between different proposals that refer to the same group, each
+// proposal will work with a different set of voter weights (the ones snapshotted at
+// proposal creation), and the passing weight for each proposal will be computed based on
+// the absolute percentage, times the total weights of the members at the time of each
+// proposal creation.
+//
+// Example: we set `percentage` to 51%. Proposal 1 starts when there is a `total_weight` of
+// 5. This will require 3 weight of Yes votes in order to pass. Later, the Proposal 2 starts
+// but the `total_weight` of the group has increased to 9. That proposal will then
+// automatically require 5 Yes of 9 to pass, rather than 3 yes of 9 as would be the case
+// with `AbsoluteCount`.
+//
+// In addition to a `threshold`, declares a `quorum` of the total votes that must
+// participate in the election in order for the vote to be considered at all. Within the
+// votes that were cast, it requires `threshold` votes in favor. That is calculated by
+// ignoring the Abstain votes (they count towards `quorum`, but do not influence
+// `threshold`). That is, we calculate `Yes / (Yes + No + Veto)` and compare it with
+// `threshold` to consider if the proposal was passed.
+//
+// It is rather difficult for a proposal of this type to pass early. That can only happen if
+// the required quorum has been already met, and there are already enough Yes votes for the
+// proposal to pass.
+//
+// 30% Yes votes, 10% No votes, and 20% Abstain would pass early if quorum <= 60% (who has
+// cast votes) and if the threshold is <= 37.5% (the remaining 40% voting no => 30% yes +
+// 50% no). Once the voting period has passed with no additional votes, that same proposal
+// would be considered successful if quorum <= 60% and threshold <= 75% (percent in favor if
+// we ignore abstain votes).
+//
+// This type is more common in general elections, where participation is often expected to
+// be low, and `AbsolutePercentage` would either be too high to pass anything, or allow low
+// percentages to pass, independently of if there was high participation in the election or
+// not.
+type ProposalThresholdResponse struct {
+	AbsoluteCount      *PurpleAbsoluteCount      `json:"absolute_count,omitempty"`
+	AbsolutePercentage *PurpleAbsolutePercentage `json:"absolute_percentage,omitempty"`
+	ThresholdQuorum    *PurpleThresholdQuorum    `json:"threshold_quorum,omitempty"`
+}
+
+type PurpleAbsoluteCount struct {
+	TotalWeight int64 `json:"total_weight"`
+	Weight      int64 `json:"weight"`
+}
+
+type PurpleAbsolutePercentage struct {
+	Percentage  string `json:"percentage"`
+	TotalWeight int64  `json:"total_weight"`
+}
+
+type PurpleThresholdQuorum struct {
+	Quorum      string `json:"quorum"`
+	Threshold   string `json:"threshold"`
+	TotalWeight int64  `json:"total_weight"`
+}
+
+type VoterListResponse struct {
+	Voters []VoterDetail `json:"voters"`
+}
+
+type VoterDetail struct {
+	Addr   string `json:"addr"`
+	Weight int64  `json:"weight"`
+}
+
+type VoteListResponse struct {
+	Votes []VoteElement `json:"votes"`
+}
+
+// Returns the vote (opinion as well as weight counted) as well as the address of the voter
+// who submitted it
+type VoteElement struct {
+	ProposalID int64  `json:"proposal_id"`
+	Vote       Vote   `json:"vote"`
+	Voter      string `json:"voter"`
+	Weight     int64  `json:"weight"`
+}
+
+// Note, if you are storing custom messages in the proposal, the querier needs to know what
+// possible custom message types those are in order to parse the response
+type ProposalResponseForEmpty struct {
+	Deposit     *ProposalResponseForEmptyDepositInfo        `json:"deposit"`
+	Description string                                      `json:"description"`
+	Expires     ProposalResponseForEmptyExpiration          `json:"expires"`
+	ID          int64                                       `json:"id"`
+	Msgs        []ProposalResponseForEmptyCosmosMsgForEmpty `json:"msgs"`
+	Proposer    string                                      `json:"proposer"`
+	Status      Status                                      `json:"status"`
+	// This is the threshold that is applied to this proposal. Both the rules of the voting
+	// contract, as well as the total_weight of the voting group may have changed since this
+	// time. That means that the generic `Threshold{}` query does not provide valid information
+	// for existing proposals.
+	Threshold ProposalResponseForEmptyThresholdResponse `json:"threshold"`
+	Title     string                                    `json:"title"`
+}
+
+// Information about the deposit required to create a proposal.
+type ProposalResponseForEmptyDepositInfo struct {
+	// The number tokens required for payment.
+	Amount string `json:"amount"`
+	// The denom of the deposit payment.
+	Denom FluffyDenom `json:"denom"`
+	// Should failed proposals have their deposits refunded?
+	RefundFailedProposals bool `json:"refund_failed_proposals"`
+}
+
+// The denom of the deposit payment.
+type FluffyDenom struct {
+	Native *string `json:"native,omitempty"`
+	Cw20   *string `json:"cw20,omitempty"`
+}
+
+// Expiration represents a point in time when some event happens. It can compare with a
+// BlockInfo and will return is_expired() == true once the condition is hit (and for every
+// block in the future)
+//
+// AtHeight will expire when `env.block.height` >= height
+//
+// AtTime will expire when `env.block.time` >= time
+//
+// Never will never expire. Used to express the empty variant
+type ProposalResponseForEmptyExpiration struct {
+	AtHeight *int64          `json:"at_height,omitempty"`
+	AtTime   *string         `json:"at_time,omitempty"`
+	Never    *TentacledNever `json:"never,omitempty"`
+}
+
+type TentacledNever struct {
+}
+
+// `CosmosMsg::Any` is the replaces the "stargate message" – a message wrapped in a
+// [protobuf Any](https://protobuf.dev/programming-guides/proto3/#any) that is supported by
+// the chain. It behaves the same as `CosmosMsg::Stargate` but has a better name and
+// slightly improved syntax.
+//
+// This is feature-gated at compile time with `cosmwasm_2_0` because a chain running
+// CosmWasm < 2.0 cannot process this.
+type ProposalResponseForEmptyCosmosMsgForEmpty struct {
+	Bank   *FluffyBankMsg `json:"bank,omitempty"`
+	Custom *FluffyEmpty   `json:"custom,omitempty"`
+	Any    *FluffyAnyMsg  `json:"any,omitempty"`
+	WASM   *FluffyWASMMsg `json:"wasm,omitempty"`
+}
+
+// A message encoded the same way as a protobuf
+// [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto).
+// This is the same structure as messages in `TxBody` from
+// [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)
+type FluffyAnyMsg struct {
+	TypeURL string `json:"type_url"`
+	Value   string `json:"value"`
+}
+
+// The message types of the bank module.
+//
+// See https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto
+//
+// Sends native tokens from the contract to the given address.
+//
+// This is translated to a
+// [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28).
+// `from_address` is automatically filled with the current contract's address.
+//
+// This will burn the given coins from the contract's account. There is no Cosmos SDK
+// message that performs this, but it can be done by calling the bank keeper. Important if a
+// contract controls significant token supply that must be retired.
+type FluffyBankMsg struct {
+	Send *FluffySend `json:"send,omitempty"`
+	Burn *FluffyBurn `json:"burn,omitempty"`
+}
+
+type FluffyBurn struct {
+	Amount []FluffyCoin `json:"amount"`
+}
+
+type FluffyCoin struct {
+	Amount string `json:"amount"`
+	Denom  string `json:"denom"`
+}
+
+type FluffySend struct {
+	Amount    []FluffyCoin `json:"amount"`
+	ToAddress string       `json:"to_address"`
+}
+
+// An empty struct that serves as a placeholder in different places, such as contracts that
+// don't set a custom message.
+//
+// It is designed to be expressible in correct JSON and JSON Schema but contains no
+// meaningful data. Previously we used enums without cases, but those cannot represented as
+// valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)
+type FluffyEmpty struct {
+}
+
+// The message types of the wasm module.
+//
+// See https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto
+//
+// Dispatches a call to another contract at a known address (with known ABI).
+//
+// This is translated to a
+// [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78).
+// `sender` is automatically filled with the current contract's address.
+//
+// Instantiates a new contracts from previously uploaded Wasm code.
+//
+// The contract address is non-predictable. But it is guaranteed that when emitting the same
+// Instantiate message multiple times, multiple instances on different addresses will be
+// generated. See also Instantiate2.
+//
+// This is translated to a
+// [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71).
+// `sender` is automatically filled with the current contract's address.
+//
+// Instantiates a new contracts from previously uploaded Wasm code using a predictable
+// address derivation algorithm implemented in [`cosmwasm_std::instantiate2_address`].
+//
+// This is translated to a
+// [MsgInstantiateContract2](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L73-L96).
+// `sender` is automatically filled with the current contract's address. `fix_msg` is
+// automatically set to false.
+//
+// Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to
+// customize behavior.
+//
+// Only the contract admin (as defined in wasmd), if any, is able to make this call.
+//
+// This is translated to a
+// [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96).
+// `sender` is automatically filled with the current contract's address.
+//
+// Sets a new admin (for migrate) on the given contract. Fails if this contract is not
+// currently admin of the target contract.
+//
+// Clears the admin on the given contract, so no more migration possible. Fails if this
+// contract is not currently admin of the target contract.
+type FluffyWASMMsg struct {
+	Execute      *FluffyExecute      `json:"execute,omitempty"`
+	Instantiate  *FluffyInstantiate  `json:"instantiate,omitempty"`
+	Instantiate2 *FluffyInstantiate2 `json:"instantiate2,omitempty"`
+	Migrate      *FluffyMigrate      `json:"migrate,omitempty"`
+	UpdateAdmin  *FluffyUpdateAdmin  `json:"update_admin,omitempty"`
+	ClearAdmin   *FluffyClearAdmin   `json:"clear_admin,omitempty"`
+}
+
+type FluffyClearAdmin struct {
+	ContractAddr string `json:"contract_addr"`
+}
+
+type FluffyExecute struct {
+	ContractAddr string       `json:"contract_addr"`
+	Funds        []FluffyCoin `json:"funds"`
+	// msg is the json-encoded ExecuteMsg struct (as raw Binary)
+	Msg string `json:"msg"`
+}
+
+type FluffyInstantiate struct {
+	Admin  *string      `json:"admin"`
+	CodeID int64        `json:"code_id"`
+	Funds  []FluffyCoin `json:"funds"`
+	// A human-readable label for the contract.
+	//
+	// Valid values should: - not be empty - not be bigger than 128 bytes (or some
+	// chain-specific limit) - not start / end with whitespace
+	Label string `json:"label"`
+	// msg is the JSON-encoded InstantiateMsg struct (as raw Binary)
+	Msg string `json:"msg"`
+}
+
+type FluffyInstantiate2 struct {
+	Admin  *string      `json:"admin"`
+	CodeID int64        `json:"code_id"`
+	Funds  []FluffyCoin `json:"funds"`
+	// A human-readable label for the contract.
+	//
+	// Valid values should: - not be empty - not be bigger than 128 bytes (or some
+	// chain-specific limit) - not start / end with whitespace
+	Label string `json:"label"`
+	// msg is the JSON-encoded InstantiateMsg struct (as raw Binary)
+	Msg  string `json:"msg"`
+	Salt string `json:"salt"`
+}
+
+type FluffyMigrate struct {
+	ContractAddr string `json:"contract_addr"`
+	// msg is the json-encoded MigrateMsg struct that will be passed to the new code
+	Msg string `json:"msg"`
+	// the code_id of the new logic to place in the given contract
+	NewCodeID int64 `json:"new_code_id"`
+}
+
+type FluffyUpdateAdmin struct {
+	Admin        string `json:"admin"`
+	ContractAddr string `json:"contract_addr"`
+}
+
+// This is the threshold that is applied to this proposal. Both the rules of the voting
+// contract, as well as the total_weight of the voting group may have changed since this
+// time. That means that the generic `Threshold{}` query does not provide valid information
+// for existing proposals.
+//
+// This defines the different ways tallies can happen. Every contract should support a
+// subset of these, ideally all.
+//
+// The total_weight used for calculating success as well as the weights of each individual
+// voter used in tallying should be snapshotted at the beginning of the block at which the
+// proposal starts (this is likely the responsibility of a correct cw4 implementation).
+//
+// Declares that a fixed weight of yes votes is needed to pass. It does not matter how many
+// no votes are cast, or how many do not vote, as long as `weight` yes votes are cast.
+//
+// This is the simplest format and usually suitable for small multisigs of trusted parties,
+// like 3 of 5. (weight: 3, total_weight: 5)
+//
+// A proposal of this type can pass early as soon as the needed weight of yes votes has been
+// cast.
+//
+// Declares a percentage of the total weight that must cast Yes votes, in order for a
+// proposal to pass. The passing weight is computed over the total weight minus the weight
+// of the abstained votes.
+//
+// This is useful for similar circumstances as `AbsoluteCount`, where we have a relatively
+// small set of voters, and participation is required. It is understood that if the voting
+// set (group) changes between different proposals that refer to the same group, each
+// proposal will work with a different set of voter weights (the ones snapshotted at
+// proposal creation), and the passing weight for each proposal will be computed based on
+// the absolute percentage, times the total weights of the members at the time of each
+// proposal creation.
+//
+// Example: we set `percentage` to 51%. Proposal 1 starts when there is a `total_weight` of
+// 5. This will require 3 weight of Yes votes in order to pass. Later, the Proposal 2 starts
+// but the `total_weight` of the group has increased to 9. That proposal will then
+// automatically require 5 Yes of 9 to pass, rather than 3 yes of 9 as would be the case
+// with `AbsoluteCount`.
+//
+// In addition to a `threshold`, declares a `quorum` of the total votes that must
+// participate in the election in order for the vote to be considered at all. Within the
+// votes that were cast, it requires `threshold` votes in favor. That is calculated by
+// ignoring the Abstain votes (they count towards `quorum`, but do not influence
+// `threshold`). That is, we calculate `Yes / (Yes + No + Veto)` and compare it with
+// `threshold` to consider if the proposal was passed.
+//
+// It is rather difficult for a proposal of this type to pass early. That can only happen if
+// the required quorum has been already met, and there are already enough Yes votes for the
+// proposal to pass.
+//
+// 30% Yes votes, 10% No votes, and 20% Abstain would pass early if quorum <= 60% (who has
+// cast votes) and if the threshold is <= 37.5% (the remaining 40% voting no => 30% yes +
+// 50% no). Once the voting period has passed with no additional votes, that same proposal
+// would be considered successful if quorum <= 60% and threshold <= 75% (percent in favor if
+// we ignore abstain votes).
+//
+// This type is more common in general elections, where participation is often expected to
+// be low, and `AbsolutePercentage` would either be too high to pass anything, or allow low
+// percentages to pass, independently of if there was high participation in the election or
+// not.
+type ProposalResponseForEmptyThresholdResponse struct {
+	AbsoluteCount      *FluffyAbsoluteCount      `json:"absolute_count,omitempty"`
+	AbsolutePercentage *FluffyAbsolutePercentage `json:"absolute_percentage,omitempty"`
+	ThresholdQuorum    *FluffyThresholdQuorum    `json:"threshold_quorum,omitempty"`
+}
+
+type FluffyAbsoluteCount struct {
+	TotalWeight int64 `json:"total_weight"`
+	Weight      int64 `json:"weight"`
+}
+
+type FluffyAbsolutePercentage struct {
+	Percentage  string `json:"percentage"`
+	TotalWeight int64  `json:"total_weight"`
+}
+
+type FluffyThresholdQuorum struct {
+	Quorum      string `json:"quorum"`
+	Threshold   string `json:"threshold"`
+	TotalWeight int64  `json:"total_weight"`
+}
+
+// This defines the different ways tallies can happen. Every contract should support a
+// subset of these, ideally all.
+//
+// The total_weight used for calculating success as well as the weights of each individual
+// voter used in tallying should be snapshotted at the beginning of the block at which the
+// proposal starts (this is likely the responsibility of a correct cw4 implementation).
+//
+// Declares that a fixed weight of yes votes is needed to pass. It does not matter how many
+// no votes are cast, or how many do not vote, as long as `weight` yes votes are cast.
+//
+// This is the simplest format and usually suitable for small multisigs of trusted parties,
+// like 3 of 5. (weight: 3, total_weight: 5)
+//
+// A proposal of this type can pass early as soon as the needed weight of yes votes has been
+// cast.
+//
+// Declares a percentage of the total weight that must cast Yes votes, in order for a
+// proposal to pass. The passing weight is computed over the total weight minus the weight
+// of the abstained votes.
+//
+// This is useful for similar circumstances as `AbsoluteCount`, where we have a relatively
+// small set of voters, and participation is required. It is understood that if the voting
+// set (group) changes between different proposals that refer to the same group, each
+// proposal will work with a different set of voter weights (the ones snapshotted at
+// proposal creation), and the passing weight for each proposal will be computed based on
+// the absolute percentage, times the total weights of the members at the time of each
+// proposal creation.
+//
+// Example: we set `percentage` to 51%. Proposal 1 starts when there is a `total_weight` of
+// 5. This will require 3 weight of Yes votes in order to pass. Later, the Proposal 2 starts
+// but the `total_weight` of the group has increased to 9. That proposal will then
+// automatically require 5 Yes of 9 to pass, rather than 3 yes of 9 as would be the case
+// with `AbsoluteCount`.
+//
+// In addition to a `threshold`, declares a `quorum` of the total votes that must
+// participate in the election in order for the vote to be considered at all. Within the
+// votes that were cast, it requires `threshold` votes in favor. That is calculated by
+// ignoring the Abstain votes (they count towards `quorum`, but do not influence
+// `threshold`). That is, we calculate `Yes / (Yes + No + Veto)` and compare it with
+// `threshold` to consider if the proposal was passed.
+//
+// It is rather difficult for a proposal of this type to pass early. That can only happen if
+// the required quorum has been already met, and there are already enough Yes votes for the
+// proposal to pass.
+//
+// 30% Yes votes, 10% No votes, and 20% Abstain would pass early if quorum <= 60% (who has
+// cast votes) and if the threshold is <= 37.5% (the remaining 40% voting no => 30% yes +
+// 50% no). Once the voting period has passed with no additional votes, that same proposal
+// would be considered successful if quorum <= 60% and threshold <= 75% (percent in favor if
+// we ignore abstain votes).
+//
+// This type is more common in general elections, where participation is often expected to
+// be low, and `AbsolutePercentage` would either be too high to pass anything, or allow low
+// percentages to pass, independently of if there was high participation in the election or
+// not.
+type ThresholdResponse struct {
+	AbsoluteCount      *TentacledAbsoluteCount      `json:"absolute_count,omitempty"`
+	AbsolutePercentage *TentacledAbsolutePercentage `json:"absolute_percentage,omitempty"`
+	ThresholdQuorum    *TentacledThresholdQuorum    `json:"threshold_quorum,omitempty"`
+}
+
+type TentacledAbsoluteCount struct {
+	TotalWeight int64 `json:"total_weight"`
+	Weight      int64 `json:"weight"`
+}
+
+type TentacledAbsolutePercentage struct {
+	Percentage  string `json:"percentage"`
+	TotalWeight int64  `json:"total_weight"`
+}
+
+type TentacledThresholdQuorum struct {
+	Quorum      string `json:"quorum"`
+	Threshold   string `json:"threshold"`
+	TotalWeight int64  `json:"total_weight"`
+}
+
+type VoteResponse struct {
+	Vote *VoteInfo `json:"vote"`
+}
+
+// Returns the vote (opinion as well as weight counted) as well as the address of the voter
+// who submitted it
+type VoteInfo struct {
+	ProposalID int64  `json:"proposal_id"`
+	Vote       Vote   `json:"vote"`
+	Voter      string `json:"voter"`
+	Weight     int64  `json:"weight"`
+}
+
+type VoterResponse struct {
+	Weight *int64 `json:"weight"`
+}
+
+// Marks support for the proposal.
+//
+// Marks opposition to the proposal.
+//
+// Marks participation but does not count towards the ratio of support / opposed
+//
+// Veto is generally to be treated as a No vote. Some implementations may allow certain
+// voters to be able to Veto, or them to be counted stronger than No in some way.
+type Vote string
+
+const (
+	Abstain Vote = "abstain"
+	No      Vote = "no"
+	Veto    Vote = "veto"
+	Yes     Vote = "yes"
+)
+
+// proposal was created, but voting has not yet begun for whatever reason
+//
+// you can vote on this
+//
+// voting is over and it did not pass
+//
+// voting is over and it did pass, but has not yet executed
+//
+// voting is over it passed, and the proposal was executed
+type Status string
+
+const (
+	Executed Status = "executed"
+	Open     Status = "open"
+	Passed   Status = "passed"
+	Pending  Status = "pending"
+	Rejected Status = "rejected"
+)

--- a/modules/cosmwasm-schema/guardrail/schema.go
+++ b/modules/cosmwasm-schema/guardrail/schema.go
@@ -62,13 +62,13 @@ type ExecuteMsg struct {
 }
 
 type Close struct {
-	SlashRequestID string `json:"slash_request_id"`
+	SlashingRequestID string `json:"slashing_request_id"`
 }
 
 type Propose struct {
-	Expiration     ProposeExpiration `json:"expiration"`
-	Reason         string            `json:"reason"`
-	SlashRequestID string            `json:"slash_request_id"`
+	Expiration        ProposeExpiration `json:"expiration"`
+	Reason            string            `json:"reason"`
+	SlashingRequestID string            `json:"slashing_request_id"`
 }
 
 // Expiration represents a point in time when some event happens. It can compare with a
@@ -102,8 +102,8 @@ type AddElement struct {
 }
 
 type ExecuteMsgVote struct {
-	SlashRequestID string `json:"slash_request_id"`
-	Vote           Vote   `json:"vote"`
+	SlashingRequestID string `json:"slashing_request_id"`
+	Vote              Vote   `json:"vote"`
 }
 
 type QueryMsg struct {
@@ -111,7 +111,6 @@ type QueryMsg struct {
 	Proposal                    *Proposal                    `json:"proposal,omitempty"`
 	ProposalBySlashingRequestID *ProposalBySlashingRequestID `json:"proposal_by_slashing_request_id,omitempty"`
 	ListProposals               *ListProposals               `json:"list_proposals,omitempty"`
-	ReverseProposals            *ReverseProposals            `json:"reverse_proposals,omitempty"`
 	Vote                        *QueryMsgVote                `json:"vote,omitempty"`
 	VoteBySlashingRequestID     *VoteBySlashingRequestID     `json:"vote_by_slashing_request_id,omitempty"`
 	ListVotes                   *ListVotes                   `json:"list_votes,omitempty"`
@@ -141,11 +140,6 @@ type Proposal struct {
 
 type ProposalBySlashingRequestID struct {
 	SlashingRequestID string `json:"slashing_request_id"`
-}
-
-type ReverseProposals struct {
-	Limit       *int64 `json:"limit"`
-	StartBefore *int64 `json:"start_before"`
 }
 
 type ThresholdClass struct {

--- a/modules/cosmwasm-schema/guardrail/schema.go
+++ b/modules/cosmwasm-schema/guardrail/schema.go
@@ -4,9 +4,10 @@
 package guardrail
 
 type InstantiateMsg struct {
-	Members   []MemberElement `json:"members"`
-	Owner     string          `json:"owner"`
-	Threshold Threshold       `json:"threshold"`
+	DefaultExpiration int64           `json:"default_expiration"`
+	Members           []MemberElement `json:"members"`
+	Owner             string          `json:"owner"`
+	Threshold         Threshold       `json:"threshold"`
 }
 
 // A group member has a weight associated with them. This may all be equal, or may have
@@ -66,27 +67,8 @@ type Close struct {
 }
 
 type Propose struct {
-	Expiration        ProposeExpiration `json:"expiration"`
-	Reason            string            `json:"reason"`
-	SlashingRequestID string            `json:"slashing_request_id"`
-}
-
-// Expiration represents a point in time when some event happens. It can compare with a
-// BlockInfo and will return is_expired() == true once the condition is hit (and for every
-// block in the future)
-//
-// AtHeight will expire when `env.block.height` >= height
-//
-// AtTime will expire when `env.block.time` >= time
-//
-// Never will never expire. Used to express the empty variant
-type ProposeExpiration struct {
-	AtHeight *int64       `json:"at_height,omitempty"`
-	AtTime   *string      `json:"at_time,omitempty"`
-	Never    *PurpleNever `json:"never,omitempty"`
-}
-
-type PurpleNever struct {
+	Reason            string `json:"reason"`
+	SlashingRequestID string `json:"slashing_request_id"`
 }
 
 type UpdateMembers struct {
@@ -211,10 +193,10 @@ type PurpleDenom struct {
 type ProposalExpiration struct {
 	AtHeight *int64       `json:"at_height,omitempty"`
 	AtTime   *string      `json:"at_time,omitempty"`
-	Never    *FluffyNever `json:"never,omitempty"`
+	Never    *PurpleNever `json:"never,omitempty"`
 }
 
-type FluffyNever struct {
+type PurpleNever struct {
 }
 
 // `CosmosMsg::Any` is the replaces the "stargate message" – a message wrapped in a
@@ -531,12 +513,12 @@ type FluffyDenom struct {
 //
 // Never will never expire. Used to express the empty variant
 type ProposalResponseForEmptyExpiration struct {
-	AtHeight *int64          `json:"at_height,omitempty"`
-	AtTime   *string         `json:"at_time,omitempty"`
-	Never    *TentacledNever `json:"never,omitempty"`
+	AtHeight *int64       `json:"at_height,omitempty"`
+	AtTime   *string      `json:"at_time,omitempty"`
+	Never    *FluffyNever `json:"never,omitempty"`
 }
 
-type TentacledNever struct {
+type FluffyNever struct {
 }
 
 // `CosmosMsg::Any` is the replaces the "stargate message" – a message wrapped in a

--- a/modules/cosmwasm-schema/package.json
+++ b/modules/cosmwasm-schema/package.json
@@ -5,6 +5,7 @@
     "build": "node generate.mjs && goimports -w */schema.go"
   },
   "devDependencies": {
+    "@satlayer/bvs-guardrail": "workspace:*",
     "@satlayer/bvs-pauser": "workspace:*",
     "@satlayer/bvs-registry": "workspace:*",
     "@satlayer/bvs-rewards": "workspace:*",

--- a/packages/cosmwasm-schema/generate.mjs
+++ b/packages/cosmwasm-schema/generate.mjs
@@ -42,6 +42,7 @@ async function generate(schema) {
 const packages = [
   "@satlayer/bvs-pauser",
   "@satlayer/bvs-registry",
+  "@satlayer/bvs-guardrail",
   "@satlayer/bvs-vault-router",
   "@satlayer/bvs-vault-cw20",
   "@satlayer/bvs-vault-cw20-tokenized",

--- a/packages/cosmwasm-schema/guardrail.d.ts
+++ b/packages/cosmwasm-schema/guardrail.d.ts
@@ -2,6 +2,7 @@
 // DO NOT MODIFY IT BY HAND.
 
 export interface InstantiateMsg {
+  default_expiration: number;
   members: MemberElement[];
   owner: string;
   threshold: Threshold;
@@ -70,29 +71,9 @@ export interface Close {
 }
 
 export interface Propose {
-  expiration: ProposeExpiration;
   reason: string;
   slashing_request_id: string;
 }
-
-/**
- * Expiration represents a point in time when some event happens. It can compare with a
- * BlockInfo and will return is_expired() == true once the condition is hit (and for every
- * block in the future)
- *
- * AtHeight will expire when `env.block.height` >= height
- *
- * AtTime will expire when `env.block.time` >= time
- *
- * Never will never expire. Used to express the empty variant
- */
-export interface ProposeExpiration {
-  at_height?: number;
-  at_time?: string;
-  never?: PurpleNever;
-}
-
-export interface PurpleNever {}
 
 export interface UpdateMembers {
   add: AddElement[];
@@ -251,10 +232,10 @@ export interface PurpleDenom {
 export interface ProposalExpiration {
   at_height?: number;
   at_time?: string;
-  never?: FluffyNever;
+  never?: PurpleNever;
 }
 
-export interface FluffyNever {}
+export interface PurpleNever {}
 
 /**
  * `CosmosMsg::Any` is the replaces the "stargate message" – a message wrapped in a
@@ -634,10 +615,10 @@ export interface FluffyDenom {
 export interface ProposalResponseForEmptyExpiration {
   at_height?: number;
   at_time?: string;
-  never?: TentacledNever;
+  never?: FluffyNever;
 }
 
-export interface TentacledNever {}
+export interface FluffyNever {}
 
 /**
  * `CosmosMsg::Any` is the replaces the "stargate message" – a message wrapped in a

--- a/packages/cosmwasm-schema/guardrail.d.ts
+++ b/packages/cosmwasm-schema/guardrail.d.ts
@@ -1,0 +1,1017 @@
+// This file was automatically generated from guardrail/schema.json.
+// DO NOT MODIFY IT BY HAND.
+
+export interface InstantiateMsg {
+  members: MemberElement[];
+  owner: string;
+  threshold: Threshold;
+}
+
+/**
+ * A group member has a weight associated with them. This may all be equal, or may have
+ * meaning in the app that makes use of the group (eg. voting power)
+ */
+export interface MemberElement {
+  addr: string;
+  weight: number;
+}
+
+/**
+ * This defines the different ways tallies can happen.
+ *
+ * The total_weight used for calculating success as well as the weights of each individual
+ * voter used in tallying should be snapshotted at the beginning of the block at which the
+ * proposal starts (this is likely the responsibility of a correct cw4 implementation). See
+ * also `ThresholdResponse` in the cw3 spec.
+ *
+ * Declares that a fixed weight of Yes votes is needed to pass. See
+ * `ThresholdResponse.AbsoluteCount` in the cw3 spec for details.
+ *
+ * Declares a percentage of the total weight that must cast Yes votes in order for a
+ * proposal to pass. See `ThresholdResponse.AbsolutePercentage` in the cw3 spec for
+ * details.
+ *
+ * Declares a `quorum` of the total votes that must participate in the election in order for
+ * the vote to be considered at all. See `ThresholdResponse.ThresholdQuorum` in the cw3 spec
+ * for details.
+ */
+export interface Threshold {
+  absolute_count?: ThresholdAbsoluteCount;
+  absolute_percentage?: ThresholdAbsolutePercentage;
+  threshold_quorum?: ThresholdThresholdQuorum;
+}
+
+export interface ThresholdAbsoluteCount {
+  weight: number;
+}
+
+export interface ThresholdAbsolutePercentage {
+  percentage: string;
+}
+
+export interface ThresholdThresholdQuorum {
+  quorum: string;
+  threshold: string;
+}
+
+/**
+ * apply a diff to the existing members. remove is applied after add, so if an address is in
+ * both, it is removed
+ */
+export interface ExecuteMsg {
+  propose?: Propose;
+  vote?: ExecuteMsgVote;
+  close?: Close;
+  update_members?: UpdateMembers;
+}
+
+export interface Close {
+  slash_request_id: string;
+}
+
+export interface Propose {
+  expiration: ProposeExpiration;
+  reason: string;
+  slash_request_id: string;
+}
+
+/**
+ * Expiration represents a point in time when some event happens. It can compare with a
+ * BlockInfo and will return is_expired() == true once the condition is hit (and for every
+ * block in the future)
+ *
+ * AtHeight will expire when `env.block.height` >= height
+ *
+ * AtTime will expire when `env.block.time` >= time
+ *
+ * Never will never expire. Used to express the empty variant
+ */
+export interface ProposeExpiration {
+  at_height?: number;
+  at_time?: string;
+  never?: PurpleNever;
+}
+
+export interface PurpleNever {}
+
+export interface UpdateMembers {
+  add: AddElement[];
+  remove: string[];
+}
+
+/**
+ * A group member has a weight associated with them. This may all be equal, or may have
+ * meaning in the app that makes use of the group (eg. voting power)
+ */
+export interface AddElement {
+  addr: string;
+  weight: number;
+}
+
+export interface ExecuteMsgVote {
+  slash_request_id: string;
+  vote: Vote;
+}
+
+/**
+ * Marks support for the proposal.
+ *
+ * Marks opposition to the proposal.
+ *
+ * Marks participation but does not count towards the ratio of support / opposed
+ *
+ * Veto is generally to be treated as a No vote. Some implementations may allow certain
+ * voters to be able to Veto, or them to be counted stronger than No in some way.
+ */
+export enum Vote {
+  Abstain = "abstain",
+  No = "no",
+  Veto = "veto",
+  Yes = "yes",
+}
+
+export interface QueryMsg {
+  threshold?: ThresholdClass;
+  proposal?: Proposal;
+  proposal_by_slashing_request_id?: ProposalBySlashingRequestID;
+  list_proposals?: ListProposals;
+  reverse_proposals?: ReverseProposals;
+  vote?: QueryMsgVote;
+  vote_by_slashing_request_id?: VoteBySlashingRequestID;
+  list_votes?: ListVotes;
+  voter?: Voter;
+  list_voters?: ListVoters;
+}
+
+export interface ListProposals {
+  limit?: number | null;
+  start_after?: number | null;
+}
+
+export interface ListVoters {
+  limit?: number | null;
+  start_after?: null | string;
+}
+
+export interface ListVotes {
+  limit?: number | null;
+  proposal_id: number;
+  start_after?: null | string;
+}
+
+export interface Proposal {
+  proposal_id: number;
+}
+
+export interface ProposalBySlashingRequestID {
+  slashing_request_id: string;
+}
+
+export interface ReverseProposals {
+  limit?: number | null;
+  start_before?: number | null;
+}
+
+export interface ThresholdClass {
+  height?: number | null;
+}
+
+export interface QueryMsgVote {
+  proposal_id: number;
+  voter: string;
+}
+
+export interface VoteBySlashingRequestID {
+  slashing_request_id: string;
+  voter: string;
+}
+
+export interface Voter {
+  address: string;
+  height?: number | null;
+}
+
+export interface ProposalListResponseForEmpty {
+  proposals: ProposalElement[];
+}
+
+/**
+ * Note, if you are storing custom messages in the proposal, the querier needs to know what
+ * possible custom message types those are in order to parse the response
+ */
+export interface ProposalElement {
+  deposit?: ProposalDepositInfo | null;
+  description: string;
+  expires: ProposalExpiration;
+  id: number;
+  msgs: ProposalCosmosMsgForEmpty[];
+  proposer: string;
+  status: Status;
+  /**
+   * This is the threshold that is applied to this proposal. Both the rules of the voting
+   * contract, as well as the total_weight of the voting group may have changed since this
+   * time. That means that the generic `Threshold{}` query does not provide valid information
+   * for existing proposals.
+   */
+  threshold: ProposalThresholdResponse;
+  title: string;
+}
+
+/**
+ * Information about the deposit required to create a proposal.
+ */
+export interface ProposalDepositInfo {
+  /**
+   * The number tokens required for payment.
+   */
+  amount: string;
+  /**
+   * The denom of the deposit payment.
+   */
+  denom: PurpleDenom;
+  /**
+   * Should failed proposals have their deposits refunded?
+   */
+  refund_failed_proposals: boolean;
+}
+
+/**
+ * The denom of the deposit payment.
+ */
+export interface PurpleDenom {
+  native?: string;
+  cw20?: string;
+}
+
+/**
+ * Expiration represents a point in time when some event happens. It can compare with a
+ * BlockInfo and will return is_expired() == true once the condition is hit (and for every
+ * block in the future)
+ *
+ * AtHeight will expire when `env.block.height` >= height
+ *
+ * AtTime will expire when `env.block.time` >= time
+ *
+ * Never will never expire. Used to express the empty variant
+ */
+export interface ProposalExpiration {
+  at_height?: number;
+  at_time?: string;
+  never?: FluffyNever;
+}
+
+export interface FluffyNever {}
+
+/**
+ * `CosmosMsg::Any` is the replaces the "stargate message" – a message wrapped in a
+ * [protobuf Any](https://protobuf.dev/programming-guides/proto3/#any) that is supported by
+ * the chain. It behaves the same as `CosmosMsg::Stargate` but has a better name and
+ * slightly improved syntax.
+ *
+ * This is feature-gated at compile time with `cosmwasm_2_0` because a chain running
+ * CosmWasm < 2.0 cannot process this.
+ */
+export interface ProposalCosmosMsgForEmpty {
+  bank?: PurpleBankMsg;
+  custom?: PurpleEmpty;
+  any?: PurpleAnyMsg;
+  wasm?: PurpleWASMMsg;
+}
+
+/**
+ * A message encoded the same way as a protobuf
+ * [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto).
+ * This is the same structure as messages in `TxBody` from
+ * [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)
+ */
+export interface PurpleAnyMsg {
+  type_url: string;
+  value: string;
+}
+
+/**
+ * The message types of the bank module.
+ *
+ * See https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto
+ *
+ * Sends native tokens from the contract to the given address.
+ *
+ * This is translated to a
+ * [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28).
+ * `from_address` is automatically filled with the current contract's address.
+ *
+ * This will burn the given coins from the contract's account. There is no Cosmos SDK
+ * message that performs this, but it can be done by calling the bank keeper. Important if a
+ * contract controls significant token supply that must be retired.
+ */
+export interface PurpleBankMsg {
+  send?: PurpleSend;
+  burn?: PurpleBurn;
+}
+
+export interface PurpleBurn {
+  amount: PurpleCoin[];
+}
+
+export interface PurpleCoin {
+  amount: string;
+  denom: string;
+}
+
+export interface PurpleSend {
+  amount: PurpleCoin[];
+  to_address: string;
+}
+
+/**
+ * An empty struct that serves as a placeholder in different places, such as contracts that
+ * don't set a custom message.
+ *
+ * It is designed to be expressible in correct JSON and JSON Schema but contains no
+ * meaningful data. Previously we used enums without cases, but those cannot represented as
+ * valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)
+ */
+export interface PurpleEmpty {}
+
+/**
+ * The message types of the wasm module.
+ *
+ * See https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto
+ *
+ * Dispatches a call to another contract at a known address (with known ABI).
+ *
+ * This is translated to a
+ * [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78).
+ * `sender` is automatically filled with the current contract's address.
+ *
+ * Instantiates a new contracts from previously uploaded Wasm code.
+ *
+ * The contract address is non-predictable. But it is guaranteed that when emitting the same
+ * Instantiate message multiple times, multiple instances on different addresses will be
+ * generated. See also Instantiate2.
+ *
+ * This is translated to a
+ * [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71).
+ * `sender` is automatically filled with the current contract's address.
+ *
+ * Instantiates a new contracts from previously uploaded Wasm code using a predictable
+ * address derivation algorithm implemented in [`cosmwasm_std::instantiate2_address`].
+ *
+ * This is translated to a
+ * [MsgInstantiateContract2](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L73-L96).
+ * `sender` is automatically filled with the current contract's address. `fix_msg` is
+ * automatically set to false.
+ *
+ * Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to
+ * customize behavior.
+ *
+ * Only the contract admin (as defined in wasmd), if any, is able to make this call.
+ *
+ * This is translated to a
+ * [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96).
+ * `sender` is automatically filled with the current contract's address.
+ *
+ * Sets a new admin (for migrate) on the given contract. Fails if this contract is not
+ * currently admin of the target contract.
+ *
+ * Clears the admin on the given contract, so no more migration possible. Fails if this
+ * contract is not currently admin of the target contract.
+ */
+export interface PurpleWASMMsg {
+  execute?: PurpleExecute;
+  instantiate?: PurpleInstantiate;
+  instantiate2?: PurpleInstantiate2;
+  migrate?: PurpleMigrate;
+  update_admin?: PurpleUpdateAdmin;
+  clear_admin?: PurpleClearAdmin;
+}
+
+export interface PurpleClearAdmin {
+  contract_addr: string;
+}
+
+export interface PurpleExecute {
+  contract_addr: string;
+  funds: PurpleCoin[];
+  /**
+   * msg is the json-encoded ExecuteMsg struct (as raw Binary)
+   */
+  msg: string;
+}
+
+export interface PurpleInstantiate {
+  admin?: null | string;
+  code_id: number;
+  funds: PurpleCoin[];
+  /**
+   * A human-readable label for the contract.
+   *
+   * Valid values should: - not be empty - not be bigger than 128 bytes (or some
+   * chain-specific limit) - not start / end with whitespace
+   */
+  label: string;
+  /**
+   * msg is the JSON-encoded InstantiateMsg struct (as raw Binary)
+   */
+  msg: string;
+}
+
+export interface PurpleInstantiate2 {
+  admin?: null | string;
+  code_id: number;
+  funds: PurpleCoin[];
+  /**
+   * A human-readable label for the contract.
+   *
+   * Valid values should: - not be empty - not be bigger than 128 bytes (or some
+   * chain-specific limit) - not start / end with whitespace
+   */
+  label: string;
+  /**
+   * msg is the JSON-encoded InstantiateMsg struct (as raw Binary)
+   */
+  msg: string;
+  salt: string;
+}
+
+export interface PurpleMigrate {
+  contract_addr: string;
+  /**
+   * msg is the json-encoded MigrateMsg struct that will be passed to the new code
+   */
+  msg: string;
+  /**
+   * the code_id of the new logic to place in the given contract
+   */
+  new_code_id: number;
+}
+
+export interface PurpleUpdateAdmin {
+  admin: string;
+  contract_addr: string;
+}
+
+/**
+ * proposal was created, but voting has not yet begun for whatever reason
+ *
+ * you can vote on this
+ *
+ * voting is over and it did not pass
+ *
+ * voting is over and it did pass, but has not yet executed
+ *
+ * voting is over it passed, and the proposal was executed
+ */
+export enum Status {
+  Executed = "executed",
+  Open = "open",
+  Passed = "passed",
+  Pending = "pending",
+  Rejected = "rejected",
+}
+
+/**
+ * This is the threshold that is applied to this proposal. Both the rules of the voting
+ * contract, as well as the total_weight of the voting group may have changed since this
+ * time. That means that the generic `Threshold{}` query does not provide valid information
+ * for existing proposals.
+ *
+ * This defines the different ways tallies can happen. Every contract should support a
+ * subset of these, ideally all.
+ *
+ * The total_weight used for calculating success as well as the weights of each individual
+ * voter used in tallying should be snapshotted at the beginning of the block at which the
+ * proposal starts (this is likely the responsibility of a correct cw4 implementation).
+ *
+ * Declares that a fixed weight of yes votes is needed to pass. It does not matter how many
+ * no votes are cast, or how many do not vote, as long as `weight` yes votes are cast.
+ *
+ * This is the simplest format and usually suitable for small multisigs of trusted parties,
+ * like 3 of 5. (weight: 3, total_weight: 5)
+ *
+ * A proposal of this type can pass early as soon as the needed weight of yes votes has been
+ * cast.
+ *
+ * Declares a percentage of the total weight that must cast Yes votes, in order for a
+ * proposal to pass. The passing weight is computed over the total weight minus the weight
+ * of the abstained votes.
+ *
+ * This is useful for similar circumstances as `AbsoluteCount`, where we have a relatively
+ * small set of voters, and participation is required. It is understood that if the voting
+ * set (group) changes between different proposals that refer to the same group, each
+ * proposal will work with a different set of voter weights (the ones snapshotted at
+ * proposal creation), and the passing weight for each proposal will be computed based on
+ * the absolute percentage, times the total weights of the members at the time of each
+ * proposal creation.
+ *
+ * Example: we set `percentage` to 51%. Proposal 1 starts when there is a `total_weight` of
+ * 5. This will require 3 weight of Yes votes in order to pass. Later, the Proposal 2 starts
+ * but the `total_weight` of the group has increased to 9. That proposal will then
+ * automatically require 5 Yes of 9 to pass, rather than 3 yes of 9 as would be the case
+ * with `AbsoluteCount`.
+ *
+ * In addition to a `threshold`, declares a `quorum` of the total votes that must
+ * participate in the election in order for the vote to be considered at all. Within the
+ * votes that were cast, it requires `threshold` votes in favor. That is calculated by
+ * ignoring the Abstain votes (they count towards `quorum`, but do not influence
+ * `threshold`). That is, we calculate `Yes / (Yes + No + Veto)` and compare it with
+ * `threshold` to consider if the proposal was passed.
+ *
+ * It is rather difficult for a proposal of this type to pass early. That can only happen if
+ * the required quorum has been already met, and there are already enough Yes votes for the
+ * proposal to pass.
+ *
+ * 30% Yes votes, 10% No votes, and 20% Abstain would pass early if quorum <= 60% (who has
+ * cast votes) and if the threshold is <= 37.5% (the remaining 40% voting no => 30% yes +
+ * 50% no). Once the voting period has passed with no additional votes, that same proposal
+ * would be considered successful if quorum <= 60% and threshold <= 75% (percent in favor if
+ * we ignore abstain votes).
+ *
+ * This type is more common in general elections, where participation is often expected to
+ * be low, and `AbsolutePercentage` would either be too high to pass anything, or allow low
+ * percentages to pass, independently of if there was high participation in the election or
+ * not.
+ */
+export interface ProposalThresholdResponse {
+  absolute_count?: PurpleAbsoluteCount;
+  absolute_percentage?: PurpleAbsolutePercentage;
+  threshold_quorum?: PurpleThresholdQuorum;
+}
+
+export interface PurpleAbsoluteCount {
+  total_weight: number;
+  weight: number;
+}
+
+export interface PurpleAbsolutePercentage {
+  percentage: string;
+  total_weight: number;
+}
+
+export interface PurpleThresholdQuorum {
+  quorum: string;
+  threshold: string;
+  total_weight: number;
+}
+
+export interface VoterListResponse {
+  voters: VoterDetail[];
+}
+
+export interface VoterDetail {
+  addr: string;
+  weight: number;
+}
+
+export interface VoteListResponse {
+  votes: VoteElement[];
+}
+
+/**
+ * Returns the vote (opinion as well as weight counted) as well as the address of the voter
+ * who submitted it
+ */
+export interface VoteElement {
+  proposal_id: number;
+  vote: Vote;
+  voter: string;
+  weight: number;
+}
+
+/**
+ * Note, if you are storing custom messages in the proposal, the querier needs to know what
+ * possible custom message types those are in order to parse the response
+ */
+export interface ProposalResponseForEmpty {
+  deposit?: ProposalResponseForEmptyDepositInfo | null;
+  description: string;
+  expires: ProposalResponseForEmptyExpiration;
+  id: number;
+  msgs: ProposalResponseForEmptyCosmosMsgForEmpty[];
+  proposer: string;
+  status: Status;
+  /**
+   * This is the threshold that is applied to this proposal. Both the rules of the voting
+   * contract, as well as the total_weight of the voting group may have changed since this
+   * time. That means that the generic `Threshold{}` query does not provide valid information
+   * for existing proposals.
+   */
+  threshold: ProposalResponseForEmptyThresholdResponse;
+  title: string;
+}
+
+/**
+ * Information about the deposit required to create a proposal.
+ */
+export interface ProposalResponseForEmptyDepositInfo {
+  /**
+   * The number tokens required for payment.
+   */
+  amount: string;
+  /**
+   * The denom of the deposit payment.
+   */
+  denom: FluffyDenom;
+  /**
+   * Should failed proposals have their deposits refunded?
+   */
+  refund_failed_proposals: boolean;
+}
+
+/**
+ * The denom of the deposit payment.
+ */
+export interface FluffyDenom {
+  native?: string;
+  cw20?: string;
+}
+
+/**
+ * Expiration represents a point in time when some event happens. It can compare with a
+ * BlockInfo and will return is_expired() == true once the condition is hit (and for every
+ * block in the future)
+ *
+ * AtHeight will expire when `env.block.height` >= height
+ *
+ * AtTime will expire when `env.block.time` >= time
+ *
+ * Never will never expire. Used to express the empty variant
+ */
+export interface ProposalResponseForEmptyExpiration {
+  at_height?: number;
+  at_time?: string;
+  never?: TentacledNever;
+}
+
+export interface TentacledNever {}
+
+/**
+ * `CosmosMsg::Any` is the replaces the "stargate message" – a message wrapped in a
+ * [protobuf Any](https://protobuf.dev/programming-guides/proto3/#any) that is supported by
+ * the chain. It behaves the same as `CosmosMsg::Stargate` but has a better name and
+ * slightly improved syntax.
+ *
+ * This is feature-gated at compile time with `cosmwasm_2_0` because a chain running
+ * CosmWasm < 2.0 cannot process this.
+ */
+export interface ProposalResponseForEmptyCosmosMsgForEmpty {
+  bank?: FluffyBankMsg;
+  custom?: FluffyEmpty;
+  any?: FluffyAnyMsg;
+  wasm?: FluffyWASMMsg;
+}
+
+/**
+ * A message encoded the same way as a protobuf
+ * [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto).
+ * This is the same structure as messages in `TxBody` from
+ * [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)
+ */
+export interface FluffyAnyMsg {
+  type_url: string;
+  value: string;
+}
+
+/**
+ * The message types of the bank module.
+ *
+ * See https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto
+ *
+ * Sends native tokens from the contract to the given address.
+ *
+ * This is translated to a
+ * [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28).
+ * `from_address` is automatically filled with the current contract's address.
+ *
+ * This will burn the given coins from the contract's account. There is no Cosmos SDK
+ * message that performs this, but it can be done by calling the bank keeper. Important if a
+ * contract controls significant token supply that must be retired.
+ */
+export interface FluffyBankMsg {
+  send?: FluffySend;
+  burn?: FluffyBurn;
+}
+
+export interface FluffyBurn {
+  amount: FluffyCoin[];
+}
+
+export interface FluffyCoin {
+  amount: string;
+  denom: string;
+}
+
+export interface FluffySend {
+  amount: FluffyCoin[];
+  to_address: string;
+}
+
+/**
+ * An empty struct that serves as a placeholder in different places, such as contracts that
+ * don't set a custom message.
+ *
+ * It is designed to be expressible in correct JSON and JSON Schema but contains no
+ * meaningful data. Previously we used enums without cases, but those cannot represented as
+ * valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)
+ */
+export interface FluffyEmpty {}
+
+/**
+ * The message types of the wasm module.
+ *
+ * See https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto
+ *
+ * Dispatches a call to another contract at a known address (with known ABI).
+ *
+ * This is translated to a
+ * [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78).
+ * `sender` is automatically filled with the current contract's address.
+ *
+ * Instantiates a new contracts from previously uploaded Wasm code.
+ *
+ * The contract address is non-predictable. But it is guaranteed that when emitting the same
+ * Instantiate message multiple times, multiple instances on different addresses will be
+ * generated. See also Instantiate2.
+ *
+ * This is translated to a
+ * [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71).
+ * `sender` is automatically filled with the current contract's address.
+ *
+ * Instantiates a new contracts from previously uploaded Wasm code using a predictable
+ * address derivation algorithm implemented in [`cosmwasm_std::instantiate2_address`].
+ *
+ * This is translated to a
+ * [MsgInstantiateContract2](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L73-L96).
+ * `sender` is automatically filled with the current contract's address. `fix_msg` is
+ * automatically set to false.
+ *
+ * Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to
+ * customize behavior.
+ *
+ * Only the contract admin (as defined in wasmd), if any, is able to make this call.
+ *
+ * This is translated to a
+ * [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96).
+ * `sender` is automatically filled with the current contract's address.
+ *
+ * Sets a new admin (for migrate) on the given contract. Fails if this contract is not
+ * currently admin of the target contract.
+ *
+ * Clears the admin on the given contract, so no more migration possible. Fails if this
+ * contract is not currently admin of the target contract.
+ */
+export interface FluffyWASMMsg {
+  execute?: FluffyExecute;
+  instantiate?: FluffyInstantiate;
+  instantiate2?: FluffyInstantiate2;
+  migrate?: FluffyMigrate;
+  update_admin?: FluffyUpdateAdmin;
+  clear_admin?: FluffyClearAdmin;
+}
+
+export interface FluffyClearAdmin {
+  contract_addr: string;
+}
+
+export interface FluffyExecute {
+  contract_addr: string;
+  funds: FluffyCoin[];
+  /**
+   * msg is the json-encoded ExecuteMsg struct (as raw Binary)
+   */
+  msg: string;
+}
+
+export interface FluffyInstantiate {
+  admin?: null | string;
+  code_id: number;
+  funds: FluffyCoin[];
+  /**
+   * A human-readable label for the contract.
+   *
+   * Valid values should: - not be empty - not be bigger than 128 bytes (or some
+   * chain-specific limit) - not start / end with whitespace
+   */
+  label: string;
+  /**
+   * msg is the JSON-encoded InstantiateMsg struct (as raw Binary)
+   */
+  msg: string;
+}
+
+export interface FluffyInstantiate2 {
+  admin?: null | string;
+  code_id: number;
+  funds: FluffyCoin[];
+  /**
+   * A human-readable label for the contract.
+   *
+   * Valid values should: - not be empty - not be bigger than 128 bytes (or some
+   * chain-specific limit) - not start / end with whitespace
+   */
+  label: string;
+  /**
+   * msg is the JSON-encoded InstantiateMsg struct (as raw Binary)
+   */
+  msg: string;
+  salt: string;
+}
+
+export interface FluffyMigrate {
+  contract_addr: string;
+  /**
+   * msg is the json-encoded MigrateMsg struct that will be passed to the new code
+   */
+  msg: string;
+  /**
+   * the code_id of the new logic to place in the given contract
+   */
+  new_code_id: number;
+}
+
+export interface FluffyUpdateAdmin {
+  admin: string;
+  contract_addr: string;
+}
+
+/**
+ * This is the threshold that is applied to this proposal. Both the rules of the voting
+ * contract, as well as the total_weight of the voting group may have changed since this
+ * time. That means that the generic `Threshold{}` query does not provide valid information
+ * for existing proposals.
+ *
+ * This defines the different ways tallies can happen. Every contract should support a
+ * subset of these, ideally all.
+ *
+ * The total_weight used for calculating success as well as the weights of each individual
+ * voter used in tallying should be snapshotted at the beginning of the block at which the
+ * proposal starts (this is likely the responsibility of a correct cw4 implementation).
+ *
+ * Declares that a fixed weight of yes votes is needed to pass. It does not matter how many
+ * no votes are cast, or how many do not vote, as long as `weight` yes votes are cast.
+ *
+ * This is the simplest format and usually suitable for small multisigs of trusted parties,
+ * like 3 of 5. (weight: 3, total_weight: 5)
+ *
+ * A proposal of this type can pass early as soon as the needed weight of yes votes has been
+ * cast.
+ *
+ * Declares a percentage of the total weight that must cast Yes votes, in order for a
+ * proposal to pass. The passing weight is computed over the total weight minus the weight
+ * of the abstained votes.
+ *
+ * This is useful for similar circumstances as `AbsoluteCount`, where we have a relatively
+ * small set of voters, and participation is required. It is understood that if the voting
+ * set (group) changes between different proposals that refer to the same group, each
+ * proposal will work with a different set of voter weights (the ones snapshotted at
+ * proposal creation), and the passing weight for each proposal will be computed based on
+ * the absolute percentage, times the total weights of the members at the time of each
+ * proposal creation.
+ *
+ * Example: we set `percentage` to 51%. Proposal 1 starts when there is a `total_weight` of
+ * 5. This will require 3 weight of Yes votes in order to pass. Later, the Proposal 2 starts
+ * but the `total_weight` of the group has increased to 9. That proposal will then
+ * automatically require 5 Yes of 9 to pass, rather than 3 yes of 9 as would be the case
+ * with `AbsoluteCount`.
+ *
+ * In addition to a `threshold`, declares a `quorum` of the total votes that must
+ * participate in the election in order for the vote to be considered at all. Within the
+ * votes that were cast, it requires `threshold` votes in favor. That is calculated by
+ * ignoring the Abstain votes (they count towards `quorum`, but do not influence
+ * `threshold`). That is, we calculate `Yes / (Yes + No + Veto)` and compare it with
+ * `threshold` to consider if the proposal was passed.
+ *
+ * It is rather difficult for a proposal of this type to pass early. That can only happen if
+ * the required quorum has been already met, and there are already enough Yes votes for the
+ * proposal to pass.
+ *
+ * 30% Yes votes, 10% No votes, and 20% Abstain would pass early if quorum <= 60% (who has
+ * cast votes) and if the threshold is <= 37.5% (the remaining 40% voting no => 30% yes +
+ * 50% no). Once the voting period has passed with no additional votes, that same proposal
+ * would be considered successful if quorum <= 60% and threshold <= 75% (percent in favor if
+ * we ignore abstain votes).
+ *
+ * This type is more common in general elections, where participation is often expected to
+ * be low, and `AbsolutePercentage` would either be too high to pass anything, or allow low
+ * percentages to pass, independently of if there was high participation in the election or
+ * not.
+ */
+export interface ProposalResponseForEmptyThresholdResponse {
+  absolute_count?: FluffyAbsoluteCount;
+  absolute_percentage?: FluffyAbsolutePercentage;
+  threshold_quorum?: FluffyThresholdQuorum;
+}
+
+export interface FluffyAbsoluteCount {
+  total_weight: number;
+  weight: number;
+}
+
+export interface FluffyAbsolutePercentage {
+  percentage: string;
+  total_weight: number;
+}
+
+export interface FluffyThresholdQuorum {
+  quorum: string;
+  threshold: string;
+  total_weight: number;
+}
+
+/**
+ * This defines the different ways tallies can happen. Every contract should support a
+ * subset of these, ideally all.
+ *
+ * The total_weight used for calculating success as well as the weights of each individual
+ * voter used in tallying should be snapshotted at the beginning of the block at which the
+ * proposal starts (this is likely the responsibility of a correct cw4 implementation).
+ *
+ * Declares that a fixed weight of yes votes is needed to pass. It does not matter how many
+ * no votes are cast, or how many do not vote, as long as `weight` yes votes are cast.
+ *
+ * This is the simplest format and usually suitable for small multisigs of trusted parties,
+ * like 3 of 5. (weight: 3, total_weight: 5)
+ *
+ * A proposal of this type can pass early as soon as the needed weight of yes votes has been
+ * cast.
+ *
+ * Declares a percentage of the total weight that must cast Yes votes, in order for a
+ * proposal to pass. The passing weight is computed over the total weight minus the weight
+ * of the abstained votes.
+ *
+ * This is useful for similar circumstances as `AbsoluteCount`, where we have a relatively
+ * small set of voters, and participation is required. It is understood that if the voting
+ * set (group) changes between different proposals that refer to the same group, each
+ * proposal will work with a different set of voter weights (the ones snapshotted at
+ * proposal creation), and the passing weight for each proposal will be computed based on
+ * the absolute percentage, times the total weights of the members at the time of each
+ * proposal creation.
+ *
+ * Example: we set `percentage` to 51%. Proposal 1 starts when there is a `total_weight` of
+ * 5. This will require 3 weight of Yes votes in order to pass. Later, the Proposal 2 starts
+ * but the `total_weight` of the group has increased to 9. That proposal will then
+ * automatically require 5 Yes of 9 to pass, rather than 3 yes of 9 as would be the case
+ * with `AbsoluteCount`.
+ *
+ * In addition to a `threshold`, declares a `quorum` of the total votes that must
+ * participate in the election in order for the vote to be considered at all. Within the
+ * votes that were cast, it requires `threshold` votes in favor. That is calculated by
+ * ignoring the Abstain votes (they count towards `quorum`, but do not influence
+ * `threshold`). That is, we calculate `Yes / (Yes + No + Veto)` and compare it with
+ * `threshold` to consider if the proposal was passed.
+ *
+ * It is rather difficult for a proposal of this type to pass early. That can only happen if
+ * the required quorum has been already met, and there are already enough Yes votes for the
+ * proposal to pass.
+ *
+ * 30% Yes votes, 10% No votes, and 20% Abstain would pass early if quorum <= 60% (who has
+ * cast votes) and if the threshold is <= 37.5% (the remaining 40% voting no => 30% yes +
+ * 50% no). Once the voting period has passed with no additional votes, that same proposal
+ * would be considered successful if quorum <= 60% and threshold <= 75% (percent in favor if
+ * we ignore abstain votes).
+ *
+ * This type is more common in general elections, where participation is often expected to
+ * be low, and `AbsolutePercentage` would either be too high to pass anything, or allow low
+ * percentages to pass, independently of if there was high participation in the election or
+ * not.
+ */
+export interface ThresholdResponse {
+  absolute_count?: TentacledAbsoluteCount;
+  absolute_percentage?: TentacledAbsolutePercentage;
+  threshold_quorum?: TentacledThresholdQuorum;
+}
+
+export interface TentacledAbsoluteCount {
+  total_weight: number;
+  weight: number;
+}
+
+export interface TentacledAbsolutePercentage {
+  percentage: string;
+  total_weight: number;
+}
+
+export interface TentacledThresholdQuorum {
+  quorum: string;
+  threshold: string;
+  total_weight: number;
+}
+
+export interface VoteResponse {
+  vote?: VoteInfo | null;
+}
+
+/**
+ * Returns the vote (opinion as well as weight counted) as well as the address of the voter
+ * who submitted it
+ */
+export interface VoteInfo {
+  proposal_id: number;
+  vote: Vote;
+  voter: string;
+  weight: number;
+}
+
+export interface VoterResponse {
+  weight?: number | null;
+}

--- a/packages/cosmwasm-schema/guardrail.d.ts
+++ b/packages/cosmwasm-schema/guardrail.d.ts
@@ -66,13 +66,13 @@ export interface ExecuteMsg {
 }
 
 export interface Close {
-  slash_request_id: string;
+  slashing_request_id: string;
 }
 
 export interface Propose {
   expiration: ProposeExpiration;
   reason: string;
-  slash_request_id: string;
+  slashing_request_id: string;
 }
 
 /**
@@ -109,7 +109,7 @@ export interface AddElement {
 }
 
 export interface ExecuteMsgVote {
-  slash_request_id: string;
+  slashing_request_id: string;
   vote: Vote;
 }
 
@@ -135,7 +135,6 @@ export interface QueryMsg {
   proposal?: Proposal;
   proposal_by_slashing_request_id?: ProposalBySlashingRequestID;
   list_proposals?: ListProposals;
-  reverse_proposals?: ReverseProposals;
   vote?: QueryMsgVote;
   vote_by_slashing_request_id?: VoteBySlashingRequestID;
   list_votes?: ListVotes;
@@ -165,11 +164,6 @@ export interface Proposal {
 
 export interface ProposalBySlashingRequestID {
   slashing_request_id: string;
-}
-
-export interface ReverseProposals {
-  limit?: number | null;
-  start_before?: number | null;
 }
 
 export interface ThresholdClass {

--- a/packages/cosmwasm-schema/package.json
+++ b/packages/cosmwasm-schema/package.json
@@ -12,6 +12,7 @@
     "build": "node generate.mjs && prettier --write *.d.ts"
   },
   "devDependencies": {
+    "@satlayer/bvs-guardrail": "workspace:*",
     "@satlayer/bvs-pauser": "workspace:*",
     "@satlayer/bvs-registry": "workspace:*",
     "@satlayer/bvs-rewards": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,8 @@ importers:
 
   crates: {}
 
+  crates/bvs-guardrail: {}
+
   crates/bvs-pauser: {}
 
   crates/bvs-registry: {}
@@ -162,6 +164,9 @@ importers:
 
   modules/cosmwasm-schema:
     devDependencies:
+      '@satlayer/bvs-guardrail':
+        specifier: workspace:*
+        version: link:../../crates/bvs-guardrail
       '@satlayer/bvs-pauser':
         specifier: workspace:*
         version: link:../../crates/bvs-pauser
@@ -242,6 +247,9 @@ importers:
 
   packages/cosmwasm-schema:
     devDependencies:
+      '@satlayer/bvs-guardrail':
+        specifier: workspace:*
+        version: link:../../crates/bvs-guardrail
       '@satlayer/bvs-pauser':
         specifier: workspace:*
         version: link:../../crates/bvs-pauser


### PR DESCRIPTION
#### What this PR does / why we need it:

Changes:

- [x] Adapt base [cw3](https://github.com/CosmWasm/cw-plus/blob/main/packages/cw3/README.md) implementation for bvs guardrail for voting logic
- [x] Adapt some [cw4](https://github.com/CosmWasm/cw-plus/blob/main/packages/cw4/README.md) members specs into bvs guardrail for member update
- [x] tests + integration tests
- [x] link up docs
- [x] configure build schema

notable changes:

- ~~in cw3, the `proposal_id` used is assigned on proposal creation and is an increasing number. However, for this contract the `proposal_id` has been updated to be the same as `slashing_id` instead which is 32 byte hex string.~~
- ~~Due to the changes above, `listProposal` query msg has to be modified because it cannot be paginated by the id but instead by specifying `skip` and `take` which may not be in the order of creation (may need to fix ??) . Also `reverseProposal` cannot be supported, thus removed.~~
- ~~Due to the changes to `proposal_id`, also note that there cannot be the same `slashing_id` used.~~
- the response emitted by the execute have been modified to put the attributes under a new event. This is to closely resemble all of our core contracts as well.
- `ExecuteMsg` only accepts `slashing_request_id` as identifier for the proposal.
- `QueryMsg` will support query from both `slashing_request_id` or `proposal_id`, while list query will only support `proposal_id` due to the linear nature of the ids.

<!-- remove if not applicable -->
Closes SL-465