### PR TITLE
feat: store service in slash request + impl partialEq

### DIFF
--- a/crates/bvs-vault-router/src/contract.rs
+++ b/crates/bvs-vault-router/src/contract.rs
@@ -310,6 +310,7 @@ mod execute {
             request_time: env.block.time,
             request_expiry: new_request_expiry,
             status: SlashingRequestStatus::Pending.into(),
+            service: service.clone(),
         };
 
         // save slash data
@@ -1192,6 +1193,7 @@ mod tests {
         let env = mock_env();
 
         let operator = deps.api.addr_make("operator");
+        let service = deps.api.addr_make("service");
         let request_id = SlashingRequestId(
             HexBinary::from_hex("dff7a6f403eff632636533660ab53ab35e7ae0fe2e5dacb160aa7d876a412f09")
                 .unwrap(),
@@ -1208,6 +1210,7 @@ mod tests {
             request_time: env.block.time,
             request_expiry: env.block.time.plus_seconds(100),
             status: SlashingRequestStatus::Pending.into(),
+            service,
         };
 
         // query request_id before its saved => None

--- a/crates/bvs-vault-router/tests/integration_test.rs
+++ b/crates/bvs-vault-router/tests/integration_test.rs
@@ -411,7 +411,7 @@ fn request_slashing_successful() {
                 .add_attribute("operator", operator.to_string())
                 .add_attribute(
                     "slashing_request_id",
-                    "256599b4308c914c2a1a0c0300ac82b68e932edc0be46339b54293e804add30e"
+                    "e99316f1087d1365c4e1c4a2d82de63c4029cd51cd7b6a1bccd42bfbad9d310d"
                 )
                 .add_attribute("reason", "test"),
         ]
@@ -435,7 +435,7 @@ fn request_slashing_successful() {
     assert_eq!(
         res,
         Some(
-            HexBinary::from_hex("256599b4308c914c2a1a0c0300ac82b68e932edc0be46339b54293e804add30e")
+            HexBinary::from_hex("e99316f1087d1365c4e1c4a2d82de63c4029cd51cd7b6a1bccd42bfbad9d310d")
                 .unwrap()
                 .into()
         )
@@ -451,7 +451,7 @@ fn request_slashing_successful() {
     assert_eq!(
         slashing_request_id,
         SlashingRequestIdResponse(Some(
-            HexBinary::from_hex("256599b4308c914c2a1a0c0300ac82b68e932edc0be46339b54293e804add30e")
+            HexBinary::from_hex("e99316f1087d1365c4e1c4a2d82de63c4029cd51cd7b6a1bccd42bfbad9d310d")
                 .unwrap()
                 .into()
         ))
@@ -467,6 +467,7 @@ fn request_slashing_successful() {
             request_time: app.block_info().time,
             request_expiry: app.block_info().time.plus_seconds(200),
             status: SlashingRequestStatus::Pending.into(),
+            service,
         }
     );
 }
@@ -862,7 +863,7 @@ fn request_slashing_lifecycle() {
                     .add_attribute("operator", operator.to_string())
                     .add_attribute(
                         "slashing_request_id",
-                        "99a3e8248790f5ac720fc24837887f507ef7cabf7880f654e7fc345bc60e5d4e"
+                        "9e2a9d4382cc5e9f3aaf99215def962ce58595ed93107a3ea052ce75b6a2249c"
                     )
                     .add_attribute("reason", "test2"),
             ]

--- a/modules/cosmwasm-schema/vault-router/schema.go
+++ b/modules/cosmwasm-schema/vault-router/schema.go
@@ -147,6 +147,8 @@ type SlashingRequest struct {
 	RequestExpiry string `json:"request_expiry"`
 	// The timestamp when the request was submitted.
 	RequestTime string `json:"request_time"`
+	// The service that initiated the slashing request.
+	Service string `json:"service"`
 	// The status of the slashing request.
 	Status int64 `json:"status"`
 }

--- a/packages/cosmwasm-schema/vault-router.d.ts
+++ b/packages/cosmwasm-schema/vault-router.d.ts
@@ -77,6 +77,8 @@ type IsWhitelistedResponse = boolean;
  *
  * The timestamp when the request was submitted.
  *
+ * The service that initiated the slashing request.
+ *
  * The response to the `WithdrawalLockPeriod` query. Not exported. This is just a wrapper
  * around `Uint64`, so that the schema can be generated.
  */
@@ -241,6 +243,10 @@ export interface SlashingRequestResponse {
    * The timestamp when the request was submitted.
    */
   request_time: string;
+  /**
+   * The service that initiated the slashing request.
+   */
+  service: string;
   /**
    * The status of the slashing request.
    */


### PR DESCRIPTION
#### What this PR does / why we need it:

- Store `Service` that initiated the slashing request in `SlashingRequest` struct.
- Changed the hashing fn to not require extra "service" address as it is now part of the struct.
- Impl `partialEq` for `SlashingRequestStatus` and `u8` so that they can be compared without explicit conversion