### PR TITLE
chore: refactor lock slashing

### DIFF
--- a/contracts/src/SLAYRouterV2.sol
+++ b/contracts/src/SLAYRouterV2.sol
@@ -258,7 +258,7 @@ contract SLAYRouterV2 is
             revert ISLAYSlashingV2.LockSlashingResolutionNotReached();
         }
 
-        // Iterate through the vaults and call slashLock on each of them
+        // Iterate through the vaults and call lockSlashing on each of them
         EnumerableSet.AddressSet storage operatorVaults = _operatorVaults[requestInfo.request.operator];
         uint256 vaultsCount = operatorVaults.length();
         for (uint256 i = 0; i < vaultsCount;) {
@@ -268,8 +268,8 @@ contract SLAYRouterV2 is
             // calculate the slash amount from mbips
             uint256 slashAmount = Math.mulDiv(vault.totalAssets(), requestInfo.request.mbips, 10_000_000);
 
-            // Call the slashLock function on the vault
-            vault.slashLock(slashAmount);
+            // Call the lockSlashing function on the vault
+            vault.lockSlashing(slashAmount);
 
             // Store the locked assets in the router for further processing
             _lockedAssets[slashId].push(ISLAYSlashingV2.LockedAssets({amount: slashAmount, vault: vaultAddress}));

--- a/contracts/src/SLAYVaultV2.sol
+++ b/contracts/src/SLAYVaultV2.sol
@@ -440,13 +440,13 @@ contract SLAYVaultV2 is
     }
 
     /// @inheritdoc ISLAYVaultV2
-    function slashLock(uint256 amount) external override {
+    function lockSlashing(uint256 amount) external override {
         if (_msgSender() != address(router)) {
             revert NotRouter();
         }
 
         SafeERC20.safeTransfer(IERC20(asset()), address(router), amount);
 
-        emit SlashLock(amount);
+        emit SlashingLocked(amount);
     }
 }

--- a/contracts/src/interface/ISLAYSlashingV2.sol
+++ b/contracts/src/interface/ISLAYSlashingV2.sol
@@ -8,6 +8,10 @@ pragma solidity ^0.8.0;
  * To be implemented on the SLAYRouter, but separated to allow for separate of slashing related concerns.
  */
 interface ISLAYSlashingV2 {
+    /*//////////////////////////////////////////////////////////////
+                                ERRORS
+    //////////////////////////////////////////////////////////////*/
+
     error LockSlashingNotAuthorized();
 
     error LockSlashingStatusIsNotPending();
@@ -15,6 +19,10 @@ interface ISLAYSlashingV2 {
     error LockSlashingExpired();
 
     error LockSlashingResolutionNotReached();
+
+    /*//////////////////////////////////////////////////////////////
+                                EVENTS
+    //////////////////////////////////////////////////////////////*/
 
     /**
      * @dev Emitted when a new slash request is created.
@@ -112,6 +120,10 @@ interface ISLAYSlashingV2 {
         /// The originating vault address from which the assets were slashed.
         address vault;
     }
+
+    /*//////////////////////////////////////////////////////////////
+                                FUNCTIONS
+    //////////////////////////////////////////////////////////////*/
 
     /**
      * @dev Get the current active slashing request for given service operator pair.

--- a/contracts/src/interface/ISLAYVaultV2.sol
+++ b/contracts/src/interface/ISLAYVaultV2.sol
@@ -49,7 +49,7 @@ interface ISLAYVaultV2 is IERC20Metadata, IERC4626, IERC7540Operator, IERC7540Re
                                 EVENTS
     //////////////////////////////////////////////////////////////*/
 
-    event SlashLock(uint256 amount);
+    event SlashingLocked(uint256 amount);
 
     /// @notice Struct representing a redeem request.
     struct RedeemRequestStruct {
@@ -92,5 +92,5 @@ interface ISLAYVaultV2 is IERC20Metadata, IERC4626, IERC7540Operator, IERC7540Re
      * @dev only callable by router
      * @param amount The amount of underlying asset to move to the router.
      */
-    function slashLock(uint256 amount) external;
+    function lockSlashing(uint256 amount) external;
 }

--- a/contracts/test/SLAYVaultV2.t.sol
+++ b/contracts/test/SLAYVaultV2.t.sol
@@ -691,7 +691,7 @@ contract SLAYVaultV2Test is Test, TestSuiteV2 {
         vm.stopPrank();
     }
 
-    function test_slashLock() public {
+    function test_lockSlashing() public {
         vm.prank(operator);
         SLAYVaultV2 vault = vaultFactory.create(underlying);
 
@@ -718,7 +718,7 @@ contract SLAYVaultV2Test is Test, TestSuiteV2 {
 
         // slash lock called by router
         vm.prank(address(router));
-        vault.slashLock(20 * underlyingMinorUnit);
+        vault.lockSlashing(20 * underlyingMinorUnit);
 
         // assert that vault balance is decreased by the slash amount
         assertEq(underlying.balanceOf(address(vault)), 80 * underlyingMinorUnit); // depositAmount - slashAmount
@@ -727,7 +727,7 @@ contract SLAYVaultV2Test is Test, TestSuiteV2 {
         assertEq(underlying.balanceOf(address(router)), 20 * underlyingMinorUnit); // slashAmount
     }
 
-    function test_revert_slashLock() public {
+    function test_revert_lockSlashing() public {
         vm.prank(operator);
         SLAYVaultV2 vault = vaultFactory.create(underlying);
 
@@ -738,18 +738,18 @@ contract SLAYVaultV2Test is Test, TestSuiteV2 {
         router.setVaultWhitelist(address(vault), true);
         vm.stopPrank();
 
-        // Attempt to call slashLock from a non-router address
+        // Attempt to call lockSlashing from a non-router address
         vm.prank(owner);
         vm.expectRevert(abi.encodeWithSelector(ISLAYVaultV2.NotRouter.selector));
-        vault.slashLock(20 * underlyingMinorUnit);
+        vault.lockSlashing(20 * underlyingMinorUnit);
 
-        // Attempt to call slashLock with zero balance
+        // Attempt to call lockSlashing with zero balance
         vm.prank(address(router));
         vm.expectRevert(
             abi.encodeWithSelector(
                 IERC20Errors.ERC20InsufficientBalance.selector, address(vault), 0, 20 * underlyingMinorUnit
             )
         );
-        vault.slashLock(20 * underlyingMinorUnit);
+        vault.lockSlashing(20 * underlyingMinorUnit);
     }
 }

--- a/contracts/test/SLAYVaultV2.t.sol
+++ b/contracts/test/SLAYVaultV2.t.sol
@@ -718,6 +718,8 @@ contract SLAYVaultV2Test is Test, TestSuiteV2 {
 
         // slash lock called by router
         vm.prank(address(router));
+        vm.expectEmit();
+        emit ISLAYVaultV2.SlashingLocked(20 * underlyingMinorUnit);
         vault.lockSlashing(20 * underlyingMinorUnit);
 
         // assert that vault balance is decreased by the slash amount


### PR DESCRIPTION
#### What this PR does / why we need it:

1. rename to `lockSlashing` for vault's fn
2. update the vault events as well to `SlashingLocked`