### PR TITLE
feat: implement _checkOperator for VaultFactory

### DIFF
--- a/contracts/test/SLAYRouter.t.sol
+++ b/contracts/test/SLAYRouter.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.0;
 
+import "./MockERC20.sol";
 import "../src/SLAYRouter.sol";
 import "../src/SLAYVault.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
@@ -36,7 +37,11 @@ contract SLAYRouterTest is Test, TestSuite {
     }
 
     function test_Whitelisted() public {
-        address vault = address(newVault());
+        vm.startPrank(makeAddr("Operator Y"));
+        registry.registerAsOperator("https://example.com", "Operator Y");
+
+        MockERC20 underlying = new MockERC20("Token", "TKN", 18);
+        address vault = address(vaultFactory.create(underlying));
         assertFalse(router.whitelisted(vault));
 
         vm.startPrank(owner);

--- a/contracts/test/TestSuite.sol
+++ b/contracts/test/TestSuite.sol
@@ -11,7 +11,7 @@ import {Test, console} from "forge-std/Test.sol";
 import {UnsafeUpgrades} from "@openzeppelin/foundry-upgrades/Upgrades.sol";
 
 /**
- * @dev set up all the contracts needed for testing.
+ * @dev To set up all the contracts needed for testing.
  */
 contract TestSuite is Test {
     address public owner = vm.randomAddress();
@@ -30,7 +30,7 @@ contract TestSuite is Test {
 
         SLAYVault vaultImpl = new SLAYVault(router, registry);
         address beacon = UnsafeUpgrades.deployBeacon(address(vaultImpl), owner);
-        SLAYVaultFactory factoryImpl = new SLAYVaultFactory(beacon);
+        SLAYVaultFactory factoryImpl = new SLAYVaultFactory(beacon, registry);
         vaultFactory = SLAYVaultFactory(
             UnsafeUpgrades.deployUUPSProxy(address(factoryImpl), abi.encodeCall(SLAYVaultFactory.initialize, (owner)))
         );
@@ -43,28 +43,5 @@ contract TestSuite is Test {
             address(registry), address(new SLAYRegistry(router)), abi.encodeCall(SLAYRegistry.initialize, ())
         );
         vm.stopPrank();
-    }
-
-    /**
-     * @dev Create a new SLAYVault instance for testing with default parameters.
-     * The vault will use a MockERC20 token with name "Token", symbol "TKN", and 18 decimals.
-     * The caller must be an operator.
-     * Use vm.startPrank() to set the operator before calling this function.
-     */
-    function newVault() public virtual returns (SLAYVault) {
-        return newVault("Token", "TKN", 18);
-    }
-
-    /**
-     * @dev Create a new SLAYVault instance for testing.
-     * Params _name, _symbol, and _decimals are used to create a MockERC20 token
-     * which serves as the underlying asset for the vault.
-     * The caller must be an operator.
-     * Use vm.startPrank() to set the operator before calling this function.
-     */
-    function newVault(string memory _name, string memory _symbol, uint8 _decimals) public virtual returns (SLAYVault) {
-        MockERC20 underlying = new MockERC20(_name, _symbol, _decimals);
-        address proxy = vaultFactory.create(underlying);
-        return SLAYVault(proxy);
     }
 }

--- a/contracts/test/TestSuite.sol
+++ b/contracts/test/TestSuite.sol
@@ -11,7 +11,7 @@ import {Test, console} from "forge-std/Test.sol";
 import {UnsafeUpgrades} from "@openzeppelin/foundry-upgrades/Upgrades.sol";
 
 /**
- * @dev To set up all the contracts needed for testing.
+ * @dev This test suite set up all the contracts needed for testing.
  */
 contract TestSuite is Test {
     address public owner = vm.randomAddress();


### PR DESCRIPTION
#### What this PR does / why we need it:

- Implement `_checkOperator` in SLAYVaultFactory.

Closes SL-556

Also, this PR removes `newVault()` helper. This was quite an opinionated setup; it's better for downstream tests to create a vault without using helpers.