### PR TITLE
feat: cancel resolved slashing request

### DIFF
--- a/crates/bvs-vault-router/src/contract.rs
+++ b/crates/bvs-vault-router/src/contract.rs
@@ -61,6 +61,9 @@ pub fn execute(
         }
         ExecuteMsg::RequestSlashing(payload) => execute::request_slashing(deps, env, info, payload),
         ExecuteMsg::LockSlashing(id) => execute::lock_slashing(deps, env, info, id),
+        ExecuteMsg::CancelSlashing(slashing_request_id) => {
+            execute::cancel_slashing(deps, env, info, slashing_request_id)
+        }
     }
 }
 
@@ -106,9 +109,10 @@ mod execute {
     use crate::contract::query::get_withdrawal_lock_period;
     use crate::error::ContractError;
     use crate::msg::{RequestSlashingPayload, RequestSlashingResponse};
-    use crate::state::SLASH_LOCKED;
-    use crate::state::{self, SlashingRequestStatus, DEFAULT_WITHDRAWAL_LOCK_PERIOD};
-    use crate::state::{SlashingRequest, WITHDRAWAL_LOCK_PERIOD};
+    use crate::state::{
+        self, SlashingRequest, SlashingRequestId, SlashingRequestStatus,
+        DEFAULT_WITHDRAWAL_LOCK_PERIOD, SLASHING_REQUESTS, SLASH_LOCKED, WITHDRAWAL_LOCK_PERIOD,
+    };
     use crate::ContractError::InvalidSlashingRequest;
     use bvs_library::addr::Operator;
     use bvs_library::ownership;
@@ -458,6 +462,57 @@ mod execute {
                     .add_attribute("affected_vaults", messages.len().to_string()),
             )
             .add_messages(messages))
+    }
+
+    /// Cancel a resolved slashing request that an operator has already resolved the issue.
+    pub fn cancel_slashing(
+        deps: DepsMut,
+        _env: Env,
+        info: MessageInfo,
+        slashing_request_id: SlashingRequestId,
+    ) -> Result<Response, ContractError> {
+        // service should be the sender
+        let service = info.sender;
+
+        let slashing_request = SLASHING_REQUESTS
+            .may_load(deps.storage, slashing_request_id.clone())?
+            .ok_or(ContractError::InvalidSlashingRequest {
+                msg: "No slashing request found by slashing request id".to_string(),
+            })?;
+
+        if slashing_request.service != service {
+            return Err(ContractError::InvalidSlashingRequest {
+                msg: "Invalid service sends a cancel slashing request".to_string(),
+            });
+        }
+
+        match slashing_request.status {
+            status
+                if status == SlashingRequestStatus::Finalized
+                    || status == SlashingRequestStatus::Locked =>
+            {
+                return Err(ContractError::InvalidSlashingRequest {
+                    msg: "Slashing resolution window has passed, cancellation is not allowed"
+                        .to_string(),
+                });
+            }
+            _ => {}
+        }
+
+        let operator = deps.api.addr_validate(&slashing_request.request.operator)?;
+        state::remove_slashing_request_id(deps.storage, &service, &operator);
+        state::update_slashing_request_status(
+            deps.storage,
+            slashing_request_id.clone(),
+            SlashingRequestStatus::Canceled,
+        )?;
+
+        Ok(Response::new().add_event(
+            Event::new("CancelSlashing")
+                .add_attribute("service", service)
+                .add_attribute("operator", operator)
+                .add_attribute("slashing_request_id", slashing_request_id.to_string()),
+        ))
     }
 }
 

