### PR TITLE
chore(release): set cli release versions manually

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,8 @@ jobs:
             echo "npm_tag=main" >> $GITHUB_OUTPUT
           fi
 
-  npm_gh:
-    name: NPM [GitHub Packages]
+  npm:
+    name: NPM
     runs-on: ubuntu-latest
     environment:
       name: npmjs.com/org/satlayer
@@ -45,12 +45,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
 
+      - run: sed -i "s/version = \"0\.0\.0\"/version = \"${{ needs.version.outputs.crate }}\"/" crates/Cargo.toml
+      - run: pnpm --filter "@satlayer/*" exec npm version ${{ needs.version.outputs.npm }} --git-tag-version=false
+
       - run: pnpm turbo run build package --filter "@satlayer/*"
         env:
           DOCKER_CACHE_FROM: ghcr.io/satlayer/cosmwasm-optimizer-cache
-
-      - run: sed -i "s/version = \"0\.0\.0\"/version = \"${{ needs.version.outputs.crate }}\"/" crates/Cargo.toml
-      - run: pnpm --filter "@satlayer/*" exec npm version ${{ needs.version.outputs.npm }} --git-tag-version=false
 
       - run: pnpm config set "//registry.npmjs.org/:_authToken" "\${NPM_PACKAGES_TOKEN}" --location=global
 

--- a/packages/cli/package.js
+++ b/packages/cli/package.js
@@ -1,6 +1,7 @@
-import { cpSync, mkdirSync, writeFileSync } from "node:fs";
+import { cpSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
+const version = JSON.parse(readFileSync("package.json", "utf8")).version;
 const packages = ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64", "win32-arm64", "win32-x64"];
 
 for (const name of packages) {
@@ -10,6 +11,7 @@ for (const name of packages) {
   mkdirSync(dir);
   const packageJson = {
     name: `@satlayer/cli-${name}`,
+    version,
     private: false,
     files: ["satlayer"],
     os: [os],


### PR DESCRIPTION
#### What this PR does / why we need it:

For cli releases, reference the main package version and set it for all the sub packages.