### PR TITLE
chore: use commonjs for package.js

### DIFF
--- a/packages/cli/package.js
+++ b/packages/cli/package.js
@@ -1,5 +1,5 @@
-import { cpSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+const { cpSync } = require("node:fs");
+const { join } = require("node:path");
 
 const packages = ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64", "win32-arm64", "win32-x64"];
 


### PR DESCRIPTION
#### What this PR does / why we need it:

- Node 20.18.2 will throw an error.
- Node 20.19.0 will show a warning, then run as ESM.

Let's just use CommonJS.
