### PR TITLE
feat: max vaults per operator

### DIFF
--- a/contracts/script/Deployment.s.sol
+++ b/contracts/script/Deployment.s.sol
@@ -46,7 +46,7 @@ contract DeploymentScript is Script {
 
         Core.validateUpgrade("SLAYRouterV2.sol:SLAYRouterV2", opts);
         address routerImpl = address(new SLAYRouterV2(registry));
-        UnsafeUpgrades.upgradeProxy(address(router), routerImpl, "");
+        UnsafeUpgrades.upgradeProxy(address(router), routerImpl, abi.encodeCall(SLAYRouterV2.initialize, ()));
 
         Core.validateUpgrade("SLAYRegistryV2.sol:SLAYRegistryV2", opts);
         address registryImpl = address(new SLAYRegistryV2(router));

--- a/contracts/src/SLAYRegistryV2.sol
+++ b/contracts/src/SLAYRegistryV2.sol
@@ -6,7 +6,7 @@ import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Own
 import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {Checkpoints} from "@openzeppelin/contracts/utils/structs/Checkpoints.sol";
-import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 import {SLAYRouterV2} from "./SLAYRouterV2.sol";
 import {RelationshipV2} from "./RelationshipV2.sol";
@@ -54,18 +54,6 @@ contract SLAYRegistryV2 is ISLAYRegistryV2, Initializable, UUPSUpgradeable, Owna
     uint8 private _maxActiveRelationships;
 
     /**
-     * @dev Initializes SLAYRegistryV2 contract.
-     * Set up slash parameters array to allow the first service to register with a valid ID.
-     * As `0` is considered as "no slashing enabled" and is used to disable slashing.
-     * Instead of using offset, this is cleaner and less prone to errors.
-     */
-    function initialize() public reinitializer(2) {
-        // Push an empty slash parameter to the array to ensure that the first service can register with a valid ID.
-        _slashParameters.push();
-        _maxActiveRelationships = 5;
-    }
-
-    /**
      * @dev Modifier to check if the provided account is a registered service.
      * Reverts with `ServiceNotFound` if the account is not registered as a service.
      */
@@ -100,6 +88,19 @@ contract SLAYRegistryV2 is ISLAYRegistryV2, Initializable, UUPSUpgradeable, Owna
     constructor(SLAYRouterV2 router_) {
         router = router_;
         _disableInitializers();
+    }
+
+    /**
+     * @dev Initializes SLAYRegistryV2 contract.
+     * Set up slash parameters array to allow the first service to register with a valid ID.
+     * As `0` is considered as "no slashing enabled" and is used to disable slashing.
+     * Instead of using offset, this is cleaner and less prone to errors.
+     */
+    function initialize() public reinitializer(2) {
+        // Push an empty slash parameter to the array to ensure that the first service can register with a valid ID.
+        _slashParameters.push();
+        // Default max active relationships is set to 5.
+        _maxActiveRelationships = 5;
     }
 
     /**

--- a/contracts/src/SLAYRouterV2.sol
+++ b/contracts/src/SLAYRouterV2.sol
@@ -73,6 +73,17 @@ contract SLAYRouterV2 is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pau
     }
 
     /// @inheritdoc ISLAYRouterV2
+    function getMaxVaultsPerOperator() external view returns (uint8) {
+        return _maxVaultsPerOperator;
+    }
+
+    /// @inheritdoc ISLAYRouterV2
+    function setMaxVaultsPerOperator(uint8 count) external onlyOwner {
+        require(count > _maxVaultsPerOperator, "Must be greater than current");
+        _maxVaultsPerOperator = count;
+    }
+
+    /// @inheritdoc ISLAYRouterV2
     function setVaultWhitelist(address vault_, bool isWhitelisted) external onlyOwner {
         require(whitelisted[vault_] != isWhitelisted, "Vault already in desired state");
 

--- a/contracts/src/SLAYVaultV2.sol
+++ b/contracts/src/SLAYVaultV2.sol
@@ -63,7 +63,7 @@ contract SLAYVaultV2 is
      * See https://build.satlayer.xyz/getting-started/operators for more information.
      * @dev This address is the address of the SatLayer operator that is delegated to manage the vault.
      */
-    address public delegated;
+    address public _delegated;
 
     /// @notice Operator approval status per controller.
     mapping(address controller => mapping(address operator => bool)) internal _isOperator;
@@ -123,7 +123,12 @@ contract SLAYVaultV2 is
         __ERC20_init(name_, symbol_);
         __ERC4626_init(asset_);
         __ERC20Permit_init(name_);
-        delegated = delegated_;
+        _delegated = delegated_;
+    }
+
+    /// @inheritdoc ISLAYVaultV2
+    function delegated() public view override returns (address) {
+        return _delegated;
     }
 
     function decimals() public view override(ERC20Upgradeable, ERC4626Upgradeable, IERC20Metadata) returns (uint8) {
@@ -201,7 +206,7 @@ contract SLAYVaultV2 is
         pendingRedemptionRequest.shares += shares;
 
         // reset the claimableAt to the current time + withdrawalDelay
-        uint32 withdrawalDelay = registry.getWithdrawalDelay(delegated);
+        uint32 withdrawalDelay = registry.getWithdrawalDelay(_delegated);
         pendingRedemptionRequest.claimableAt = block.timestamp + withdrawalDelay;
 
         // update _totalPendingRedemption

--- a/contracts/src/interface/ISLAYRouterV2.sol
+++ b/contracts/src/interface/ISLAYRouterV2.sol
@@ -22,6 +22,18 @@ interface ISLAYRouterV2 {
     //////////////////////////////////////////////////////////////*/
 
     /**
+     * @return The max number of vaults allowed per operator.
+     */
+    function getMaxVaultsPerOperator() external view returns (uint8);
+
+    /**
+     * @dev Update the max number of vaults allowed per operator.
+     * The new value must be greater than the previous value.
+     * @param count The new maximum number of vaults per operator.
+     */
+    function setMaxVaultsPerOperator(uint8 count) external;
+
+    /**
      * @dev Set the individual whitelist status for a SLAYVault.
      * This allows CA owner to control which vaults can be interacted with through the router.
      * For non-granular state/modifier, use {SLAYRouterV2-pause} to pause all vaults.

--- a/contracts/src/interface/ISLAYRouterV2.sol
+++ b/contracts/src/interface/ISLAYRouterV2.sol
@@ -15,16 +15,17 @@ interface ISLAYRouterV2 {
     /**
      * @dev Emitted when the vault whitelist status is updated.
      */
-    event VaultWhitelisted(address indexed vault, bool whitelisted);
+    event VaultWhitelisted(address indexed operator, address vault, bool whitelisted);
 
     /*//////////////////////////////////////////////////////////////
                                 FUNCTIONS
     //////////////////////////////////////////////////////////////*/
 
     /**
-     * Set a individual whitelist status for a vault.
+     * @dev Set the individual whitelist status for a SLAYVault.
      * This allows CA owner to control which vaults can be interacted with through the router.
      * For non-granular state/modifier, use {SLAYRouterV2-pause} to pause all vaults.
+     * When a vault is whitelisted, it can be interacted with through the router.
      *
      * @param vault_ address of the vault to set the whitelist status for.
      * This should be a SLAYVault contract address but isn't "checked" to allow for flexible un-whitelisting of vaults.

--- a/contracts/src/interface/ISLAYVaultV2.sol
+++ b/contracts/src/interface/ISLAYVaultV2.sol
@@ -55,6 +55,14 @@ interface ISLAYVaultV2 is IERC20Metadata, IERC4626, IERC7540Redeem, IERC7540Oper
     //////////////////////////////////////////////////////////////*/
 
     /**
+     * @notice The `delegated` is the address where the vault is delegated to.
+     * This address cannot withdraw assets from the vault.
+     * See https://build.satlayer.xyz/getting-started/operators for more information.
+     * @dev This address is the address of the SatLayer operator that is delegated to manage the vault.
+     */
+    function delegated() external view returns (address);
+
+    /**
      * @notice Returns the total amount of shares pending redemption across all controllers.
      * This is the sum of all shares in pending and claimable redemption requests.
      *

--- a/contracts/test/SLAYRouterV2.t.sol
+++ b/contracts/test/SLAYRouterV2.t.sol
@@ -121,4 +121,33 @@ contract SLAYRouterV2Test is Test, TestSuiteV2 {
 
         assertFalse(router.whitelisted(vault));
     }
+
+    function test_Whitelisted_NewVaultsCanBeAddedAfterRemoval() public {
+        MockERC20 underlying = new MockERC20("Token", "TKN", 18);
+        address[] memory vaults = new address[](10);
+
+        address operator = makeAddr("Operator Y");
+        vm.prank(operator);
+        registry.registerAsOperator("https://example.com", "Operator Y");
+
+        for (uint256 i = 0; i < 10; i++) {
+            vm.prank(operator);
+            vaults[i] = address(vaultFactory.create(underlying));
+
+            vm.prank(owner);
+            router.setVaultWhitelist(vaults[i], true);
+        }
+
+        vm.prank(operator);
+        address newVault = address(vaultFactory.create(underlying));
+        assertFalse(router.whitelisted(newVault));
+
+        vm.prank(owner);
+        router.setVaultWhitelist(vaults[0], false);
+        assertFalse(router.whitelisted(vaults[0]));
+
+        vm.prank(owner);
+        router.setVaultWhitelist(newVault, true);
+        assertTrue(router.whitelisted(newVault));
+    }
 }

--- a/contracts/test/TestSuiteV2.sol
+++ b/contracts/test/TestSuiteV2.sol
@@ -36,7 +36,9 @@ contract TestSuiteV2 is Test {
         );
 
         vm.startPrank(owner);
-        UnsafeUpgrades.upgradeProxy(address(router), address(new SLAYRouterV2(registry)), "");
+        UnsafeUpgrades.upgradeProxy(
+            address(router), address(new SLAYRouterV2(registry)), abi.encodeCall(SLAYRouterV2.initialize, ())
+        );
         UnsafeUpgrades.upgradeProxy(
             address(registry), address(new SLAYRegistryV2(router)), abi.encodeCall(SLAYRegistryV2.initialize, ())
         );


### PR DESCRIPTION
#### What this PR does / why we need it:

- Set max vaults allowed per operator. Enforced with `EnumerableSet.AddressSet`. Stored in     a operator mapping: `mapping(address operator => EnumerableSet.AddressSet)`
- The vault max count can be updated by the owner, but only with a higher value.


Closes SL-611
