### PR TITLE
chore: document and refactor SLAYVaultFactory

### DIFF
--- a/contracts/src/SLAYBase.sol
+++ b/contracts/src/SLAYBase.sol
@@ -18,8 +18,9 @@ import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/Pau
  * DO NOT add any state variables as this is an empty implementation.
  *
  * Extended by:
- * - SLAYRegistryV2.sol
- * - SLAYRouterV2.sol
+ * - SLAYRegistry
+ * - SLAYRouter
+ * - SLAYVaultFactory
  */
 contract SLAYBase is Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
     /// @custom:oz-upgrades-unsafe-allow constructor

--- a/contracts/src/SLAYVaultFactoryV2.sol
+++ b/contracts/src/SLAYVaultFactoryV2.sol
@@ -10,6 +10,9 @@ import {BeaconProxy} from "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol"
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+
+import {SLAYBase} from "./SLAYBase.sol";
+
 import {SLAYVaultV2} from "./SLAYVaultV2.sol";
 import {ISLAYRegistryV2} from "./interface/ISLAYRegistryV2.sol";
 import {ISLAYVaultFactoryV2} from "./interface/ISLAYVaultFactoryV2.sol";
@@ -24,6 +27,7 @@ contract SLAYVaultFactoryV2 is
     UUPSUpgradeable,
     OwnableUpgradeable,
     PausableUpgradeable,
+    SLAYBase,
     ISLAYVaultFactoryV2
 {
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
@@ -44,24 +48,6 @@ contract SLAYVaultFactoryV2 is
         registry = registry_;
         _disableInitializers();
     }
-
-    /**
-     * @dev Initializes the contract and sets the initial owner.
-     *
-     * @param initialOwner The address to be set as the initial owner.
-     */
-    function initialize(address initialOwner) public initializer {
-        __Ownable_init(initialOwner);
-        __UUPSUpgradeable_init();
-        __Pausable_init();
-    }
-
-    /**
-     * @dev Authorizes an upgrade to a new implementation.
-     * This function is required by UUPS and restricts upgradeability to the contract owner.
-     * @param newImplementation The address of the new contract implementation.
-     */
-    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
 
     /// @dev Throws if the sender is not the operator.
     function _checkOperator(address account) internal view virtual {

--- a/contracts/src/interface/ISLAYVaultFactoryV2.sol
+++ b/contracts/src/interface/ISLAYVaultFactoryV2.sol
@@ -28,6 +28,9 @@ interface ISLAYVaultFactoryV2 {
      * @notice For operator (the caller) to create a new SLAYVault instance using the Beacon proxy pattern.
      * The IERC20Metadata is used to initialize the vault with its name and symbol prefixed.
      * This self-serve function allows operators to create new vaults without needing to go through the owner.
+     * For example an operator can create a vault for a new token that is IERC20Metadata compliant.
+     * Given the {ERC20.name()} is Token and {ERC20.symbol()} is TKN,
+     * the vault will be initialized with the name "SatLayer Token" and symbol "satTKN".
      *
      * @param asset The ERC20Metadata asset to be used in the vault.
      * @return The newly created SLAYVault instance.
@@ -38,6 +41,7 @@ interface ISLAYVaultFactoryV2 {
      * @notice For owner to create a new SLAYVault instance using the Beacon proxy pattern.
      * This function allows the owner to create a vault with a custom operator, name, and symbol.
      * This scenario is mainly used for creating vaults that aren't IERC20Metadata compliant.
+     * For example, an owner can create a vault for a custom token that does not implement the IERC20Metadata interface.
      *
      * @param asset The ERC20 asset to be used in the vault.
      * @param operator The address that will be the operator of the vault.


### PR DESCRIPTION
#### What this PR does / why we need it:

As titled, this PR cleans up the documentation and testing for SLAYVaultFactory.
For consistency, we will use `SLAYBase` for `SLAYVaultFactory`.

I've also updated "Slaynet.s.sol" script to `Deployment.s.sol` so that what we deploy into testnet is the same as mainnet to prevent any unnecessary drift in code.


Closes SL-633