### PR TITLE
feat: SLAYRouter whitelist and pausable implementation

### DIFF
--- a/contracts/src/SLAYRouter.sol
+++ b/contracts/src/SLAYRouter.sol
@@ -11,6 +11,13 @@ import {SLAYRegistry} from "./SLAYRegistry.sol";
 contract SLAYRouter is Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
     SLAYRegistry public immutable registry;
 
+    mapping(address => bool) public whitelisted;
+
+    /**
+     * @dev Emitted when the pause is triggered by `account`.
+     */
+    event Whitelisted(address indexed vault, bool whitelisted);
+
     /**
      * @dev Set the immutable SLAYRegistry proxy address for the implementation.
      * Cyclic params in constructor are possible as an EmptyImpl is used for an initial deployment,
@@ -28,4 +35,28 @@ contract SLAYRouter is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausa
     }
 
     function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
+
+    /**
+     * @dev Pauses the contract, all SLAYVaults will also be paused.
+     */
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    /**
+     * @dev Unpauses the contract, all SLAYVaults will also be unpaused.
+     */
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
+    /**
+     * Set a individual whitelist status for a vault.
+     * This allows CA owner to control which vaults can be interacted with through the router.
+     * For non-granular state/modifier, use {SLAYRouter-pause} to pause all vaults.
+     */
+    function setWhitelist(address vault_, bool whitelisted_) external onlyOwner {
+        whitelisted[vault_] = whitelisted_;
+        emit Whitelisted(vault_, whitelisted_);
+    }
 }

--- a/contracts/src/SLAYRouter.sol
+++ b/contracts/src/SLAYRouter.sol
@@ -54,6 +54,9 @@ contract SLAYRouter is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausa
      * Set a individual whitelist status for a vault.
      * This allows CA owner to control which vaults can be interacted with through the router.
      * For non-granular state/modifier, use {SLAYRouter-pause} to pause all vaults.