--- a/crates/bvs-vault-router/src/contract.rs
+++ b/crates/bvs-vault-router/src/contract.rs
@@ -487,10 +487,7 @@ mod execute {
         }
 
         match slashing_request.status {
-            status
-                if status == SlashingRequestStatus::Finalized
-                    || status == SlashingRequestStatus::Locked =>
-            {
+            status if status != SlashingRequestStatus::Pending => {
                 return Err(ContractError::InvalidSlashingRequest {
                     msg: "Slashing resolution window has passed, cancellation is not allowed"
                         .to_string(),

--- a/crates/bvs-vault-router/src/contract.rs
+++ b/crates/bvs-vault-router/src/contract.rs
@@ -489,8 +489,7 @@ mod execute {
         match slashing_request.status {
             status if status != SlashingRequestStatus::Pending => {
                 return Err(ContractError::InvalidSlashingRequest {
-                    msg: "Slashing resolution window has passed, cancellation is not allowed"
-                        .to_string(),
+                    msg: "Canceled slashing request status should be pending".to_string(),
                 });
             }
             _ => {}

--- a/crates/bvs-vault-router/src/msg.rs
+++ b/crates/bvs-vault-router/src/msg.rs
@@ -50,6 +50,12 @@ pub enum ExecuteMsg {
     /// router which will later be finalized and handle according to the service slashing
     /// rules.
     LockSlashing(SlashingRequestId),
+
+    /// ExecuteMsg CancelSlashing cancels a resolved slashing request.
+    ///
+    /// The service (slash initiator) should cancel the slashing process if the operator
+    /// has resolved the issue. The definition of “resolved” is up to the service to define.
+    CancelSlashing(SlashingRequestId),
 }
 
 #[cw_serde]

--- a/crates/bvs-vault-router/src/state.rs
+++ b/crates/bvs-vault-router/src/state.rs
@@ -361,6 +361,7 @@ mod test {
         let slashing_request = SlashingRequest {
             request: data.clone(),
             request_time: env.block.time,
+            request_resolution: env.block.time.plus_seconds(50),
             request_expiry: env.block.time.plus_seconds(100),
             status: SlashingRequestStatus::Pending.into(),
             service: service.clone(),

--- a/modules/cosmwasm-schema/vault-router/schema.go
+++ b/modules/cosmwasm-schema/vault-router/schema.go
@@ -50,12 +50,17 @@ type InstantiateMsg struct {
 //
 // ExecuteMsg LockSlashing initiates the movement of slashed collateral from vaults to the
 // router which will later be finalized and handle according to the service slashing rules.
+// ExecuteMsg CancelSlashing cancels a resolved slashing request.
+//
+// The service (slash initiator) should cancel the slashing process if the operator has
+// resolved the issue. The definition of “resolved” is up to the service to define.
 type ExecuteMsg struct {
 	SetVault                *SetVault             `json:"set_vault,omitempty"`
 	SetWithdrawalLockPeriod *string               `json:"set_withdrawal_lock_period,omitempty"`
 	TransferOwnership       *TransferOwnership    `json:"transfer_ownership,omitempty"`
 	RequestSlashing         *RequestSlashingClass `json:"request_slashing,omitempty"`
 	LockSlashing            *string               `json:"lock_slashing,omitempty"`
+	CancelSlashing          *string               `json:"cancel_slashing,omitempty"`
 }
 
 type RequestSlashingClass struct {

--- a/modules/cosmwasm-schema/vault-router/schema.go
+++ b/modules/cosmwasm-schema/vault-router/schema.go
@@ -50,6 +50,7 @@ type InstantiateMsg struct {
 //
 // ExecuteMsg LockSlashing initiates the movement of slashed collateral from vaults to the
 // router which will later be finalized and handle according to the service slashing rules.
+//
 // ExecuteMsg CancelSlashing cancels a resolved slashing request.
 //
 // The service (slash initiator) should cancel the slashing process if the operator has

--- a/packages/cosmwasm-schema/vault-router.d.ts
+++ b/packages/cosmwasm-schema/vault-router.d.ts
@@ -140,6 +140,10 @@ export interface InstantiateMsg {
  *
  * ExecuteMsg LockSlashing initiates the movement of slashed collateral from vaults to the
  * router which will later be finalized and handle according to the service slashing rules.
+ * ExecuteMsg CancelSlashing cancels a resolved slashing request.
+ *
+ * The service (slash initiator) should cancel the slashing process if the operator has
+ * resolved the issue. The definition of “resolved” is up to the service to define.
  */
 export interface ExecuteMsg {
   set_vault?: SetVault;
@@ -147,6 +151,7 @@ export interface ExecuteMsg {
   transfer_ownership?: TransferOwnership;
   request_slashing?: RequestSlashingClass;
   lock_slashing?: string;
+  cancel_slashing?: string;
 }
 
 export interface RequestSlashingClass {

--- a/packages/cosmwasm-schema/vault-router.d.ts
+++ b/packages/cosmwasm-schema/vault-router.d.ts
@@ -140,6 +140,7 @@ export interface InstantiateMsg {
  *
  * ExecuteMsg LockSlashing initiates the movement of slashed collateral from vaults to the
  * router which will later be finalized and handle according to the service slashing rules.
+ *
  * ExecuteMsg CancelSlashing cancels a resolved slashing request.
  *
  * The service (slash initiator) should cancel the slashing process if the operator has


### PR DESCRIPTION
#### What this PR does / why we need it:

Cancel slashing request for operators that have resolved the issues. About `CancelSlashing`, can refer [doc](https://build.satlayer.xyz/getting-started/slashing#cancel-slashing-resolved).

<!-- remove if not applicable -->
Closes SL-474