### PR TITLE
chore: use OZ validateImplementation and validateUpgrade for scripts before deployment

### DIFF
--- a/contracts/script/Deployment.s.sol
+++ b/contracts/script/Deployment.s.sol
@@ -9,37 +9,47 @@ import "../src/SLAYRegistry.sol";
 
 import {Script, console} from "forge-std/Script.sol";
 import {UnsafeUpgrades} from "@openzeppelin/foundry-upgrades/Upgrades.sol";
+import {Options} from "@openzeppelin/foundry-upgrades/Options.sol";
+import {Core} from "@openzeppelin/foundry-upgrades/internal/Core.sol";
 
 /// @title Deployment Script for Initialization of SatLayer Protocol
 /// @dev For deployment, we use the OpenZeppelin `UnsafeUpgrades` library to deploy UUPS proxies and beacons.
 /// Although it is "unsafe" and not recommended for production, the "safe version" does not support non-empty constructor arguments.
-/// This allow us to use the constructor arguments in the implementation contracts.
+/// This "unsafe" allow us to use the constructor arguments in the implementation contracts.
 /// Which we use to set immutable proxy addresses for the router and registry.
 /// After which we can upgrade the proxies to the actual implementations.
+/// However, to ensure the safety of the deployment, we validate each implementation (just as the "safe" version does)
+/// to ensure the implementation is valid and does not contain any unsafe code.
 contract DeploymentScript is Script {
+    Options public opts;
     address public owner = address(0x011);
 
     function run() public {
         vm.startBroadcast(owner);
 
         // Create the initial implementation contract and deploy the proxies for router and registry
+        Core.validateImplementation("InitialImpl.sol:InitialImpl", opts);
         address initialImpl = address(new InitialImpl());
+
         SLAYRouter router =
             SLAYRouter(UnsafeUpgrades.deployUUPSProxy(initialImpl, abi.encodeCall(InitialImpl.initialize, (owner))));
         SLAYRegistry registry =
             SLAYRegistry(UnsafeUpgrades.deployUUPSProxy(initialImpl, abi.encodeCall(InitialImpl.initialize, (owner))));
 
+        Core.validateImplementation("SLAYVault.sol:SLAYVault", opts);
         address vaultImpl = address(new SLAYVault(router, registry));
         address beacon = UnsafeUpgrades.deployBeacon(vaultImpl, owner);
+
+        Core.validateImplementation("SLAYVaultFactory.sol:SLAYVaultFactory", opts);
         address factoryImpl = address(new SLAYVaultFactory(beacon, registry));
-        SLAYVaultFactory vaultFactory = SLAYVaultFactory(
-            UnsafeUpgrades.deployUUPSProxy(factoryImpl, abi.encodeCall(SLAYVaultFactory.initialize, (owner)))
-        );
+        UnsafeUpgrades.deployUUPSProxy(factoryImpl, abi.encodeCall(SLAYVaultFactory.initialize, (owner)));
 
+        Core.validateUpgrade("SLAYRouter.sol:SLAYRouter", opts);
         address routerImpl = address(new SLAYRouter(registry));
-        UnsafeUpgrades.upgradeProxy(address(router), routerImpl, abi.encodeCall(SLAYRouter.initialize, ()));
+        UnsafeUpgrades.upgradeProxy(address(router), routerImpl, abi.encodeCall(SLAYRouter.initialize2, ()));
 
+        Core.validateUpgrade("SLAYRegistry.sol:SLAYRegistry", opts);
         address registryImpl = address(new SLAYRegistry(router));
-        UnsafeUpgrades.upgradeProxy(address(registry), registryImpl, abi.encodeCall(SLAYRegistry.initialize, ()));
+        UnsafeUpgrades.upgradeProxy(address(registry), registryImpl, abi.encodeCall(SLAYRegistry.initialize2, ()));
     }
 }

--- a/contracts/src/SLAYRegistry.sol
+++ b/contracts/src/SLAYRegistry.sol
@@ -9,13 +9,14 @@ import {Checkpoints} from "@openzeppelin/contracts/utils/structs/Checkpoints.sol
 
 import {SLAYRouter} from "./SLAYRouter.sol";
 
