### PR TITLE
chore: move _advanceBlockBy to TestSuiteV2

### DIFF
--- a/contracts/test/SLAYRegistryV2.t.sol
+++ b/contracts/test/SLAYRegistryV2.t.sol
@@ -253,11 +253,6 @@ contract SLAYRegistryV2Test is Test, TestSuiteV2 {
         registry.deregisterServiceFromOperator(service);
     }
 
-    function _advanceBlockBy(uint256 newHeight) internal {
-        vm.roll(block.number + newHeight);
-        vm.warp(block.timestamp + (12 * newHeight));
-    }
-
     function test_getRelationshipStatusAt() public {
         {
             vm.prank(service);

--- a/contracts/test/SLAYRouterV2.t.sol
+++ b/contracts/test/SLAYRouterV2.t.sol
@@ -203,11 +203,6 @@ contract SLAYRouterV2Test is Test, TestSuiteV2 {
         assertEq(router.getMaxVaultsPerOperator(), 15);
     }
 
-    function _advanceBlockBy(uint256 newHeight) internal {
-        vm.roll(block.number + newHeight);
-        vm.warp(block.timestamp + (12 * newHeight));
-    }
-
     function test_slashRequest_ideal() public {
         _advanceBlockBy(20000000);
         address operator = makeAddr("Operator X");

--- a/contracts/test/TestSuiteV2.sol
+++ b/contracts/test/TestSuiteV2.sol
@@ -44,4 +44,9 @@ contract TestSuiteV2 is Test {
         );
         vm.stopPrank();
     }
+
+    function _advanceBlockBy(uint256 blocks) internal {
+        vm.roll(block.number + blocks);
+        vm.warp(block.timestamp + (12 * blocks));
+    }
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

This is shared by many test cases, abstracting and moving to the TestSuite contract.