+     *
+     * @param vault_ address of the vault to set the whitelist status for.
+     * This should be a SLAYVault contract address but isn't "checked" to allow for flexible un-whitelisting of vaults.
      */
     function setWhitelist(address vault_, bool whitelisted_) external onlyOwner {
         whitelisted[vault_] = whitelisted_;

--- a/contracts/src/SLAYVault.sol
+++ b/contracts/src/SLAYVault.sol
@@ -9,17 +9,41 @@ import {ERC20PermitUpgradeable} from
     "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20PermitUpgradeable.sol";
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 
 import {SLAYRegistry} from "./SLAYRegistry.sol";
 import {SLAYRouter} from "./SLAYRouter.sol";
 
 /**
+ * @dev Interface for the SLAYVault contract.
+ */
+interface ISLAYVault is IERC20Metadata, IERC4626 {}
+
+/**
  * Implementation contract for SLAYVault.
  * This contract is not initialized directly, but through the SLAYVaultFactory using the Beacon proxy pattern.
  */
-contract SLAYVault is Initializable, ERC20Upgradeable, ERC4626Upgradeable, ERC165Upgradeable, ERC20PermitUpgradeable {
+contract SLAYVault is
+    Initializable,
+    ERC20Upgradeable,
+    ERC4626Upgradeable,
+    ERC165Upgradeable,
+    ERC20PermitUpgradeable,
+    ISLAYVault
+{
     SLAYRouter public immutable router;
     SLAYRegistry public immutable registry;
+
+    /**
+     * @dev The operation failed because the contract is paused.
+     */
+    error EnforcedPause();
+
+    /**
+     * @dev The operation failed because the contract is not whitelisted.
+     */
+    error ExpectedWhitelisted();
 
     /**
      * @custom:oz-upgrades-unsafe-allow constructor
@@ -36,7 +60,57 @@ contract SLAYVault is Initializable, ERC20Upgradeable, ERC4626Upgradeable, ERC16
         __ERC20Permit_init(name_);
     }
 
-    function decimals() public view override(ERC20Upgradeable, ERC4626Upgradeable) returns (uint8) {
+    function decimals() public view override(ERC20Upgradeable, ERC4626Upgradeable, IERC20Metadata) returns (uint8) {
         return ERC4626Upgradeable.decimals();
+    }
+
+    /**
+     * @dev See {ERC20-_update} with additional requirements for the SLAYRouter.
+     *
+     * To _update the balances of the SLAYVault (and therefore mint/deposit/withdraw/redeem),
+     * the following conditions must be met:
+     *
+     * - the contract must not be paused in the SLAYRouter.
+     * - the contract must be whitelisted in the SLAYRouter.
+     */
+    function _update(address from, address to, uint256 value) internal virtual override whenNotPaused whenWhitelisted {
+        super._update(from, to, value);
+    }
+
+    /**
+     * @dev Modifier to make a function callable only when the SLAYRouter is not paused.
+     * SLAYVault doesn't enforce its own pause state, but relies on the SLAYRouter to manage the pause state.
+     * If the SLAYRouter is paused, all operations marked with this modifier will revert with `EnforcedPause`.
+     */
+    modifier whenNotPaused() {
+        _requireNotPaused();
+        _;
+    }
+
+    /**
+     * @dev Modifier to make a function callable only when the SLAYVault is whitelisted in the SLAYRouter.
+     * If the SLAYVault is not whitelisted, all operations marked with this modifier will revert with `ExpectedWhitelisted`.
+     */
+    modifier whenWhitelisted() {
+        _requireWhitelisted();
+        _;
+    }
+
+    /**
+     * @dev Throws if the SLAYRouter is paused.
+     */
+    function _requireNotPaused() internal view virtual {
+        if (router.paused()) {
+            revert EnforcedPause();
+        }
+    }
+
+    /**
+     * @dev Throws if the SLAYVault is not whitelisted in the SLAYRouter.
+     */
+    function _requireWhitelisted() internal view virtual {
+        if (!router.whitelisted(address(this))) {
+            revert ExpectedWhitelisted();
+        }
     }
 }

--- a/contracts/test/SLAYRouter.t.sol
+++ b/contracts/test/SLAYRouter.t.sol
@@ -1,12 +1,72 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.0;
 
+import "../src/SLAYRouter.sol";
+import "../src/SLAYVault.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {Test, console} from "forge-std/Test.sol";
 import {TestSuite} from "./TestSuite.sol";
 
 contract SLAYRouterTest is Test, TestSuite {
-    function test() public view {
+    function test_defaults() public view {
         assertEq(router.owner(), owner);
         assertEq(router.paused(), false);
+    }
+
+    function test_paused() public {
+        vm.startPrank(owner);
+        router.pause();
+        vm.stopPrank();
+
+        assertTrue(router.paused());
+    }
+
+    function test_pausedOnlyOwnerError() public {
+        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, address(this)));
+        router.pause();
+    }
+
+    function test_unpausedOnlyOwnerError() public {
+        vm.startPrank(owner);
+        router.pause();
+        vm.stopPrank();
+
+        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, address(this)));
+        router.unpause();
+    }
+
+    function test_Whitelisted() public {
+        address vault = address(newVault());
+        assertFalse(router.whitelisted(vault));
+
+        vm.startPrank(owner);
+
+        vm.expectEmit();
+        emit SLAYRouter.Whitelisted(vault, true);
+        router.setWhitelist(vault, true);
+
+        assertTrue(router.whitelisted(vault));
+
+        vm.expectEmit();
+        emit SLAYRouter.Whitelisted(vault, false);
+        router.setWhitelist(vault, false);
+
+        assertFalse(router.whitelisted(vault));
+    }
+
+    /**
+     * We allow whitelisting of fake vaults, which are not created by the factory.
+     */
+    function test_WhitelistedFakeVault() public {
+        address vault = vm.randomAddress();
+        assertFalse(router.whitelisted(vault));
+
+        vm.startPrank(owner);
+
+        vm.expectEmit();
+        emit SLAYRouter.Whitelisted(vault, true);
+        router.setWhitelist(vault, true);
+
+        assertTrue(router.whitelisted(vault));
     }
 }

--- a/contracts/test/SLAYVault.t.sol
+++ b/contracts/test/SLAYVault.t.sol
@@ -2,14 +2,14 @@
 pragma solidity ^0.8.0;
 
 import "./MockERC20.sol";
