### PR TITLE
chore: script for virtual testnet deployment

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -10,11 +10,7 @@ build_info = true
 extra_output = ["storageLayout"]
 
 [rpc_endpoints]
-mainnet = "https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
-sepolia = "https://eth-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
-holesky = "https://eth-holesky.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
+slaynet = "${TENDERLY_RPC_URL}"
 
 [etherscan]
-mainnet = { chain = 1, key = "${ETHERSCAN_API_KEY}" }
-sepolia = { chain = 11155111, key = "${ETHERSCAN_API_KEY}" }
-holesky = { chain = 17000, key = "${ETHERSCAN_API_KEY}" }
+slaynet = { chain = 83766589, key = "${TENDERLY_ACCESS_KEY}", url = "${TENDERLY_RPC_URL}/verify/etherscan" }

--- a/contracts/script/Slaynet.s.sol
+++ b/contracts/script/Slaynet.s.sol
@@ -12,7 +12,7 @@ import {UnsafeUpgrades} from "@openzeppelin/foundry-upgrades/Upgrades.sol";
 import {Options} from "@openzeppelin/foundry-upgrades/Options.sol";
 import {Core} from "@openzeppelin/foundry-upgrades/internal/Core.sol";
 
-/// @title Deployment Script for Initialization of SatLayer Protocol
+/// @title Slaynet Deployment Script for Initialization of SatLayer Protocol
 /// @dev For deployment, we use the OpenZeppelin `UnsafeUpgrades` library to deploy UUPS proxies and beacons.
 /// Although it is "unsafe" and not recommended for production, the "safe version" does not support non-empty constructor arguments.
 /// This "unsafe" allow us to use the constructor arguments in the implementation contracts.
@@ -20,12 +20,17 @@ import {Core} from "@openzeppelin/foundry-upgrades/internal/Core.sol";
 /// After which we can upgrade the proxies to the actual implementations.
 /// However, to ensure the safety of the deployment, we validate each implementation (just as the "safe" version does)
 /// to ensure the implementation is valid and does not contain any unsafe code.
-contract DeploymentScript is Script {
+contract SlaynetDeployment is Script {
     Options public opts;
-    address public owner = address(0x011);
 
+    /// export PRIVATE_KEY=
+    /// export TENDERLY_RPC_URL=
+    /// export TENDERLY_ACCESS_KEY=
+    /// forge script SlaynetDeployment --rpc-url slaynet --slow --broadcast --verify
     function run() public {
-        vm.startBroadcast(owner);
+        uint256 pk = vm.envUint("PRIVATE_KEY");
+        address owner = vm.addr(pk);
+        vm.startBroadcast(pk);
 
         // Create the initial implementation contract and deploy the proxies for router and registry
         Core.validateImplementation("InitialImpl.sol:InitialImpl", opts);
@@ -46,10 +51,10 @@ contract DeploymentScript is Script {
 
         Core.validateUpgrade("SLAYRouterV2.sol:SLAYRouterV2", opts);
         address routerImpl = address(new SLAYRouterV2(registry));
-        UnsafeUpgrades.upgradeProxy(address(router), routerImpl, abi.encodeCall(SLAYRouterV2.initialize, ()));
+        UnsafeUpgrades.upgradeProxy(address(router), routerImpl, abi.encodeCall(SLAYRouterV2.initialize2, ()));
 
         Core.validateUpgrade("SLAYRegistryV2.sol:SLAYRegistryV2", opts);
         address registryImpl = address(new SLAYRegistryV2(router));
-        UnsafeUpgrades.upgradeProxy(address(registry), registryImpl, abi.encodeCall(SLAYRegistryV2.initialize, ()));
+        UnsafeUpgrades.upgradeProxy(address(registry), registryImpl, abi.encodeCall(SLAYRegistryV2.initialize2, ()));
     }
 }

--- a/contracts/src/SLAYRouterV2.sol
+++ b/contracts/src/SLAYRouterV2.sol
@@ -11,6 +11,8 @@ import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
+import {InitialImpl} from "./InitialImpl.sol";
+
 import {ISLAYRegistryV2} from "./interface/ISLAYRegistryV2.sol";
 import {ISLAYRouterV2} from "./interface/ISLAYRouterV2.sol";
 import {ISLAYVaultV2} from "./interface/ISLAYVaultV2.sol";
@@ -28,6 +30,7 @@ contract SLAYRouterV2 is
     UUPSUpgradeable,
     OwnableUpgradeable,
     PausableUpgradeable,
+    InitialImpl,
     ISLAYRouterV2,
     ISLAYRouterSlashingV2
 {
@@ -92,29 +95,8 @@ contract SLAYRouterV2 is
      * @dev Initializes SLAYRouterV2 contract.
      * Set the default max vaults per operator to 10.
      */
-    function initialize() public reinitializer(2) {
+    function initialize2() public reinitializer(2) {
         _maxVaultsPerOperator = 10;
-    }
-
-    /**
-     * @dev Authorizes an upgrade to a new implementation.
-     * This function is required by UUPS and restricts upgradeability to the contract owner.
-     * @param newImplementation The address of the new contract implementation.
-     */
-    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
-
-    /**
-     * @dev Pauses the contract, all SLAYVaults will also be paused.
-     */
-    function pause() external onlyOwner {
-        _pause();
-    }
-
-    /**
-     * @dev Unpauses the contract, all SLAYVaults will also be unpaused.
-     */
-    function unpause() external onlyOwner {
-        _unpause();
     }
 
     /// @inheritdoc ISLAYRouterV2

--- a/contracts/test/TestSuiteV2.sol
+++ b/contracts/test/TestSuiteV2.sol
@@ -37,10 +37,10 @@ contract TestSuiteV2 is Test {
 
         vm.startPrank(owner);
         UnsafeUpgrades.upgradeProxy(
-            address(router), address(new SLAYRouterV2(registry)), abi.encodeCall(SLAYRouterV2.initialize, ())
+            address(router), address(new SLAYRouterV2(registry)), abi.encodeCall(SLAYRouterV2.initialize2, ())
         );
         UnsafeUpgrades.upgradeProxy(
-            address(registry), address(new SLAYRegistryV2(router)), abi.encodeCall(SLAYRegistryV2.initialize, ())
+            address(registry), address(new SLAYRegistryV2(router)), abi.encodeCall(SLAYRegistryV2.initialize2, ())
         );
         vm.stopPrank();
     }


### PR DESCRIPTION
#### What this PR does / why we need it:

This script enables "Slaynet" virtual testnet deployment through `forge script SlaynetDeployment ...`.

For this change, we also moved `initialize` to `initialize2` as they are `reinitializer`. And to properly reflect their Initial "v1" state, both `SLAYRouter` and `SLAYRegistry` extend `InitialImpl`. This means, `_authorizeUpgrade`, `pause` and `unpause` is removed and will be provided by the `InitialImpl`.



Closes SL-547
