### PR TITLE
chore: add layerzerolabs group to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,10 +41,12 @@ updates:
           - "nextra-*"
           - "react*"
           - "@types/react*"
-
       cosmjs:
         patterns:
           - "@cosmjs/*"
+      layerzerolabs:
+        patterns:
+          - "@layerzerolabs/*"
 
   - package-ecosystem: cargo
     directory: "/crates"


### PR DESCRIPTION
#### What this PR does / why we need it:

As titled.