### PR TITLE
chore: only allow self or operator to withdraw

### DIFF
--- a/contracts/src/SLAYVault.sol
+++ b/contracts/src/SLAYVault.sol
@@ -190,6 +190,11 @@ contract SLAYVault is
             _spendAllowance(owner, _msgSender(), shares);
         }
 
+        // if the controller is not the sender, check that the controller has msg.sender set as the operator
+        if (controller != _msgSender() && !_isOperator[controller][_msgSender()]) {
+            revert NotControllerOrOperator();
+        }
+
         RedeemRequestStruct storage pendingRedemptionRequest = _pendingRedemption[controller];
 
         // increment the shares in the pending redemption request


### PR DESCRIPTION
#### What this PR does / why we need it:

Only allow these entities to request withdrawal on behalf of owner:

1. owner
2. owner's approved operator
3. owner's approved operator's approved operator (with appropriate allowance from owner)


<!-- remove if not applicable -->
Closes SL-602