+import "../src/SLAYVault.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import {SLAYVault} from "../src/SLAYVault.sol";
 import {Test, console} from "forge-std/Test.sol";
 import {UnsafeUpgrades} from "@openzeppelin/foundry-upgrades/Upgrades.sol";
 import {TestSuite} from "./TestSuite.sol";
 
 contract SLAYVaultTest is Test, TestSuite {
-    function testToken1() public {
+    function test_token1() public {
         MockERC20 underlying = new MockERC20("Mock Token", "MTK", 12);
         address proxy = vaultFactory.create(underlying, "SLAY TokenName", "SLAY.MTK");
         SLAYVault vault = SLAYVault(proxy);
@@ -17,11 +17,58 @@ contract SLAYVaultTest is Test, TestSuite {
         assertEq(vault.symbol(), "SLAY.MTK");
     }
 
-    function testToken2() public {
+    function test_token2() public {
         MockERC20 underlying = new MockERC20("Mock Token AAA", "AAA", 15);
         address proxy = vaultFactory.create(underlying, "SLAY AAA", "SLAY.AAA");
         SLAYVault vault = SLAYVault(proxy);
         assertEq(vault.decimals(), 15);
         assertEq(vault.symbol(), "SLAY.AAA");
+    }
+
+    function test_whitelisted() public {
+        SLAYVault vault = newVault("Bitcoin", "BTC", 8);
+
+        vm.startPrank(owner);
+        router.setWhitelist(address(vault), true);
+        assertTrue(router.whitelisted(address(vault)));
+        vm.stopPrank();
+
+        MockERC20 underlying = MockERC20(vault.asset());
+        address account = address(this);
+        underlying.mint(account, 1000 * 10 ** vault.decimals());
+        underlying.approve(address(vault), type(uint256).max);
+        vault.deposit(100 * 10 ** vault.decimals(), account);
+        assertEq(vault.balanceOf(account), 100 * 10 ** vault.decimals());
+    }
+
+    function test_notWhitelisted() public {
+        SLAYVault vault = newVault();
+
+        MockERC20 underlying = MockERC20(vault.asset());
+        address account = address(this);
+
+        underlying.mint(account, 1000 * 10 ** vault.decimals());
+        underlying.approve(address(vault), type(uint256).max);
+
+        vm.expectRevert(SLAYVault.ExpectedWhitelisted.selector);
+        vault.deposit(100, account);
+    }
+
+    function test_paused() public {
+        SLAYVault vault = newVault();
+
+        vm.startPrank(owner);
+        router.setWhitelist(address(vault), true);
+        router.pause();
+        vm.stopPrank();
+
+        MockERC20 underlying = MockERC20(vault.asset());
+        address account = address(this);
+
+        underlying.mint(account, 1000 * 10 ** vault.decimals());
+        underlying.approve(address(vault), type(uint256).max);
+
+        vm.expectRevert(SLAYVault.EnforcedPause.selector);
+        vault.deposit(100, account);
     }
 }

--- a/contracts/test/TestSuite.sol
+++ b/contracts/test/TestSuite.sol
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.0;
 
+import {MockERC20} from "./MockERC20.sol";
+import {EmptyImpl} from "../src/EmptyImpl.sol";
+import {SLAYRegistry} from "../src/SLAYRegistry.sol";
+import {SLAYRouter} from "../src/SLAYRouter.sol";
+import {SLAYVaultFactory} from "../src/SLAYVaultFactory.sol";
+import {SLAYVault} from "../src/SLAYVault.sol";
 import {Test, console} from "forge-std/Test.sol";
 import {UnsafeUpgrades} from "@openzeppelin/foundry-upgrades/Upgrades.sol";
-import {SLAYRouter} from "../src/SLAYRouter.sol";
-import {SLAYRegistry} from "../src/SLAYRegistry.sol";
-import {EmptyImpl} from "../src/EmptyImpl.sol";
-import {SLAYVault} from "../src/SLAYVault.sol";
-import {SLAYVaultFactory} from "../src/SLAYVaultFactory.sol";
 
 /**
  * @dev set up all the contracts needed for testing.
@@ -42,5 +43,17 @@ contract TestSuite is Test {
             address(registry), address(new SLAYRegistry(router)), abi.encodeCall(SLAYRegistry.initialize, ())
         );
         vm.stopPrank();
+    }
+
+    function newVault() public virtual returns (SLAYVault) {
+        return newVault("Token", "TKN", 18);
+    }
+
+    function newVault(string memory _name, string memory _symbol, uint8 _decimals) public virtual returns (SLAYVault) {
+        MockERC20 underlying = new MockERC20(_name, _symbol, _decimals);
+        string memory vaultName = string(abi.encodePacked("SLAY ", _name));
+        string memory vaultSymbol = string(abi.encodePacked("SLAY.", _symbol));
+        address proxy = vaultFactory.create(underlying, vaultName, vaultSymbol);
+        return SLAYVault(proxy);
     }
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

Add `modifier whenNotPaused` to SLAYVault, which sources paused state from SLAYRouter. SLAYVault doesn't enforce its own pause state, but relies on the SLAYRouter to manage the pause state. If the SLAYRouter is paused, all operations marked with this modifier will revert with `EnforcedPause`.

Add `modifier whenWhitelisted` to SLAYVault. If the SLAYVault is not whitelisted on SLAYRouter, all operations marked with this modifier will revert with `ExpectedWhitelisted`.

Closes SL-544
