### PR TITLE
chore: return guardrail in testcontainers contracts

### DIFF
--- a/packages/testcontainers/src/container.ts
+++ b/packages/testcontainers/src/container.ts
@@ -1,8 +1,8 @@
 import { join } from "node:path";
 
 import { SigningCosmWasmClient } from "@cosmjs/cosmwasm-stargate";
-import { Slip10RawIndex } from "@cosmjs/crypto";
-import { DirectSecp256k1HdWallet, OfflineSigner, parseCoins } from "@cosmjs/proto-signing";
+import { Bip39, sha256, Slip10RawIndex } from "@cosmjs/crypto";
+import { AccountData, DirectSecp256k1HdWallet, OfflineSigner, parseCoins } from "@cosmjs/proto-signing";
 import { DeliverTxResponse, GasPrice } from "@cosmjs/stargate";
 import { AbstractStartedContainer, GenericContainer, StartedTestContainer, Wait } from "testcontainers";
 
@@ -98,5 +98,18 @@ export class StartedCosmWasmContainer extends AbstractStartedContainer {
       gasPrice: GasPrice.fromString("0.002000ustake"),
       broadcastPollIntervalMs: 200,
     });
+  }
+
+  /**
+   * Generates a new account from the given seed.
+   */
+  async generateAccount(seed: string): Promise<AccountData> {
+    const seedEntropy = sha256(new TextEncoder().encode(seed));
+    const mnemonic = Bip39.encode(seedEntropy);
+    const wallet = await DirectSecp256k1HdWallet.fromMnemonic(mnemonic.toString(), {
+      prefix: "wasm",
+    });
+    const accounts = await wallet.getAccounts();
+    return accounts[0];
   }
 }

--- a/packages/testcontainers/src/satlayer.ts
+++ b/packages/testcontainers/src/satlayer.ts
@@ -11,6 +11,7 @@ type Data = {
   cw20: { codeId: number };
   pauser: { codeId: number; address: string };
   registry: { codeId: number; address: string };
+  guardrail: { codeId: number; address: string };
   router: { codeId: number; address: string };
   vaultCw20: { codeId: number };
   vaultBank: { codeId: number };
@@ -22,6 +23,7 @@ export class SatLayerContracts {
     public readonly data: Data,
     public readonly pauser = new Pauser(started, data.pauser.address),
     public readonly registry = new Registry(started, data.registry.address),
+    public readonly guardrail = new Router(started, data.guardrail.address),
     public readonly router = new Router(started, data.router.address),
   ) {}
 
@@ -98,6 +100,7 @@ export class SatLayerContracts {
       cw20: { codeId: cw20Upload.codeId },
       pauser: { address: pauserResult.contractAddress, codeId: pauserUpload.codeId },
       registry: { address: registryResult.contractAddress, codeId: registryUpload.codeId },
+      guardrail: { address: guardrailResult.contractAddress, codeId: guardrailUpload.codeId },
       router: { address: routerResult.contractAddress, codeId: routerUpload.codeId },
       vaultBank: { codeId: vaultBankUpload.codeId },
       vaultCw20: { codeId: vaultCw20Upload.codeId },


### PR DESCRIPTION
#### What this PR does / why we need it:

return `guardrail` contracts in testcontainers, needed for examples
added `generateAccount` to generate new valid address for a given seed