### PR TITLE
chore: rename enableSlashing(address) to approveSlashingFor(address)

### DIFF
--- a/contracts/src/Relationship.sol
+++ b/contracts/src/Relationship.sol
@@ -43,8 +43,17 @@ library Relationship {
         ServiceRegistered
     }
 
+    /**
+     * @title Object of Relationship
+     * @dev This struct represents the relationship object that contains the status
+     * - 8 bits for the {Status} enum
+     * - 32 bits for the slash parameter ID
+     * Total: 40 bits (5 bytes) used so far.
+     */
     struct Object {
+        /// @dev The registration status of the relationship.
         Status status;
+        /// @dev The ID of the slash parameter associated with this relationship.
         uint32 slashParameterId;
     }
 
@@ -107,12 +116,21 @@ library Relationship {
         return Checkpoints.length(self);
     }
 
+    /**
+     * @dev Encodes the status and slash parameter ID into a single uint224 value.
+     * Why encode into uint224, when could declare a new struct and let Solidity handle it?
+     * This is done for efficiency, by packing the Struct into uint224 allowing us to
+     * use the existing Checkpoints library which well audited and optimized for production use.
+     */
     function encode(Status status, uint32 slashParameterId) internal pure returns (uint224) {
         uint224 encoded = uint224(uint8(status));
         encoded |= (uint224(slashParameterId) << 8);
         return encoded;
     }
 
+    /**
+     * @dev Decodes a uint224 value into an Object struct.
+     */
     function decode(uint224 encoded) internal pure returns (Object memory) {
         Object memory obj;
         obj.status = Status(uint8(encoded));

--- a/contracts/src/SLAYRegistry.sol
+++ b/contracts/src/SLAYRegistry.sol
@@ -277,7 +277,7 @@ contract SLAYRegistry is ISLAYRegistry, Initializable, UUPSUpgradeable, OwnableU
     }
 
     /// @inheritdoc ISLAYRegistry
