### PR TITLE
feat: move pausability to `InitialImpl`

### DIFF
--- a/contracts/script/Deployment.s.sol
+++ b/contracts/script/Deployment.s.sol
@@ -46,10 +46,10 @@ contract DeploymentScript is Script {
 
         Core.validateUpgrade("SLAYRouter.sol:SLAYRouter", opts);
         address routerImpl = address(new SLAYRouter(registry));
-        UnsafeUpgrades.upgradeProxy(address(router), routerImpl, abi.encodeCall(SLAYRouter.initialize2, ()));
+        UnsafeUpgrades.upgradeProxy(address(router), routerImpl, "");
 
         Core.validateUpgrade("SLAYRegistry.sol:SLAYRegistry", opts);
         address registryImpl = address(new SLAYRegistry(router));
-        UnsafeUpgrades.upgradeProxy(address(registry), registryImpl, abi.encodeCall(SLAYRegistry.initialize2, ()));
+        UnsafeUpgrades.upgradeProxy(address(registry), registryImpl, "");
     }
 }

--- a/contracts/src/InitialImpl.sol
+++ b/contracts/src/InitialImpl.sol
@@ -2,28 +2,60 @@
 pragma solidity ^0.8.0;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 
 /**
  * @title Initial Implementation Contract
- * @dev Used as a base for all SLAY contracts.
- * Designed to be initialized once to get an immutable address for each subsequent contract.
- * The immutable address (Proxies with empty implementation) is used to then set up the rest of the SLAY contracts
- * with immutable addresses. Allowing for cyclic-dependent contracts to be deployed with immutable references.
+ * @dev Serves as a placeholder implementation used to reserve immutable addresses for SLAY contracts.
+ * This contract is deployed once and initialized solely to assign ownership.
+ * The reserved address (via proxies with this empty implementation) is later used to deploy
+ * actual SLAY contracts with immutable references—enabling deployment of cyclically dependent contracts.
+ *
+ * Used by:
+ * - SLAYRegistry.sol
+ * - SLAYRouter.sol
  */
-contract InitialImpl is Initializable, UUPSUpgradeable, OwnableUpgradeable {
-    /**
-     * @custom:oz-upgrades-unsafe-allow constructor
-     */
+contract InitialImpl is Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
+    /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();
     }
 
+    /**
+     * @dev Initializes the contract and sets the initial owner.
+     * Called once to reserve the proxy address for future immutable contract deployment.
+     * `__Pausable_init()` is also initialized here to ensure that the contract can be paused before upgrade.
+     *
+     * @param initialOwner The address to be set as the initial owner.
+     */
     function initialize(address initialOwner) public initializer {
         __Ownable_init(initialOwner);
         __UUPSUpgradeable_init();
+        __Pausable_init();
     }
 
+    /**
+     * @dev Authorizes an upgrade to a new implementation.
+     * This function is required by UUPS and restricts upgradeability to the contract owner.
+     * @param newImplementation The address of the new contract implementation.
+     */
     function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
+
+    /**
+     * @dev Pauses the contract.
+     * Allow the contract to be paused before any upgrade to the actual implementation.
+     */
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    /**
+     * @dev Unpauses the contract..
+     * Allow the contract to be also be unpaused—if necessary.
+     */
+    function unpause() external onlyOwner {
+        _unpause();
+    }
 }

--- a/contracts/src/SLAYRouter.sol
+++ b/contracts/src/SLAYRouter.sol
@@ -9,7 +9,13 @@ import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/Pau
 import {SLAYRegistry} from "./SLAYRegistry.sol";
 import {ISLAYRouter} from "./interface/ISLAYRouter.sol";
 
-/// @custom:oz-upgrades-from src/InitialImpl.sol:InitialImpl
+/**
+ * @title SLAYRouter
+ * @dev The central point for managing interactions with SLAYVaults.
+ * This contract is designed to work with the SLAYRegistry for managing vaults and their states.
+ *
+ * @custom:oz-upgrades-from src/InitialImpl.sol:InitialImpl
+ */
 contract SLAYRouter is Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable, ISLAYRouter {
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     SLAYRegistry public immutable registry;
@@ -28,17 +34,11 @@ contract SLAYRouter is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausa
         _disableInitializers();
     }
 
