### PR TITLE
feat: service operator registry

### DIFF
--- a/contracts/src/SLAYRegistry.sol
+++ b/contracts/src/SLAYRegistry.sol
@@ -21,7 +21,7 @@ contract SLAYRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pau
      * This mean both service and operator has to register to pair with each other
      * See [`RegistrationStatus`] enum for more information
      */
-    mapping(bytes32 service_operator_hash => Checkpoints.Trace224) private registration_status;
+    mapping(bytes32 serviceOperatorHash => Checkpoints.Trace224) private registrationStatus;
 
     enum RegistrationStatus {
         /**
@@ -203,21 +203,21 @@ contract SLAYRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pau
     }
 
     /**
-     * @dev Hash the service and operator addresses to create a unique key for the registration_status map.
+     * @dev Hash the service and operator addresses to create a unique key for the `registrationStatus` map.
      */
     function _getKey(address service, address operator) public pure returns (bytes32) {
         return keccak256(abi.encodePacked(service, operator));
     }
 
     /**
-     * @dev Get the registration_status for a given service-operator pair at the latest checkpoint.
+     * @dev Get the `registrationStatus` for a given service-operator pair at the latest checkpoint.
      * @param key The hash of the service and operator addresses. See `_getKey()`.
      * Returns the latest registration status as an enum value.
      */
     function getLatestRegistrationStatus(bytes32 key) public view returns (RegistrationStatus) {
         // checkpoint.latest() returns 0 on null cases, that nicely fit into
         // RegistrationStatus.Inactive being 0
-        return RegistrationStatus(uint8(registration_status[key].latest()));
+        return RegistrationStatus(uint8(registrationStatus[key].latest()));
     }
 
     /**
@@ -227,7 +227,7 @@ contract SLAYRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pau
      * Returns the registration status as an enum value.
      */
     function getRegistrationStatusAt(bytes32 key, uint32 timestamp) public view returns (RegistrationStatus) {
-        return RegistrationStatus(uint8(registration_status[key].upperLookup(timestamp)));
+        return RegistrationStatus(uint8(registrationStatus[key].upperLookup(timestamp)));
     }
 
     /**
@@ -237,7 +237,7 @@ contract SLAYRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pau
      * @param status The new registration status to set.
      */
     function setRegistrationStatus(bytes32 key, RegistrationStatus status) internal {
-        registration_status[key].push(uint32(block.timestamp), uint224(uint8(status)));
+        registrationStatus[key].push(uint32(block.timestamp), uint224(uint8(status)));
     }
 
     /**

--- a/contracts/src/SLAYRegistry.sol
+++ b/contracts/src/SLAYRegistry.sol
@@ -74,7 +74,7 @@ contract SLAYRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pau
 
     /**
      * @notice this modifier limit the sender to be registered service
-     * @param operator in addtional to sender be registered service
+     * @param operator in addition to sender be registered service
      * this param also require operator to be registered
      */
     modifier onlyServiceOperator(address operator) {
@@ -85,7 +85,7 @@ contract SLAYRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pau
 
     /**
      * @notice this modifier limit the sender to be registered operator
-     * @param service in additional to sender be registered operator
+     * @param service in addition to sender be registered operator
      * this param also require operator to be registered
      */
     modifier onlyOperatorService(address service) {

--- a/contracts/src/SLAYRegistry.sol
+++ b/contracts/src/SLAYRegistry.sol
@@ -85,7 +85,7 @@ contract SLAYRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pau
 
     /**
      * @notice this modifier limit the sender to be registered operator
-     * @param service in addtional to sender be registered operator
+     * @param service in additional to sender be registered operator
      * this param also require operator to be registered
      */
     modifier onlyOperatorService(address service) {

--- a/contracts/src/SLAYRegistry.sol
+++ b/contracts/src/SLAYRegistry.sol
@@ -10,6 +10,30 @@ import {SLAYRouter} from "./SLAYRouter.sol";
 
 contract SLAYRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
     SLAYRouter public immutable router;
+    mapping(address => bool) public services;
+    mapping(address => bool) public operators;
+    mapping(byte32 => bool) public registration_status;
+
+    enum RegistrationStatus {
+        /// Default state when neither the Operator nor the Service has registered,
+        /// or when either the Operator or Service has unregistered
+        Inactive,
+        /// State when both the Operator and Service have registered with each other,
+        /// indicating a fully established relationship
+        Active,
+        /// State when only the Operator has registered but the Service hasn't yet registered,
+        /// indicating a pending registration from the Service side
+        /// This is Operator-initiated registration, waiting for Service to finalize
+        OperatorRegistered,
+        /// State when only the Service has registered but the Operator hasn't yet registered,
+        /// indicating a pending registration from the Operator side
+        /// This is Service-initiated registration, waiting for Operator to finalize
+        ServiceRegistered
+    }
+
+    event ServiceRegistered(address indexed service, string uri, string name);
+    event OperatorRegistered(address indexed operator, string uri, string name);
+    event RegistrationStatusUpdated(address indexed service, address indexed operator, RegistrationStatus status);
 
     /**
      * @dev Set the immutable SLAYRouter proxy address for the implementation.
@@ -28,4 +52,107 @@ contract SLAYRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pau
     }
 
     function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
+
+    function registerAsService(string uri, string name) public {
+        require(!services[msg.sender], "Service has been registered");
+        services[msg.sender] = true;
+        emit ServiceRegistered(msg.sender, uri, name);
+    }
+
+    function registerAsOperator(string uri, string name) public {
+        require(!operators[msg.sender], "Operator has been registerd");
+        operators[msg.sender] = true;
+        emit OperatorRegistered(msg.sender, uri, name);
+    }
+
+    function registerOperatorToService(address operator) public {
+        address service = msg.sender;
+        require(operators[operator], "Operator not found");
+        require(services[service], "Service not found");
+
+        byte32 key = _getKey(service, operator);
+        RegistrationStatus status = registration_status[key];
+
+        if (status == RegistrationStatus.Active) {
+            revert("Registration is already active");
+        } else if (status == RegistrationStatus.ServiceRegistered) {
+            revert("Service has already registered this operator");
+        } else if (status == RegistrationStatus.Inactive) {
+            registration_status[key] = RegistrationStatus.ServiceRegistered;
+
+            emit RegistrationStatusUpdated(operator, service, RegistrationStatus.ServiceRegistered);
+        } else if (status == RegistrationStatus.OperatorRegistered) {
+            registration_status[key] = RegistrationStatus.Active;
+
+            emit RegistrationStatusUpdated(operator, service, RegistrationStatus.Active);
+        } else {
+            revert("Invalid registration state");
+        }
+    }
+
+    function deregisterOperatorFromService(address operator) public {
+        address service = msg.sender;
+
+        require(services[service], "Service not registered");
+
+        bytes32 key = _getKey(operator, service);
+        RegistrationStatus status = registration_status[key];
+
+        if (status == RegistrationStatus.Inactive) {
+            revert("Operator is not registered with this service");
+        }
+
+        registration_status[key] = RegistrationStatus.Inactive;
+
+        emit RegistrationStatusUpdated(service, operator, RegistrationStatus.Inactive);
+    }
+
+    function registerServiceToOperator(address service) public {
+        address operator = msg.sender;
+        require(services[service], "Service not registered");
+        require(operators[operator], "Operator not registered");
+
+        bytes32 key = _getKey(operator, service);
+        RegistrationStatus status = registration_status[key];
+
+        if (status == RegistrationStatus.Active) {
+            revert("Registration between operator and service is already active");
+        } else if (status == RegistrationStatus.OperatorRegistered) {
+            revert("Operator has already registered this service");
+        } else if (status == RegistrationStatus.Inactive) {
+            registration_status[key] = RegistrationStatus.OperatorRegistered;
+
+            emit RegistrationStatusUpdated(service, operator, RegistrationStatus.OperatorRegistered);
+        } else if (status == RegistrationStatus.ServiceRegistered) {
+            registration_status[key] = RegistrationStatus.Active;
+
+            emit RegistrationStatusUpdated(service, operator, RegistrationStatus.Active);
+        } else {
+            // treat default (None) same as Inactive?
+            registration_status[key] = RegistrationStatus.OperatorRegistered;
+
+            emit RegistrationStatusUpdated(service, operator, RegistrationStatus.OperatorRegistered);
+        }
+    }
+
+    function deregisterServiceFromOperator(address service) public {
+        address operator = msg.sender;
+        require(operators[operator], "Operator not registered");
+        require(service[service], "Service not registered to operator");
+
+        byte32 key = _getKey(service, operator);
+        RegistrationStatus status = registration_status[key];
+
+        if (status == RegistrationStatus.Inactive) {
+            revert("Service is not registered to this operator");
+        }
+
+        registration_status[key] = RegistrationStatus.Inactive;
+
+        emit RegistrationStatusUpdated(service, operator, RegistrationStatus.Inactive);
+    }
+
+    function _getKey(address service, address operator) internal pure returns (byte32) {
+        return keccak256(abi.encodePacked(service, operator));
+    }
 }

--- a/contracts/src/SLAYRegistry.sol
+++ b/contracts/src/SLAYRegistry.sol
@@ -16,25 +16,36 @@ contract SLAYRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pau
 
     using Checkpoints for Checkpoints.Trace224;
 
-    // Service <-> Operator registration is a two sided consensus
-    // This mean both service and operator has to register to pair with each other
-    // See [`RegistrationStatus`] enum for more information
+    /**
+     * @dev Service <-> Operator registration is a two sided consensus
+     * This mean both service and operator has to register to pair with each other
+     * See [`RegistrationStatus`] enum for more information
+     */
     mapping(bytes32 service_operator_hash => Checkpoints.Trace224) private registration_status;
 
     enum RegistrationStatus {
-        // Default state when neither the Operator nor the Service has registered,
-        // or when either the Operator or Service has unregistered
+        /**
+         * Default state when neither the Operator nor the Service has registered,
+         * or when either the Operator or Service has unregistered
+         */
         Inactive,
-        // State when both the Operator and Service have registered with each other,
-        // indicating a fully established relationship
+        /**
+         * State when both the Operator and Service have registered with each other,
+         * indicating a fully established relationship
+         */
         Active,
-        // State when only the Operator has registered but the Service hasn't yet registered,
-        // indicating a pending registration from the Service side
-        // This is Operator-initiated registration, waiting for Service to finalize
+        /**
+         * State when only the Operator has registered but the Service hasn't yet registered,
+         * indicating a pending registration from the Service side
+         * This is Operator-initiated registration, waiting for Service to finalize
+         */
         OperatorRegistered,
-        // State when only the Service has registered but the Operator hasn't yet registered,
-        // indicating a pending registration from the Operator side
-        // This is Service-initiated registration, waiting for Operator to finalize
+        /**
+         *
+         * This state is used when the Service has registered an Operator, but the Operator hasn't yet registered,
+         * indicating a pending registration from the Operator side
+         * This is Service-initiated registration, waiting for Operator to finalize
+         */
         ServiceRegistered
     }
 
@@ -62,22 +73,32 @@ contract SLAYRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pau
 
     function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
 
+    /**
+     * @dev Register as a service
+     * This function allows an address to be registered as a service.
+     */
     function registerAsService(string memory uri, string memory name) public {
         require(!services[msg.sender], "Service has been registered");
         services[msg.sender] = true;
         emit ServiceRegistered(msg.sender, uri, name);
     }
 
+    /**
+     * @dev Register as a service
+     * This function allows an address to be registered as an operator.
+     */
     function registerAsOperator(string memory uri, string memory name) public {
         require(!operators[msg.sender], "Operator has been registerd");
         operators[msg.sender] = true;
         emit OperatorRegistered(msg.sender, uri, name);
     }
 
-    // Register an operator to a service (info.sender is the service)
-    // Service must be registered via [`RegisterAsService()`].
-    // If the operator has registered this service, the registration status will be set to [`RegistrationStatus.Active`] (1)
-    // Else the registration status will be set to [`RegistrationStatus.ServiceRegistered`] (3)
+    /**
+     * @dev Register an operator to a service (info.sender is the service)
+     * Service must be registered via [`RegisterAsService()`].
+     * If the operator has registered this service, the registration status will be set to [`RegistrationStatus.Active`] (1)
+     * Else the registration status will be set to [`RegistrationStatus.ServiceRegistered`] (3)
+     */
     function registerOperatorToService(address operator) public {
         address service = msg.sender;
         require(operators[operator], "Operator not found");
@@ -104,6 +125,12 @@ contract SLAYRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pau
         }
     }
 
+    /**
+     * @dev Deregister an operator from a service (info.sender is the service)
+     * Service must be registered via [`RegisterAsService()`].
+     * If the operator is not registered with this service, it will revert.
+     * If the operator is registered with this service, it will set the registration status to [`RegistrationStatus.Inactive`] (0)
+     */
     function deregisterOperatorFromService(address operator) public {
         address service = msg.sender;
 
@@ -121,10 +148,12 @@ contract SLAYRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pau
         emit RegistrationStatusUpdated(service, operator, RegistrationStatus.Inactive);
     }
 
-    // Register a service to an operator (info.sender is the operator)
-    // Operator must be registered with [`RegisterAsOperator()`]
-    // If the service has registered this operator, the registration status will be set to [`RegistrationStatus::Active`] (1)
-    // Else the registration status will be set to [`RegistrationStatus.OperatorRegistered`] (2)
+    /**
+     * @dev Register a service to an operator (info.sender is the operator)
+     * Operator must be registered with [`RegisterAsOperator()`]
+     * If the service has registered this operator, the registration status will be set to [`RegistrationStatus::Active`] (1)
+     * Else the registration status will be set to [`RegistrationStatus.OperatorRegistered`] (2)
+     */
     function registerServiceToOperator(address service) public {
         address operator = msg.sender;
         require(services[service], "Service not registered");
@@ -150,6 +179,12 @@ contract SLAYRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pau
         }
     }
 
+    /**
+     * @dev Deregister a service from an operator (info.sender is the operator)
+     * Operator must be registered with [`RegisterAsOperator()`]
+     * If the service is not registered to the operator, it will revert.
+     * If the service is registered to the operator, it will set the registration status to [`RegistrationStatus.Inactive`] (0)
+     */
     function deregisterServiceFromOperator(address service) public {
         address operator = msg.sender;
         require(operators[operator], "Operator not registered");
@@ -167,30 +202,59 @@ contract SLAYRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pau
         emit RegistrationStatusUpdated(service, operator, RegistrationStatus.Inactive);
     }
 
+    /**
+     * @dev Hash the service and operator addresses to create a unique key for the registration_status map.
+     */
     function _getKey(address service, address operator) public pure returns (bytes32) {
         return keccak256(abi.encodePacked(service, operator));
     }
 
+    /**
+     * @dev Get the registration_status for a given service-operator pair at the latest checkpoint.
+     * @param key The hash of the service and operator addresses. See `_getKey()`.
+     * Returns the latest registration status as an enum value.
+     */
     function getLatestRegistrationStatus(bytes32 key) public view returns (RegistrationStatus) {
         // checkpoint.latest() returns 0 on null cases, that nicely fit into
         // RegistrationStatus.Inactive being 0
         return RegistrationStatus(uint8(registration_status[key].latest()));
     }
 
+    /**
+     * @dev Get the registration status for a service-operator pair at a specific timestamp.
+     * @param key The hash of the service and operator addresses. See `_getKey()`.
+     * @param timestamp The timestamp to check the registration status at.
+     * Returns the registration status as an enum value.
+     */
     function getRegistrationStatusAt(bytes32 key, uint32 timestamp) public view returns (RegistrationStatus) {
         return RegistrationStatus(uint8(registration_status[key].upperLookup(timestamp)));
     }
 
-    /// @notice Set the status for a service-operator pair at current block time
+    /**
+     * @dev Set the registration status for a service-operator pair.
+     * This function is used internally to update the registration status.
+     * @param key The hash of the service and operator addresses. See `_getKey()`.
+     * @param status The new registration status to set.
+     */
     function setRegistrationStatus(bytes32 key, RegistrationStatus status) internal {
         registration_status[key].push(uint32(block.timestamp), uint224(uint8(status)));
     }
 
-    function is_operator(address operator) public view returns (bool) {
+    /**
+     * @dev Check if an address is registered as an operator.
+     * @param operator The address to check.
+     * @return True if the address is registered as an operator, false otherwise.
+     */
+    function isOperator(address operator) public view returns (bool) {
         return operators[operator];
     }
 
-    function is_service(address service) public view returns (bool) {
+    /**
+     * @dev Check if an address is registered as a service.
+     * @param service The address to check.
+     * @return True if the address is registered as a service, false otherwise.
+     */
+    function isService(address service) public view returns (bool) {
         return services[service];
     }
 }

--- a/contracts/src/SLAYRegistry.sol
+++ b/contracts/src/SLAYRegistry.sol
@@ -73,8 +73,8 @@ contract SLAYRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pau
     function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
 
     /**
-     * @notice this modifier limit the sender to be registered service
-     * @param operator in addition to sender be registered service
+     * @notice this modifier limit the sender to be a registered service
+     * @param operator In addition to sender be registered service
      * this param also require operator to be registered
      */
     modifier onlyServiceOperator(address operator) {
@@ -84,8 +84,8 @@ contract SLAYRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pau
     }
 
     /**
-     * @notice this modifier limit the sender to be registered operator
-     * @param service in addition to sender be registered operator
+     * @notice this modifier limit the sender to be a registered operator
+     * @param service In addition to sender be registered operator
      * this param also require operator to be registered
      */
     modifier onlyOperatorService(address service) {

--- a/contracts/test/SLAYRegistry.t.sol
+++ b/contracts/test/SLAYRegistry.t.sol
@@ -2,11 +2,305 @@
 pragma solidity ^0.8.0;
 
 import {Test, console} from "forge-std/Test.sol";
-import {TestSuite} from "./TestSuite.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
-contract SLAYRegistryTest is Test, TestSuite {
-    function test() public view {
-        assertEq(registry.owner(), owner);
-        assertEq(registry.paused(), false);
+import {SLAYRegistry} from "../src/SLAYRegistry.sol";
+import {SLAYRouter} from "../src/SLAYRouter.sol";
+import {EmptyImpl} from "../src/EmptyImpl.sol";
+
+contract SLAYRegistryTest is Test {
+    // --- State Variables ---
+
+    SLAYRegistry public registry;
+    SLAYRouter public router;
+
+    address public owner;
+    address public service;
+    address public operator;
+    address public anotherUser;
+
+    // --- Setup ---
+
+    /**
+     * @dev Sets up the test environment.
+     * This setup handles the deployment of UUPS upgradeable proxies with cyclic dependencies
+     * between SLAYRegistry and SLAYRouter.
+     * 1. Deploy an EmptyImpl contract to serve as the initial implementation for proxies.
+     * 2. Deploy ERC1967Proxy for both Registry and Router, pointing to EmptyImpl.
+     * 3. Initialize the EmptyImpl proxies, setting the owner.
+     * 4. Deploy the actual SLAYRegistry and SLAYRouter logic contracts, providing the
+     * respective proxy addresses to their constructors to resolve the cyclic dependency.
+     * 5. Upgrade the proxies from EmptyImpl to the actual logic contracts.
+     * 6. Initialize the final Registry and Router contracts through their proxies.
+     */
+    function setUp() public {
+        // --- Initialize addresses ---
+        owner = makeAddr("owner");
+        service = makeAddr("service");
+        operator = makeAddr("operator");
+        anotherUser = makeAddr("anotherUser");
+
+        vm.prank(owner);
+
+        // Deploy Empty Implementation ---
+        EmptyImpl emptyImpl = new EmptyImpl();
+
+        // Deploy and Initialize Proxies with EmptyImpl ---
+        bytes memory emptyImplInitData = abi.encodeWithSelector(EmptyImpl.initialize.selector, owner);
+
+        ERC1967Proxy registryProxy = new ERC1967Proxy(address(emptyImpl), emptyImplInitData);
+        registry = SLAYRegistry(address(registryProxy));
+
+        ERC1967Proxy routerProxy = new ERC1967Proxy(address(emptyImpl), emptyImplInitData);
+        router = SLAYRouter(address(routerProxy));
+
+        // Deploy Logic Contracts with cyclic dependency ---
+        SLAYRouter routerLogic = new SLAYRouter(registry);
+        SLAYRegistry registryLogic = new SLAYRegistry(router);
+
+        // Upgrade Proxies to Logic Contracts ---
+        vm.prank(owner);
+        registry.upgradeToAndCall(address(registryLogic), "");
+        vm.prank(owner);
+        router.upgradeToAndCall(address(routerLogic), "");
+
+        // Initialize Logic Contracts ---
+        vm.prank(owner);
+        registry.initialize();
+        vm.prank(owner);
+        router.initialize();
+    }
+
+    // --- Test Registration Functions ---
+
+    function test_RegisterAsService() public {
+        vm.prank(service);
+        vm.expectEmit(true, true, true, true);
+        emit SLAYRegistry.ServiceRegistered(service, "service_uri", "Service A");
+        registry.registerAsService("service_uri", "Service A");
+        assertTrue(registry.services(service), "Service should be registered");
+    }
+
+    function test_Fail_RegisterAsService_AlreadyRegistered() public {
+        vm.prank(service);
+        registry.registerAsService("service_uri", "Service A");
+
+        vm.prank(service);
+        vm.expectRevert("Service has been registered");
+        registry.registerAsService("service_uri_2", "Service A2");
+    }
+
+    function test_RegisterAsOperator() public {
+        vm.prank(operator);
+        vm.expectEmit(true, true, true, true);
+        emit SLAYRegistry.OperatorRegistered(operator, "operator_uri", "Operator X");
+        registry.registerAsOperator("operator_uri", "Operator X");
+        assertTrue(registry.operators(operator), "Operator should be registered");
+    }
+
+    function test_Fail_RegisterAsOperator_AlreadyRegistered() public {
+        vm.prank(operator);
+        registry.registerAsOperator("operator_uri", "Operator X");
+
+        vm.prank(operator);
+        vm.expectRevert("Operator has been registerd");
+        registry.registerAsOperator("operator_uri_2", "Operator X2");
+    }
+
+    // --- Test Registration Flow ---
+
+    function _registerServiceAndOperator() internal {
+        vm.prank(service);
+        registry.registerAsService("service_uri", "Service A");
+        vm.prank(operator);
+        registry.registerAsOperator("operator_uri", "Operator X");
+    }
+
+    /**
+     * Tests the full registration flow initiated by the service.
+     * 1. Service registers the operator (status -> ServiceRegistered).
+     * 2. Operator registers the service (status -> Active).
+     */
+    function test_FullFlow_ServiceInitiatesRegistration() public {
+        _registerServiceAndOperator();
+        bytes32 key = registry._getKey(service, operator);
+
+        // --- Step 1: Service registers operator ---
+        vm.prank(service);
+        registry.registerOperatorToService(operator);
+
+        assertEq(
+            uint256(registry.getLatestRegistrationStatus(key)),
+            uint256(SLAYRegistry.RegistrationStatus.ServiceRegistered),
+            "Status should be ServiceRegistered"
+        );
+
+        // --- Step 2: Operator accept and register to the service ---
+        vm.prank(operator);
+        registry.registerServiceToOperator(service);
+        assertEq(
+            uint256(registry.getLatestRegistrationStatus(key)),
+            uint256(SLAYRegistry.RegistrationStatus.Active),
+            "Status should be Active"
+        );
+    }
+
+    /**
+     * Tests the full registration flow initiated by the operator.
+     * 1. Operator registers the service (status -> OperatorRegistered).
+     * 2. Service registers the operator (status -> Active).
+     */
+    function test_FullFlow_OperatorInitiatesRegistration() public {
+        _registerServiceAndOperator();
+        bytes32 key = registry._getKey(service, operator);
+
+        // --- Step 1: Operator registers service ---
+        vm.prank(operator);
+        vm.expectEmit(true, true, true, true);
+        emit SLAYRegistry.RegistrationStatusUpdated(
+            service, operator, SLAYRegistry.RegistrationStatus.OperatorRegistered
+        );
+        registry.registerServiceToOperator(service);
+
+        assertEq(
+            uint256(registry.getLatestRegistrationStatus(key)),
+            uint256(SLAYRegistry.RegistrationStatus.OperatorRegistered),
+            "Status should be OperatorRegistered"
+        );
+
+        // -- Step 2: Service accept and register operator
+        vm.prank(service);
+        registry.registerOperatorToService(operator);
+
+        assertEq(
+            uint256(registry.getLatestRegistrationStatus(key)),
+            uint256(SLAYRegistry.RegistrationStatus.Active),
+            "Status should be Active"
+        );
+    }
+
+    // --- Test Deregistration Functions ---
+
+    function test_DeregisterOperatorFromService() public {
+        // First, complete registration
+        test_FullFlow_ServiceInitiatesRegistration();
+        bytes32 key = registry._getKey(service, operator);
+
+        // Now, deregister
+        vm.prank(service);
+        registry.deregisterOperatorFromService(operator);
+
+        assertEq(
+            uint256(registry.getLatestRegistrationStatus(key)),
+            uint256(SLAYRegistry.RegistrationStatus.Inactive),
+            "Status should be Inactive after deregistration"
+        );
+    }
+
+    function test_DeregisterServiceFromOperator() public {
+        // First, complete registration
+        test_FullFlow_OperatorInitiatesRegistration();
+        bytes32 key = registry._getKey(service, operator);
+
+        // Now, deregister
+        vm.prank(operator);
+        vm.expectEmit(true, true, true, true);
+        emit SLAYRegistry.RegistrationStatusUpdated(service, operator, SLAYRegistry.RegistrationStatus.Inactive);
+        registry.deregisterServiceFromOperator(service);
+
+        assertEq(
+            uint256(registry.getLatestRegistrationStatus(key)),
+            uint256(SLAYRegistry.RegistrationStatus.Inactive),
+            "Status should be Inactive after deregistration"
+        );
+    }
+
+    // --- Test Checkpoints and Status Lookups ---
+
+    function test_GetRegistrationStatusAt() public {
+        _registerServiceAndOperator();
+        vm.roll(block.number + 1);
+        bytes32 key = registry._getKey(service, operator);
+
+        // Initial state is Inactive
+        uint256 blockBeforeRegister = block.number;
+        assertEq(
+            uint256(registry.getRegistrationStatusAt(key, blockBeforeRegister)),
+            uint256(SLAYRegistry.RegistrationStatus.Inactive),
+            "Status should be Inactive because no prior history"
+        );
+
+        // Service initiates registration
+        vm.prank(service);
+        registry.registerOperatorToService(operator);
+        uint256 blockAfterServiceRegister = block.number;
+        assertEq(
+            uint256(registry.getRegistrationStatusAt(key, blockAfterServiceRegister)),
+            uint256(SLAYRegistry.RegistrationStatus.ServiceRegistered),
+            "Status should be ServiceRegistered"
+        );
+
+        vm.roll(blockBeforeRegister + 100);
+
+        assertEq(block.number, blockBeforeRegister + 100, "Blocks should be advanced by 100");
+
+        // Check previous block status
+        assertEq(
+            uint256(registry.getRegistrationStatusAt(key, blockBeforeRegister - 1)),
+            uint256(SLAYRegistry.RegistrationStatus.Inactive),
+            "Status should be Inactive"
+        );
+
+        // Operator completes registration
+        vm.prank(operator);
+        registry.registerServiceToOperator(service);
+        uint256 blockAfterActive = block.number;
+        assertEq(
+            uint256(registry.getRegistrationStatusAt(key, blockAfterActive)),
+            uint256(SLAYRegistry.RegistrationStatus.Active),
+            "Status should be Active"
+        );
+        // Check previous block status
+        assertEq(
+            uint256(registry.getRegistrationStatusAt(key, blockAfterServiceRegister)),
+            uint256(SLAYRegistry.RegistrationStatus.ServiceRegistered),
+            "Status should be ServiceRegistered"
+        );
+    }
+
+    // --- Test Revert Conditions ---
+
+    function test_Fail_RegisterOperatorToService_UnregisteredOperator() public {
+        vm.prank(service);
+        registry.registerAsService("service_uri", "Service A");
+
+        vm.prank(service);
+        vm.expectRevert("Operator not found");
+        registry.registerOperatorToService(operator);
+    }
+
+    function test_Fail_RegisterServiceToOperator_UnregisteredService() public {
+        vm.prank(operator);
+        registry.registerAsOperator("operator_uri", "Operator X");
+
+        vm.prank(operator);
+        vm.expectRevert("Service not registered");
+        registry.registerServiceToOperator(service);
+    }
+
+    function test_Fail_RegisterOperatorToService_AlreadyActive() public {
+        test_FullFlow_ServiceInitiatesRegistration();
+
+        vm.prank(service);
+        vm.expectRevert("Registration is already active");
+        registry.registerOperatorToService(operator);
+    }
+
+    function test_Fail_RegisterServiceToOperator_AlreadyActive() public {
+        test_FullFlow_ServiceInitiatesRegistration();
+
+        vm.prank(operator);
+        vm.expectRevert("Registration between operator and service is already active");
+        registry.registerServiceToOperator(service);
     }
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR replicate `bvs-registry` contract's service operator lifecycle. Added foundry tests. 

#### Nuance
In cosmowasm `Snapshot` state type allow tracking of historical state mutation at given key or typically it's block related chrono deterministic key. Openzepplin has `Checkpoints` lib that practically serve the same purpose. The caveat is that the key is of uint32. This mean using block timestamp is grantee to overflow (wrap around) at some point in the future (which is about in 83 years). Realistically, by then we'll probably have alternative that can handles large timestamps.

#### Progress

- [x] implementation
- [x] testing
- [x] In-line documentations


<!-- remove if not applicable -->
Closes SL-536
