### PR TITLE
feat: utility methods for testcontainers

### DIFF
--- a/packages/testcontainers/src/container.ts
+++ b/packages/testcontainers/src/container.ts
@@ -2,8 +2,8 @@ import { join } from "node:path";
 
 import { SigningCosmWasmClient } from "@cosmjs/cosmwasm-stargate";
 import { Slip10RawIndex } from "@cosmjs/crypto";
-import { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
-import { GasPrice } from "@cosmjs/stargate";
+import { DirectSecp256k1HdWallet, parseCoins } from "@cosmjs/proto-signing";
+import { DeliverTxResponse, GasPrice } from "@cosmjs/stargate";
 import { AbstractStartedContainer, GenericContainer, StartedTestContainer, Wait } from "testcontainers";
 
 export class CosmWasmContainer extends GenericContainer {
@@ -53,5 +53,10 @@ export class StartedCosmWasmContainer extends AbstractStartedContainer {
     const host = this.startedTestContainer.getHost();
     const port = this.startedTestContainer.getMappedPort(26657);
     return `tcp://${host}:${port}/`;
+  }
+
+  async fund(address: string, coins: string): Promise<DeliverTxResponse> {
+    const [account] = await this.wallet.getAccounts();
+    return this.client.sendTokens(account.address, address, parseCoins(coins), "auto");
   }
 }

--- a/packages/testcontainers/src/satlayer.test.ts
+++ b/packages/testcontainers/src/satlayer.test.ts
@@ -17,12 +17,12 @@ afterEach(async () => {
 });
 
 test("should bootstrap contracts", async () => {
-  const client = contracts.client;
   const queryMsg: RouterQueryMsg = {
     list_vaults: {},
   };
 
-  const vaults = await client.queryContractSmart(contracts.state.router.address, queryMsg);
+  const client = contracts.client;
+  const vaults = await client.queryContractSmart(contracts.data.router.address, queryMsg);
   expect(vaults).toEqual([]);
 }, 30_000);
 
@@ -45,12 +45,11 @@ test("should bootstrap contracts and deploy vaults", async () => {
   });
   const vault3 = await contracts.initVaultCw20(operator.address, cw20_address);
 
-  const client = contracts.client;
   const queryMsg: RouterQueryMsg = {
     list_vaults: {},
   };
 
-  const vaults = await client.queryContractSmart(contracts.state.router.address, queryMsg);
+  const vaults = await contracts.router.query(queryMsg);
   expect(vaults).toEqual(
     expect.arrayContaining([
       {


### PR DESCRIPTION
#### What this PR does / why we need it:

- `fund` address with coins
- `contracts.router.execute` and `.query` for ease for dev testing
- `contracts.registry.execute` and `.query` for ease for dev testing