### PR TITLE
chore(release): replace workspace:* versions

### DIFF
--- a/packages/cli/package.js
+++ b/packages/cli/package.js
@@ -38,7 +38,7 @@ const packageJson = {
     postinstall: "node postinstall.js",
   },
   optionalDependencies: packages.reduce((acc, name) => {
-    acc[`@satlayer/cli-${name}`] = `workspace:*`;
+    acc[`@satlayer/cli-${name}`] = version;
     return acc;
   }, {}),
 };


### PR DESCRIPTION
#### What this PR does / why we need it:

`workspace:*` should be set to actual versions.