-    function enableSlashing(address service) external onlyOperator(_msgSender()) whenNotPaused {
+    function approveSlashingFor(address service) external onlyOperator(_msgSender()) whenNotPaused {
         address operator = _msgSender();
         Relationship.Object memory obj = _getRelationshipObject(service, operator);
         require(obj.status == Relationship.Status.Active, "Relationship not active");

--- a/contracts/src/SLAYRegistry.sol
+++ b/contracts/src/SLAYRegistry.sol
@@ -283,8 +283,7 @@ contract SLAYRegistry is ISLAYRegistry, Initializable, UUPSUpgradeable, OwnableU
         require(obj.status == Relationship.Status.Active, "Relationship not active");
 
         uint32 slashParameterId = _services[service].slashParameterId;
-        require(slashParameterId != 0, "Slashing not enabled");
-        require(slashParameterId != obj.slashParameterId, "Same slashing parameters");
+        require(slashParameterId != obj.slashParameterId, "Slashing not updated");
         obj.slashParameterId = slashParameterId;
         _updateRelationshipObject(service, operator, obj);
     }

--- a/contracts/src/interface/ISLAYRegistry.sol
+++ b/contracts/src/interface/ISLAYRegistry.sol
@@ -251,20 +251,26 @@ interface ISLAYRegistry {
     function enableSlashing(SlashParameter calldata parameter) external;
 
     /**
-     * @dev For service to disable slashing.
-     * The {msg.sender} must be a registered service.
+     * @dev For service to disable slashing for itself.
+     * - The {msg.sender} must be a registered service.
+     * - Disabling slashing will set the slash parameter ID to 0.
+     * - This will not remove existing slash relationships
+     * - New slash relationships will not be created when operator {enableSlashing(address)} is called.
      */
     function disableSlashing() external;
 
     /**
-     * @dev For operator to enable slashing for a service it's validating.
+     * @dev For operator to approve (enable, disable or update) slashing for a service it's validating.
      * - The {msg.sender} must be a registered operator.
-     * - The service it intends to enable slashing for must be registered and have slashing enabled.
      * - The service and operator must have an active relationship.
+     * - To enable slashing, the service must have already enabled slashing via {enableSlashing(SlashParameter)}.
+     * - To disable slashing, the service must have already disabled slashing via {disableSlashing()}.
+     * - To update (set new parameters), the service must have a new set of slash parameters registered via {enableSlashing(SlashParameter)}.
+     * - If no update is registered, the function will revert.
      *
      * @param service The address of the service for which slashing is being enabled.
      */
-    function enableSlashing(address service) external;
+    function approveSlashingFor(address service) external;
 
     /**
      * @dev Get the current slash parameters for a given service.

--- a/contracts/test/SLAYRegistry.t.sol
+++ b/contracts/test/SLAYRegistry.t.sol
@@ -711,8 +711,8 @@ contract SLAYRegistryTest is Test, TestSuite {
         registry.setMaxActiveRelationships(5);
     }
 
-    function test_enableSlashing_lifecycle_but_parameterChanged() public {
-        // test operator's slash optin loyalty (past and present) throughout service's slashing parameter mutations.
+    function test_slashingLifecycle_but_parameterChanged() public {
+        // test operator's slash opt-in loyalty (past and present) throughout service's slashing parameter mutations.
         vm.prank(operator);
         registry.registerAsOperator("operator.com", "Operator X");
 
@@ -729,7 +729,7 @@ contract SLAYRegistryTest is Test, TestSuite {
 
         vm.prank(operator);
         uint256 timeAtWhichOperatorOptedInParam1 = block.timestamp;
-        registry.enableSlashing(service);
+        registry.approveSlashingFor(service);
         ISLAYRegistry.SlashParameter memory obj =
             registry.getSlashParameterAt(service, operator, uint32(block.timestamp));
 
@@ -752,7 +752,7 @@ contract SLAYRegistryTest is Test, TestSuite {
         _advanceBlockBy(10);
 
         vm.prank(operator);
-        registry.enableSlashing(service);
+        registry.approveSlashingFor(service);
 
         _advanceBlockBy(10);
 
@@ -766,7 +766,7 @@ contract SLAYRegistryTest is Test, TestSuite {
         assert(obj3.maxMbips == 100_000);
     }
 
-    function test_enableSlashing_lifecycle_timestamped_query() public {
+    function test_slashingLifecycle_timestamped_query() public {
         vm.prank(operator);
         registry.registerAsOperator("operator.com", "Operator X");
 
@@ -783,7 +783,7 @@ contract SLAYRegistryTest is Test, TestSuite {
 
         vm.prank(operator);
         uint256 timeAtWhichOperatorOptedInParam1 = block.timestamp;
-        registry.enableSlashing(service);
+        registry.approveSlashingFor(service);
 
         _advanceBlockBy(10);
 
@@ -793,7 +793,7 @@ contract SLAYRegistryTest is Test, TestSuite {
         );
         uint256 timeAtWhichOperatorOptedInParam2 = block.timestamp;
         vm.prank(operator);
-        registry.enableSlashing(service);
+        registry.approveSlashingFor(service);
 
         _advanceBlockBy(10);
 
@@ -803,7 +803,7 @@ contract SLAYRegistryTest is Test, TestSuite {
         );
         vm.prank(operator);
         uint256 timeAtWhichOperatorOptedInParam3 = block.timestamp;
-        registry.enableSlashing(service);
+        registry.approveSlashingFor(service);
 
         _advanceBlockBy(10);
 

--- a/contracts/test/SLAYRegistry.t.sol
+++ b/contracts/test/SLAYRegistry.t.sol
@@ -534,7 +534,7 @@ contract SLAYRegistryTest is Test, TestSuite {
         vm.prank(operator);
         vm.expectEmit();
         emit ISLAYRegistry.RelationshipUpdated(service, operator, Relationship.Status.Active, 1);
-        registry.enableSlashing(service);
+        registry.approveSlashingFor(service);
     }
 
     function test_enableSlashing_lifecycle_notOperator() public {
@@ -542,7 +542,7 @@ contract SLAYRegistryTest is Test, TestSuite {
         registry.registerAsService("service.com", "Service A");
 
         vm.expectRevert(abi.encodeWithSelector(ISLAYRegistry.OperatorNotFound.selector, address(this)));
-        registry.enableSlashing(service);
+        registry.approveSlashingFor(service);
     }
 
     function test_enableSlashing_lifecycle_relationship_not_active_1() public {
@@ -552,7 +552,7 @@ contract SLAYRegistryTest is Test, TestSuite {
         address someone = vm.randomAddress();
         vm.prank(operator);
         vm.expectRevert("Relationship not active");
-        registry.enableSlashing(someone);
+        registry.approveSlashingFor(someone);
     }
 
     function test_enableSlashing_lifecycle_relationship_not_active_2() public {
@@ -569,7 +569,7 @@ contract SLAYRegistryTest is Test, TestSuite {
 
         vm.prank(operator);
         vm.expectRevert("Relationship not active");
-        registry.enableSlashing(service);
+        registry.approveSlashingFor(service);
     }
 
     function test_enableSlashing_lifecycle_but_paused() public {
@@ -584,7 +584,7 @@ contract SLAYRegistryTest is Test, TestSuite {
 
         vm.prank(operator);
         vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
-        registry.enableSlashing(service);
+        registry.approveSlashingFor(service);
     }
 
     function test_enableSlashing_lifecycle_slashing_notEnabled() public {
@@ -601,7 +601,7 @@ contract SLAYRegistryTest is Test, TestSuite {
 
         vm.prank(operator);
         vm.expectRevert("Slashing not enabled");
-        registry.enableSlashing(service);
+        registry.approveSlashingFor(service);
     }
 
     function test_enableSlashing_lifecycle_noChange() public {
@@ -620,12 +620,12 @@ contract SLAYRegistryTest is Test, TestSuite {
         registry.registerServiceToOperator(service);
 
         vm.prank(operator);
-        registry.enableSlashing(service);
+        registry.approveSlashingFor(service);
 
         // No change in slashing parameters
         vm.expectRevert("Same slashing parameters");
         vm.prank(operator);
-        registry.enableSlashing(service);
+        registry.approveSlashingFor(service);
     }
 
     function test_Fail_MaxActiveRelationships_ServiceRelationshipsExceeded() public {

--- a/contracts/test/SLAYRegistry.t.sol
+++ b/contracts/test/SLAYRegistry.t.sol
@@ -438,7 +438,7 @@ contract SLAYRegistryTest is Test, TestSuite {
         registry.setWithdrawalDelay(0);
     }
 
-    function test_service_enableSlashing() public {
+    function test_enableSlashing() public {
         vm.prank(service);
         registry.registerAsService("service.com", "Service A");
 
@@ -458,7 +458,7 @@ contract SLAYRegistryTest is Test, TestSuite {
         assertEq(param.resolutionWindow, 3600);
     }
 
-    function test_service_enableSlashing_but_paused() public {
+    function test_enableSlashing_but_paused() public {
         vm.prank(service);
         registry.registerAsService("service.com", "Service A");
 
@@ -472,7 +472,7 @@ contract SLAYRegistryTest is Test, TestSuite {
         );
     }
 
-    function test_service_enableSlashing_notService() public {
+    function test_enableSlashing_notService() public {
         address notService = vm.randomAddress();
         vm.prank(notService);
         vm.expectRevert(abi.encodeWithSelector(ISLAYRegistry.ServiceNotFound.selector, notService));
@@ -482,7 +482,7 @@ contract SLAYRegistryTest is Test, TestSuite {
         );
     }
 
-    function test_service_enableSlashing_revert_conditions() public {
+    function test_enableSlashing_revert_conditions() public {
         vm.startPrank(service);
 
         registry.registerAsService("service.com", "Service A");
@@ -537,7 +537,7 @@ contract SLAYRegistryTest is Test, TestSuite {
         registry.approveSlashingFor(service);
     }
 
-    function test_enableSlashing_lifecycle_notOperator() public {
+    function test_approveSlashingFor_notOperator() public {
         vm.prank(service);
         registry.registerAsService("service.com", "Service A");
 
@@ -545,7 +545,7 @@ contract SLAYRegistryTest is Test, TestSuite {
         registry.approveSlashingFor(service);
     }
 
-    function test_enableSlashing_lifecycle_relationship_not_active_1() public {
+    function test_approveSlashingFor_relationship_not_active_1() public {
         vm.prank(operator);
         registry.registerAsOperator("operator.com", "Operator X");
 
@@ -555,7 +555,7 @@ contract SLAYRegistryTest is Test, TestSuite {
         registry.approveSlashingFor(someone);
     }
 
-    function test_enableSlashing_lifecycle_relationship_not_active_2() public {
+    function test_approveSlashingFor_relationship_not_active_2() public {
         vm.prank(operator);
         registry.registerAsOperator("operator.com", "Operator X");
 
@@ -572,7 +572,7 @@ contract SLAYRegistryTest is Test, TestSuite {
         registry.approveSlashingFor(service);
     }
 
-    function test_enableSlashing_lifecycle_but_paused() public {
+    function test_approveSlashingFor_but_paused() public {
         vm.prank(operator);
         registry.registerAsOperator("operator.com", "Operator X");
 
@@ -587,7 +587,7 @@ contract SLAYRegistryTest is Test, TestSuite {
         registry.approveSlashingFor(service);
     }
 
-    function test_enableSlashing_lifecycle_slashing_notEnabled() public {
+    function test_approveSlashingFor_notEnabled() public {
         vm.prank(operator);
         registry.registerAsOperator("operator.com", "Operator X");
 
@@ -604,7 +604,7 @@ contract SLAYRegistryTest is Test, TestSuite {
         registry.approveSlashingFor(service);
     }
 
-    function test_enableSlashing_lifecycle_noChange() public {
+    function test_approveSlashingFor_notUpdated() public {
         vm.prank(operator);
         registry.registerAsOperator("operator.com", "Operator X");
 

--- a/contracts/test/SLAYRegistry.t.sol
+++ b/contracts/test/SLAYRegistry.t.sol
@@ -600,7 +600,7 @@ contract SLAYRegistryTest is Test, TestSuite {
         registry.registerServiceToOperator(service);
 
         vm.prank(operator);
-        vm.expectRevert("Slashing not enabled");
+        vm.expectRevert("Slashing not updated");
         registry.approveSlashingFor(service);
     }
 
@@ -623,7 +623,7 @@ contract SLAYRegistryTest is Test, TestSuite {
         registry.approveSlashingFor(service);
 
         // No change in slashing parameters
-        vm.expectRevert("Same slashing parameters");
+        vm.expectRevert("Slashing not updated");
         vm.prank(operator);
         registry.approveSlashingFor(service);
     }


### PR DESCRIPTION
#### What this PR does / why we need it:

Refactor `enableSlashing(address)` to `approveSlashingFor(address)` for better clarity of method.