-    /// @custom:oz-upgrades-validate-as-initializer
-    function initialize(address initialOwner) public reinitializer(2) {
-        __Ownable_init(initialOwner);
-        __UUPSUpgradeable_init();
-        __Pausable_init();
-    }
-
-    function initialize2() public reinitializer(2) {
-        __Pausable_init();
-    }
-
+    /**
+     * @dev Authorizes an upgrade to a new implementation.
+     * This function is required by UUPS and restricts upgradeability to the contract owner.
+     * @param newImplementation The address of the new contract implementation.
+     */
     function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
 
     /**

--- a/contracts/src/SLAYVault.sol
+++ b/contracts/src/SLAYVault.sol
@@ -18,8 +18,21 @@ import {IERC7540Redeem, IERC7540Operator} from "./interface/IERC7540.sol";
 import {ISLAYVault} from "./interface/ISLAYVault.sol";
 
 /**
- * Implementation contract for SLAYVault.
- * This contract is not initialized directly, but through the SLAYVaultFactory using the Beacon proxy pattern.
+ * @title SLAYVault
+ * @notice ERC4626-compliant tokenized vault designed for asynchronous redemption workflows.
+ * @dev
+ * - This contract is deployed via the SLAYVaultFactory using the Beacon Proxy pattern.
+ * - It integrates the ERC20, ERC4626, and ERC20Permit standards with custom logic for delayed redemptions,
+ *   as defined in the ERC7540 interface.
+ * - Redeem requests are initiated by transferring shares to the vault and can be claimed after a configurable delay.
+ * - Preview functions are intentionally disabled to prevent misuse in async flows.
+ * - Immutable dependencies (`SLAYRouter` and `SLAYRegistry`) are injected at construction for efficient immutable access.
+ *
+ * Key Features:
+ * - Asynchronous redeem request/claim pattern using `requestRedeem`, `withdraw`, and `redeem`
+ * - IERC7540Operator for request/claim with configurable controller-operator relationships
+ * - Upgradeable via Beacon Proxy pattern
+ * - Pausing and whitelisting enforced by SLAYRouter
  */
 contract SLAYVault is
     Initializable,

