### PR TITLE
chore: allow variable withdrawal delay for service and operator

### DIFF
--- a/contracts/src/SLAYRegistry.sol
+++ b/contracts/src/SLAYRegistry.sol
@@ -258,6 +258,7 @@ contract SLAYRegistry is ISLAYRegistry, Initializable, UUPSUpgradeable, OwnableU
                 "Operator withdrawal delay must be more than or equal to active service's minimum withdrawal delay"
             );
 
+            // unchecked because we are iterating over a fixed length array, not more than {_maxActiveRelationships}.
             unchecked {
                 ++i;
             }
@@ -432,6 +433,7 @@ contract SLAYRegistry is ISLAYRegistry, Initializable, UUPSUpgradeable, OwnableU
                 "Service's minimum withdrawal delay must be less than or equal to active operator's withdrawal delay"
             );
 
+            // unchecked because we are iterating over a fixed length array, not more than {_maxActiveRelationships}.
             unchecked {
                 ++i;
             }

--- a/contracts/src/SLAYRegistry.sol
+++ b/contracts/src/SLAYRegistry.sol
@@ -445,6 +445,7 @@ contract SLAYRegistry is ISLAYRegistry, Initializable, UUPSUpgradeable, OwnableU
         emit MinWithdrawalDelayUpdated(_msgSender(), delay);
     }
 
+    /// @inheritdoc ISLAYRegistry
     function getMinWithdrawalDelay(address service) external view returns (uint32) {
         return _services[service].minWithdrawalDelay;
     }

--- a/contracts/src/SLAYRegistry.sol
+++ b/contracts/src/SLAYRegistry.sol
@@ -422,7 +422,7 @@ contract SLAYRegistry is ISLAYRegistry, Initializable, UUPSUpgradeable, OwnableU
     function setMinWithdrawalDelay(uint32 delay) external whenNotPaused onlyService(_msgSender()) {
         require(delay > 0, "Delay must be more than 0");
 
-        // checks for each of its active operators if their withdrawal delay is less than the new minimum delay.this
+        // checks for each of its active operators if their withdrawal delay is less than the new minimum delay
         EnumerableSet.AddressSet storage activeOperators = _servicesActiveRelationships[_msgSender()];
         uint256 activeOperatorsCount = activeOperators.length();
         for (uint256 i = 0; i < activeOperatorsCount;) {
@@ -437,7 +437,7 @@ contract SLAYRegistry is ISLAYRegistry, Initializable, UUPSUpgradeable, OwnableU
             }
         }
 
-        // If all checks pass, set the new minimum delay for the service.
+        // If all checks pass, set the new minimum delay for the service
         _services[_msgSender()].minWithdrawalDelay = delay;
 
         emit MinWithdrawalDelayUpdated(_msgSender(), delay);

--- a/contracts/src/interface/ISLAYRegistry.sol
+++ b/contracts/src/interface/ISLAYRegistry.sol
@@ -10,15 +10,16 @@ interface ISLAYRegistry {
         /// @dev Id of the slash parameter for the service. Stored in {_slashParameters} array.
         /// If slashing is disabled, this will be 0.
         uint32 slashParameterId;
-        /// @dev The number of operators actively registered to this service.
-        uint8 activeOperatorsCount;
+        /// @dev the minimum withdrawal delay operators must have to be actively registered to this service.
+        uint32 minWithdrawalDelay;
     }
 
     struct Operator {
         /// @dev Whether the operator is registered.
         bool registered;
-        /// @dev The number of services actively registered to this operator.
-        uint8 activeServicesCount;
+        /// @dev The withdrawal delay in seconds before the stakes can be withdrawn from the vault.
+        /// By default, this will be {DEFAULT_WITHDRAWAL_DELAY} (7 days).
+        uint32 withdrawalDelay;
     }
 
     /**
@@ -99,6 +100,13 @@ interface ISLAYRegistry {
      * @param delay The new withdrawal delay in seconds.
      */
     event WithdrawalDelayUpdated(address indexed operator, uint32 delay);
+
+    /**
+     * @dev Emitted when a service updates the minimum withdrawal delay.
+     * @param service The address of the service setting the delay.
+     * @param delay The new minimum withdrawal delay in seconds.
+     */
+    event MinWithdrawalDelayUpdated(address indexed service, uint32 delay);
 
     /**
      * @dev Emitted when {SlashParameter} for a service is updated.
@@ -231,7 +239,6 @@ interface ISLAYRegistry {
 
     /**
      * @notice Get the withdrawal delay for an operator's vault.
-     * @dev If the delay is not set, it returns the default delay of 7 days.
      * @param operator The address of the operator.
      * @return uint32 The withdrawal delay in seconds.
      */
@@ -303,4 +310,18 @@ interface ISLAYRegistry {
         external
         view
         returns (SlashParameter memory);
+
+    /**
+     * @dev Set the minimum withdrawal delay for service. All of the service's active operators must respect this delay, else revert.
+     * This function can only be called by the service.
+     * @param delay The new minimum withdrawal delay in seconds.
+     */
+    function setMinWithdrawalDelay(uint32 delay) external;
+
+    /**
+     * @dev Get the minimum withdrawal delay for a service.
+     * @param service The address of the service.
+     * @return uint32 The minimum withdrawal delay in seconds.
+     */
+    function getMinWithdrawalDelay(address service) external view returns (uint32);
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
Changes:
1. move `_withdrawalDelay` state into `Operator` struct
2. introduce 2 mappings `_operatorsActiveRelationships` and `_servicesActiveRelationships`
3. removed `activeOperatorsCount` and `activeServicesCount` in favour of the above
4. add checks whenever, `operator` or `service` changes their withdrawal delay
5. set operator's default withdrawal delay on first registration `operator.withdrawalDelay = DEFAULT_WITHDRAWAL_DELAY`


<!-- remove if not applicable -->
Closes SL-545