-/**
- * @title SLAYRegistry
- * @dev This contract serves as a registry for services and operators in the SatLayer ecosystem.
- * It allows services and operators to register themselves, manage their relationships,
- * and track registration statuses.
- */
+/// @title SLAYRegistry
+/// @dev This contract serves as a registry for services and operators in the SatLayer ecosystem.
+/// It allows services and operators to register themselves, manage their relationships,
+/// and track registration statuses.
+///
+/// @custom:oz-upgrades-from src/InitialImpl.sol:InitialImpl
 contract SLAYRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     SLAYRouter public immutable router;
 
     /**
@@ -117,7 +118,14 @@ contract SLAYRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pau
         _disableInitializers();
     }
 
-    function initialize() public reinitializer(2) {
+    /// @custom:oz-upgrades-validate-as-initializer
+    function initialize(address initialOwner) public reinitializer(2) {
+        __Ownable_init(initialOwner);
+        __UUPSUpgradeable_init();
+        __Pausable_init();
+    }
+
+    function initialize2() public reinitializer(2) {
         __Pausable_init();
     }
 

--- a/contracts/src/SLAYRouter.sol
+++ b/contracts/src/SLAYRouter.sol
@@ -8,7 +8,9 @@ import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/Pau
 
 import {SLAYRegistry} from "./SLAYRegistry.sol";
 
+/// @custom:oz-upgrades-from src/InitialImpl.sol:InitialImpl
 contract SLAYRouter is Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     SLAYRegistry public immutable registry;
 
     mapping(address => bool) public whitelisted;
@@ -30,7 +32,14 @@ contract SLAYRouter is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausa
         _disableInitializers();
     }
 
-    function initialize() public reinitializer(2) {
+    /// @custom:oz-upgrades-validate-as-initializer
+    function initialize(address initialOwner) public reinitializer(2) {
+        __Ownable_init(initialOwner);
+        __UUPSUpgradeable_init();
+        __Pausable_init();
+    }
+
+    function initialize2() public reinitializer(2) {
         __Pausable_init();
     }
 

--- a/contracts/src/SLAYVault.sol
+++ b/contracts/src/SLAYVault.sol
@@ -32,7 +32,10 @@ contract SLAYVault is
     ERC20PermitUpgradeable,
     ISLAYVault
 {
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     SLAYRouter public immutable router;
+
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     SLAYRegistry public immutable registry;
 
     /**
@@ -52,9 +55,7 @@ contract SLAYVault is
      */
     error ExpectedWhitelisted();
 
-    /**
-     * @custom:oz-upgrades-unsafe-allow constructor
-     */
+    /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(SLAYRouter router_, SLAYRegistry registry_) {
         router = router_;
         registry = registry_;
@@ -70,8 +71,8 @@ contract SLAYVault is
         public
         initializer
     {
-        __ERC4626_init(asset_);
         __ERC20_init(name_, symbol_);
+        __ERC4626_init(asset_);
         __ERC20Permit_init(name_);
         operator = operator_;
     }

--- a/contracts/src/SLAYVaultFactory.sol
+++ b/contracts/src/SLAYVaultFactory.sol
@@ -14,7 +14,10 @@ import {SLAYVault} from "./SLAYVault.sol";
 import {SLAYRegistry} from "./SLAYRegistry.sol";
 
 contract SLAYVaultFactory is Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     address public immutable beacon;
+
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     SLAYRegistry public immutable registry;
 
     /**
@@ -22,9 +25,7 @@ contract SLAYVaultFactory is Initializable, UUPSUpgradeable, OwnableUpgradeable,
      */
     error NotOperator(address account);
 
-    /**
-     * @custom:oz-upgrades-unsafe-allow constructor
-     */
+    /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(address beacon_, SLAYRegistry registry_) {
         beacon = beacon_;
         registry = registry_;

--- a/contracts/test/TestSuite.sol
+++ b/contracts/test/TestSuite.sol
@@ -37,10 +37,10 @@ contract TestSuite is Test {
 
         vm.startPrank(owner);
         UnsafeUpgrades.upgradeProxy(
-            address(router), address(new SLAYRouter(registry)), abi.encodeCall(SLAYRouter.initialize, ())
+            address(router), address(new SLAYRouter(registry)), abi.encodeCall(SLAYRouter.initialize2, ())
         );
         UnsafeUpgrades.upgradeProxy(
-            address(registry), address(new SLAYRegistry(router)), abi.encodeCall(SLAYRegistry.initialize, ())
+            address(registry), address(new SLAYRegistry(router)), abi.encodeCall(SLAYRegistry.initialize2, ())
         );
         vm.stopPrank();
     }


### PR DESCRIPTION
#### What this PR does / why we need it:

Use OZ `Core.validateImplementation` and `Core.validateUpgrade` to validate implementation and upgrade before deployment.

Closes SL-576