--- a/contracts/test/InitialImpl.t.sol
+++ b/contracts/test/InitialImpl.t.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {Test, console} from "forge-std/Test.sol";
+import {InitialImpl} from "../src/InitialImpl.sol";
+import {UnsafeUpgrades} from "@openzeppelin/foundry-upgrades/Upgrades.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+
+contract InitialImplTest is Test {
+    InitialImpl public initialImpl = new InitialImpl();
+
+    function test_paused() public {
+        address proxy = UnsafeUpgrades.deployUUPSProxy(
+            address(initialImpl), abi.encodeCall(InitialImpl.initialize, (address(this)))
+        );
+        InitialImpl impl = InitialImpl(proxy);
+        impl.pause();
+
+        assertTrue(impl.paused(), "Contract should be paused");
+    }
+
+    function test_unpaused() public {
+        address proxy = UnsafeUpgrades.deployUUPSProxy(
+            address(initialImpl), abi.encodeCall(InitialImpl.initialize, (address(this)))
+        );
+        InitialImpl impl = InitialImpl(proxy);
+        impl.pause();
+        impl.unpause();
+
+        assertFalse(impl.paused(), "Contract should be unpaused");
+    }
+
+    function test_owner() public {
+        address proxy = UnsafeUpgrades.deployUUPSProxy(
+            address(initialImpl), abi.encodeCall(InitialImpl.initialize, (address(this)))
+        );
+        InitialImpl impl = InitialImpl(proxy);
+
+        address owner = address(this);
+        assertEq(impl.owner(), owner, "Owner should be set correctly");
+    }
+
+    function test_only_owner_can_pause() public {
+        address proxy = UnsafeUpgrades.deployUUPSProxy(
+            address(initialImpl), abi.encodeCall(InitialImpl.initialize, (address(this)))
+        );
+        InitialImpl impl = InitialImpl(proxy);
+
+        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, address(0x123)));
+        vm.prank(address(0x123));
+        impl.pause();
+    }
+
+    function test_only_owner_can_unpause() public {
+        address proxy = UnsafeUpgrades.deployUUPSProxy(
+            address(initialImpl), abi.encodeCall(InitialImpl.initialize, (address(this)))
+        );
+        InitialImpl impl = InitialImpl(proxy);
+        impl.pause();
+
+        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, address(0x123)));
+        vm.prank(address(0x123));
+        impl.unpause();
+    }
+
+    function test_upgrade_proxy() public {
+        address proxy = UnsafeUpgrades.deployUUPSProxy(
+            address(initialImpl), abi.encodeCall(InitialImpl.initialize, (address(this)))
+        );
+        InitialImpl impl = InitialImpl(proxy);
+
+        InitialImpl newImpl = new InitialImpl();
+        UnsafeUpgrades.upgradeProxy(proxy, address(newImpl), "");
+
+        assertEq(impl.owner(), address(this), "Owner should remain unchanged after upgrade");
+    }
+
+    function test_only_owner_can_upgrade() public {
+        address proxy = UnsafeUpgrades.deployUUPSProxy(
+            address(initialImpl), abi.encodeCall(InitialImpl.initialize, (address(this)))
+        );
+        InitialImpl impl = InitialImpl(proxy);
+
+        InitialImpl newImpl = new InitialImpl();
+        try this.upgradeCallNonOwner(proxy, address(newImpl)) {
+            fail();
+        } catch (bytes memory reason) {
+            assertEq(
+                reason, abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, address(0x123))
+            );
+        }
+    }
+
+    function upgradeCallNonOwner(address proxy, address newImpl) external {
+        vm.startPrank(address(0x123));
+        UnsafeUpgrades.upgradeProxy(proxy, newImpl, "");
+    }
+}

--- a/contracts/test/SLAYRouter.t.sol
+++ b/contracts/test/SLAYRouter.t.sol
@@ -16,9 +16,8 @@ contract SLAYRouterTest is Test, TestSuite {
     }
 
     function test_paused() public {
-        vm.startPrank(owner);
+        vm.prank(owner);
         router.pause();
-        vm.stopPrank();
 
         assertTrue(router.paused());
     }
@@ -29,9 +28,8 @@ contract SLAYRouterTest is Test, TestSuite {
     }
 
     function test_unpausedOnlyOwnerError() public {
-        vm.startPrank(owner);
+        vm.prank(owner);
         router.pause();
-        vm.stopPrank();
 
         vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, address(this)));
         router.unpause();

--- a/contracts/test/TestSuite.sol
+++ b/contracts/test/TestSuite.sol
@@ -36,12 +36,8 @@ contract TestSuite is Test {
         );
 
         vm.startPrank(owner);
-        UnsafeUpgrades.upgradeProxy(
-            address(router), address(new SLAYRouter(registry)), abi.encodeCall(SLAYRouter.initialize2, ())
-        );
-        UnsafeUpgrades.upgradeProxy(
-            address(registry), address(new SLAYRegistry(router)), abi.encodeCall(SLAYRegistry.initialize2, ())
-        );
+        UnsafeUpgrades.upgradeProxy(address(router), address(new SLAYRouter(registry)), "");
+        UnsafeUpgrades.upgradeProxy(address(registry), address(new SLAYRegistry(router)), "");
         vm.stopPrank();
     }
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

Include `PausableUpgradeable` in `InitialImpl` to allow contracts to be paused during initial deployment. Remove `initialize2` and `initialize` from `SLAYRouter` and `SLAYRegistry` since they will be initialized only from `InitialImpl`, doing so to prevent confusion.

Also, add updated a bunch of tests to test for `whenNotPaused` state.

Closes SL-583