### PR TITLE
chore: add mock forwarder contract for guardrail testing

### DIFF
--- a/contracts/test/MockGuardrail.sol
+++ b/contracts/test/MockGuardrail.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// A very simple mock Guardrail contract, this would be replaced with Safe (or similar) contract
+/// in production. In this mock, it only allows the owner to forward calls to other contracts.
+contract MockGuardrail is Ownable {
+    constructor(address initialOwner) Ownable(initialOwner) {}
+
+    function forwardCall(address target, bytes calldata data) external onlyOwner returns (bytes memory returnData) {
+        (bool success, bytes memory _returnData) = target.call(data);
+        require(success, "Forward call failed");
+        return _returnData;
+    }
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

Unlike [bvs-guardrail](https://github.com/satlayer/satlayer-bvs/tree/main/crates/bvs-guardrail) for CW, we don't need such complex mechanisms in solidity due to the rich ecosystem on EVM.

Closes SL-599