### PR TITLE
chore: update merkle rewards hashing to keccak256

### DIFF
--- a/contracts/src/MerkleProof.sol
+++ b/contracts/src/MerkleProof.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+
+library MerkleProof {
+    error InvalidProofLength();
+
+    /**
+     * @dev this function verifies a Merkle proof for a given leaf, index, and total number of leaves.
+     * It computes the Merkle root from the proof and checks if it matches the provided root.
+     * @param proof The Merkle proof containing sibling hashes that are needed to compute the root.
+     * @param root The expected Merkle root to verify against.
+     * @param leaf The leaf node to verify inclusion in the Merkle tree.
+     * @param index The index of the leaf in the Merkle tree.
+     * @param totalLeaves The total number of leaves in the Merkle tree.
+     * @return bool indicating whether the proof is valid or not.
+     */
+    function verify(bytes32[] memory proof, bytes32 root, bytes32 leaf, uint256 index, uint256 totalLeaves)
+        internal
+        pure
+        returns (bool)
+    {
+        return processProof(proof, leaf, index, totalLeaves) == root;
+    }
+
+    /**
+     * @dev this function processes a Merkle proof to compute the Merkle root from a given leaf and its index.
+     * It also does sanity checks on the proof length and the total number of leaves to prevent second pre-image attacks.
+     * This function assumes that the Merkle tree is built using the keccak256 hash function.
+     * This function assumes that the node hash used is non-commutative, meaning that the order of the hashes matters.
+     * @param proof The Merkle proof containing sibling hashes that are needed to compute the root.
+     * @param leaf The leaf node to verify inclusion in the Merkle tree.
+     * @param index The index of the leaf in the Merkle tree.
+     * @param totalLeaves The total number of leaves in the Merkle tree.
+     * @return The computed Merkle root.
+     */
+    function processProof(bytes32[] memory proof, bytes32 leaf, uint256 index, uint256 totalLeaves)
+        internal
+        pure
+        returns (bytes32)
+    {
+        // treeHeight is log2(totalLeaves), so the proof length must match the height of the tree
+        uint256 treeHeight = Math.log2(totalLeaves, Math.Rounding.Ceil);
+        if (treeHeight != proof.length) revert InvalidProofLength();
+
+        bytes32 computedHash = leaf;
+        // hash the node with the proof to rebuild the Merkle root
+        for (uint256 i = 1; i <= proof.length; i++) {
+            if (index % 2 == 0) {
+                // if index is even, then computedHash is a left sibling
+                assembly {
+                    mstore(0x00, computedHash)
+                    mstore(0x20, mload(add(proof, mul(i, 0x20))))
+                    computedHash := keccak256(0x00, 0x40)
+                    index := div(index, 2)
+                }
+            } else {
+                // if index is odd, then computedHash is a right sibling
+                assembly {
+                    mstore(0x00, mload(add(proof, mul(i, 0x20))))
+                    mstore(0x20, computedHash)
+                    computedHash := keccak256(0x00, 0x40)
+                    index := div(index, 2)
+                }
+            }
+        }
+        return computedHash;
+    }
+}

--- a/contracts/test/MerkleProof.t.sol
+++ b/contracts/test/MerkleProof.t.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+
+import {Test, console} from "forge-std/Test.sol";
+import {MerkleProof} from "../src/MerkleProof.sol";
+
+contract MerkleProofTest is Test {
+    function test_verify() public {
+        bytes32 leaf = keccak256(
+            abi.encodePacked(
+                keccak256(abi.encodePacked("bbn1eywhap4hwzd3lpwee4hgt2rh0rjlsq6dqck894100000000000000000"))
+            )
+        );
+
+        bytes32[] memory proof = new bytes32[](1);
+        proof[0] = bytes32(abi.encodePacked(hex"614a2406c3e74dca5a75c5429158a486c9d0d9eb5efbea928cc309beb6b3fce6"));
+
+        bytes32 root = bytes32(abi.encodePacked(hex"4b83dc8ecaa7a9d69ac8a7c12718eed8639e1ba1a1b30a51741ccfd020255cec"));
+
+        assertEq(MerkleProof.verify(proof, root, leaf, 1, 2), true);
+    }
+
+    function test_verify_complex() public {
+        bytes32 leaf = keccak256(
+            abi.encodePacked(keccak256(abi.encodePacked("bbn1j8k7l6m5n4o3p2q1r0s9t8u7v6w5x4y3z2a1b600000000000000000")))
+        );
+
+        bytes32[] memory proof = new bytes32[](4);
+        proof[0] = bytes32(abi.encodePacked(hex"c99659b6e1c7a2df5c6ce352241ef43152f1fed170d2fdc8d67ee2c47d9f26a5"));
+        proof[1] = bytes32(abi.encodePacked(hex"662362a44a545cd42cdf7e9c1cfc7eb3b55ebb3af452e1bd516d7329f0f490fa"));
+        proof[2] = bytes32(abi.encodePacked(hex"8a12e22ffa7163c5249a71f3df41704c2e2ccf8bab02dec02fc8db2740f51256"));
+        proof[3] = bytes32(abi.encodePacked(hex"afb5ee202bbe624a5d933b1eda40f5bf6bcd6674dbf1af8eea698ae023c104fe"));
+
+        bytes32 root = bytes32(abi.encodePacked(hex"1c8dd9ca252d7eb9bf1cccb9ab587e9a1dccca4c7474bb8739c0e5218964a2b4"));
+
+        assertEq(MerkleProof.verify(proof, root, leaf, 7, 9), true);
+    }
+
+    function test_verify_complex2() public {
+        bytes32 leaf = keccak256(
+            abi.encodePacked(keccak256(abi.encodePacked("bbn1j8k7l6m5n4o3p2q1r0s9t8u7v6w5x4y3z2a1b600000000000000000")))
+        );
+
+        bytes32[] memory proof = new bytes32[](4);
+        proof[0] = bytes32(abi.encodePacked(hex"c99659b6e1c7a2df5c6ce352241ef43152f1fed170d2fdc8d67ee2c47d9f26a5"));
+        proof[1] = bytes32(abi.encodePacked(hex"662362a44a545cd42cdf7e9c1cfc7eb3b55ebb3af452e1bd516d7329f0f490fa"));
+        proof[2] = bytes32(abi.encodePacked(hex"8a12e22ffa7163c5249a71f3df41704c2e2ccf8bab02dec02fc8db2740f51256"));
+        proof[3] = bytes32(abi.encodePacked(hex"afb5ee202bbe624a5d933b1eda40f5bf6bcd6674dbf1af8eea698ae023c104fe"));
+
+        bytes32 root = bytes32(abi.encodePacked(hex"1c8dd9ca252d7eb9bf1cccb9ab587e9a1dccca4c7474bb8739c0e5218964a2b4"));
+
+        assertEq(MerkleProof.verify(proof, root, leaf, 7, 9), true);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function test_revert_processProof_wrongTotalLeaves() public {
+        bytes32 leaf = keccak256(
+            abi.encodePacked(keccak256(abi.encodePacked("bbn1j8k7l6m5n4o3p2q1r0s9t8u7v6w5x4y3z2a1b600000000000000000")))
+        );
+
+        bytes32[] memory proof = new bytes32[](4);
+        proof[0] = bytes32(abi.encodePacked(hex"c99659b6e1c7a2df5c6ce352241ef43152f1fed170d2fdc8d67ee2c47d9f26a5"));
+        proof[1] = bytes32(abi.encodePacked(hex"662362a44a545cd42cdf7e9c1cfc7eb3b55ebb3af452e1bd516d7329f0f490fa"));
+        proof[2] = bytes32(abi.encodePacked(hex"8a12e22ffa7163c5249a71f3df41704c2e2ccf8bab02dec02fc8db2740f51256"));
+        proof[3] = bytes32(abi.encodePacked(hex"afb5ee202bbe624a5d933b1eda40f5bf6bcd6674dbf1af8eea698ae023c104fe"));
+
+        bytes32 root = bytes32(abi.encodePacked(hex"1c8dd9ca252d7eb9bf1cccb9ab587e9a1dccca4c7474bb8739c0e5218964a2b4"));
+
+        // expect revert because the total number of leaves is not correct
+        vm.expectRevert(MerkleProof.InvalidProofLength.selector);
+        MerkleProof.verify(proof, root, leaf, 7, 8); // totalLeaves should be 9, but we pass 8
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function test_revert_processProof_wrongProofLength() public {
+        bytes32 leaf = keccak256(
+            abi.encodePacked(keccak256(abi.encodePacked("bbn1j8k7l6m5n4o3p2q1r0s9t8u7v6w5x4y3z2a1b600000000000000000")))
+        );
+
+        bytes32[] memory proof = new bytes32[](3);
+        proof[0] = bytes32(abi.encodePacked(hex"c99659b6e1c7a2df5c6ce352241ef43152f1fed170d2fdc8d67ee2c47d9f26a5"));
+        proof[1] = bytes32(abi.encodePacked(hex"662362a44a545cd42cdf7e9c1cfc7eb3b55ebb3af452e1bd516d7329f0f490fa"));
+        proof[2] = bytes32(abi.encodePacked(hex"8a12e22ffa7163c5249a71f3df41704c2e2ccf8bab02dec02fc8db2740f51256"));
+
+        bytes32 root = bytes32(abi.encodePacked(hex"1c8dd9ca252d7eb9bf1cccb9ab587e9a1dccca4c7474bb8739c0e5218964a2b4"));
+
+        // expect revert because the proof length must be 4
+        vm.expectRevert(MerkleProof.InvalidProofLength.selector);
+        MerkleProof.verify(proof, root, leaf, 7, 9);
+    }
+}

--- a/contracts/test/MerkleProof.t.sol
+++ b/contracts/test/MerkleProof.t.sol
@@ -38,22 +38,6 @@ contract MerkleProofTest is Test {
         assertEq(MerkleProof.verify(proof, root, leaf, 7, 9), true);
     }
 
-    function test_verify_complex2() public {
-        bytes32 leaf = keccak256(
-            abi.encodePacked(keccak256(abi.encodePacked("bbn1j8k7l6m5n4o3p2q1r0s9t8u7v6w5x4y3z2a1b600000000000000000")))
-        );
-
-        bytes32[] memory proof = new bytes32[](4);
-        proof[0] = bytes32(abi.encodePacked(hex"c99659b6e1c7a2df5c6ce352241ef43152f1fed170d2fdc8d67ee2c47d9f26a5"));
-        proof[1] = bytes32(abi.encodePacked(hex"662362a44a545cd42cdf7e9c1cfc7eb3b55ebb3af452e1bd516d7329f0f490fa"));
-        proof[2] = bytes32(abi.encodePacked(hex"8a12e22ffa7163c5249a71f3df41704c2e2ccf8bab02dec02fc8db2740f51256"));
-        proof[3] = bytes32(abi.encodePacked(hex"afb5ee202bbe624a5d933b1eda40f5bf6bcd6674dbf1af8eea698ae023c104fe"));
-
-        bytes32 root = bytes32(abi.encodePacked(hex"1c8dd9ca252d7eb9bf1cccb9ab587e9a1dccca4c7474bb8739c0e5218964a2b4"));
-
-        assertEq(MerkleProof.verify(proof, root, leaf, 7, 9), true);
-    }
-
     /// forge-config: default.allow_internal_expect_revert = true
     function test_revert_processProof_wrongTotalLeaves() public {
         bytes32 leaf = keccak256(

--- a/crates/bvs-rewards/src/merkle.rs
+++ b/crates/bvs-rewards/src/merkle.rs
@@ -2,18 +2,18 @@ use crate::error::RewardsError;
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{HexBinary, Uint128};
 use rs_merkle::Hasher;
-use sha3::{Digest, Sha3_256};
+use sha3::{Digest, Keccak256};
 
-/// Implements the SHA3-256 hashing algorithm
+/// Implements the Keccak256 hashing algorithm
 #[derive(Clone)]
 #[allow(dead_code)]
-pub struct Sha3_256Algorithm {}
+pub struct Keccak256Algorithm {}
 
-impl Hasher for Sha3_256Algorithm {
+impl Hasher for Keccak256Algorithm {
     type Hash = [u8; 32];
 
     fn hash(data: &[u8]) -> [u8; 32] {
-        let mut hasher = Sha3_256::new();
+        let mut hasher = Keccak256::new();
 
         hasher.update(data);
         <[u8; 32]>::from(hasher.finalize())
@@ -30,7 +30,7 @@ impl Leaf {
     // double hash the leaf
     pub fn hash(&self) -> [u8; 32] {
         let leaf = format!("{}{}", self.earner, self.amount);
-        Sha3_256Algorithm::hash(Sha3_256Algorithm::hash(leaf.as_bytes()).as_ref())
+        Keccak256Algorithm::hash(Keccak256Algorithm::hash(leaf.as_bytes()).as_ref())
     }
 }
 
@@ -61,7 +61,7 @@ pub fn verify_merkle_proof(
             })?;
 
     Ok(
-        rs_merkle::MerkleProof::<Sha3_256Algorithm>::new(proof_bytes).verify(
+        rs_merkle::MerkleProof::<Keccak256Algorithm>::new(proof_bytes).verify(
             root.to_array()?,
             &[leaf_index],
             &[leaf_hash],
@@ -77,18 +77,51 @@ mod tests {
     use cosmwasm_std::HexBinary;
 
     #[test]
+    fn test_keccak256() {
+        // to make sure that the keccak256 algorithm is compatible with solidity keccak256
+        let res = Keccak256Algorithm::hash("".as_bytes());
+        assert_eq!(
+            res,
+            HexBinary::from_hex("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
+                .unwrap()
+                .to_array()
+                .unwrap()
+        )
+    }
+
+    #[test]
     fn test_leaf_hash() {
         let earner = "bbn1eywhap4hwzd3lpwee4hgt2rh0rjlsq6dqck894".to_string();
         let amount = Uint128::new(100_000_000_000_000_000);
 
-        let expected_hash = "0ed336b10e9f46e2183d56c888b109aca9533bf0b653ab04e35aa65248f18d29";
+        let expected_hash = "bee6cd3b687cd34ea235eb51432375dc7be5a5d6d1d26d23beff099dbf88eeb5";
         assert_eq!(
             HexBinary::from_hex(expected_hash)
                 .unwrap()
                 .to_array()
                 .unwrap(),
-            Sha3_256Algorithm::hash(format!("{earner}{amount}").as_bytes())
+            Keccak256Algorithm::hash(format!("{earner}{amount}").as_bytes())
         );
+    }
+
+    #[test]
+    fn test_verify_merkle_proof_hardcoded() {
+        let root =
+            HexBinary::from_hex("4b83dc8ecaa7a9d69ac8a7c12718eed8639e1ba1a1b30a51741ccfd020255cec")
+                .unwrap();
+        let leaf = Leaf {
+            earner: "bbn1eywhap4hwzd3lpwee4hgt2rh0rjlsq6dqck894".to_string(),
+            amount: Uint128::new(100000000000000000),
+        };
+        let leaf_index = 1u32;
+        let total_leaf_count = 2u32;
+
+        let proof = vec![HexBinary::from_hex(
+            "614a2406c3e74dca5a75c5429158a486c9d0d9eb5efbea928cc309beb6b3fce6",
+        )
+        .unwrap()];
+
+        assert!(verify_merkle_proof(&root, proof, leaf, leaf_index, total_leaf_count).unwrap());
     }
 
     #[test]

--- a/crates/bvs-rewards/src/merkle.rs
+++ b/crates/bvs-rewards/src/merkle.rs
@@ -144,6 +144,32 @@ mod tests {
     }
 
     #[test]
+    fn test_verify_complex_merkle_proof_hardcoded() {
+        let root =
+            HexBinary::from_hex("1c8dd9ca252d7eb9bf1cccb9ab587e9a1dccca4c7474bb8739c0e5218964a2b4")
+                .unwrap();
+        let leaf = Leaf {
+            earner: "bbn1j8k7l6m5n4o3p2q1r0s9t8u7v6w5x4y3z2a1b".to_string(),
+            amount: Uint128::new(600000000000000000),
+        };
+        let leaf_index = 7u32;
+        let total_leaf_count = 9u32;
+
+        let proof = vec![
+            HexBinary::from_hex("c99659b6e1c7a2df5c6ce352241ef43152f1fed170d2fdc8d67ee2c47d9f26a5")
+                .unwrap(),
+            HexBinary::from_hex("662362a44a545cd42cdf7e9c1cfc7eb3b55ebb3af452e1bd516d7329f0f490fa")
+                .unwrap(),
+            HexBinary::from_hex("8a12e22ffa7163c5249a71f3df41704c2e2ccf8bab02dec02fc8db2740f51256")
+                .unwrap(),
+            HexBinary::from_hex("afb5ee202bbe624a5d933b1eda40f5bf6bcd6674dbf1af8eea698ae023c104fe")
+                .unwrap(),
+        ];
+
+        assert!(verify_merkle_proof(&root, proof, leaf, leaf_index, total_leaf_count).unwrap());
+    }
+
+    #[test]
     fn test_verify_complex_merkle_proof() {
         let leaves = vec![
             Leaf {

--- a/crates/bvs-rewards/src/testing.rs
+++ b/crates/bvs-rewards/src/testing.rs
@@ -1,7 +1,7 @@
 #![cfg(not(target_arch = "wasm32"))]
 
 use crate::error::RewardsError;
-use crate::merkle::{Leaf, Sha3_256Algorithm};
+use crate::merkle::{Keccak256Algorithm, Leaf};
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use bvs_library::testing::TestingContract;
 use cosmwasm_std::{Addr, Empty, Env, HexBinary};
@@ -40,8 +40,8 @@ impl TestingContract<InstantiateMsg, ExecuteMsg, QueryMsg> for RewardsContract {
     }
 }
 
-pub fn generate_merkle_tree(leaves: &[Leaf]) -> MerkleTree<Sha3_256Algorithm> {
-    MerkleTree::<Sha3_256Algorithm>::from_leaves(
+pub fn generate_merkle_tree(leaves: &[Leaf]) -> MerkleTree<Keccak256Algorithm> {
+    MerkleTree::<Keccak256Algorithm>::from_leaves(
         leaves
             .iter()
             .map(|leaf| leaf.hash())
@@ -51,7 +51,7 @@ pub fn generate_merkle_tree(leaves: &[Leaf]) -> MerkleTree<Sha3_256Algorithm> {
 }
 
 pub fn generate_merkle_proof(
-    tree: &MerkleTree<Sha3_256Algorithm>,
+    tree: &MerkleTree<Keccak256Algorithm>,
     leaf_index: u32,
 ) -> Result<Vec<HexBinary>, RewardsError> {
     // convert leaf index into usize

--- a/crates/bvs-rewards/tests/integration_test.rs
+++ b/crates/bvs-rewards/tests/integration_test.rs
@@ -1,5 +1,5 @@
 use bvs_library::testing::{Cw20TokenContract, TestingContract};
-use bvs_rewards::merkle::{Leaf, Sha3_256Algorithm};
+use bvs_rewards::merkle::{Keccak256Algorithm, Leaf};
 use bvs_rewards::msg::ExecuteMsg::{ClaimRewards, DistributeRewards};
 use bvs_rewards::msg::{
     ClaimRewardsProof, DistributionRootResponse, QueryMsg, RewardDistribution, RewardsType,
@@ -34,7 +34,7 @@ fn instantiate() -> (App, RewardsContract, Cw20TokenContract) {
 }
 
 // prep_merkle_tree_equalised generates n leaves for n different earners with equalised amount (1:1 ratio).
-fn prep_merkle_tree_equalised(app: &App, n: u8, amount: Uint128) -> MerkleTree<Sha3_256Algorithm> {
+fn prep_merkle_tree_equalised(app: &App, n: u8, amount: Uint128) -> MerkleTree<Keccak256Algorithm> {
     // iterate and generate n leaves with equalised amount
     prep_merkle_tree_rationed(app, vec![1; n as usize], amount)
 }
@@ -46,7 +46,7 @@ fn prep_merkle_tree_rationed(
     app: &App,
     ratio: Vec<u8>,
     amount: Uint128,
-) -> MerkleTree<Sha3_256Algorithm> {
+) -> MerkleTree<Keccak256Algorithm> {
     let total_ratio = ratio.iter().sum::<u8>() as u128;
     let n = ratio.len() as u8;
 

--- a/modules/cosmwasm-cli/cmd/rewards.go
+++ b/modules/cosmwasm-cli/cmd/rewards.go
@@ -316,7 +316,7 @@ func createMerkleTreeFromDistribution(dist Distribution) (*RewardsMerkleTree, er
 	tree, err := merkletree.NewTree(
 		merkletree.WithData(data),
 		merkletree.WithHashType(keccak256.New()),
-		merkletree.WithSorted(true),
+		merkletree.WithSorted(false),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create merkle tree: %w", err)

--- a/modules/cosmwasm-cli/cmd/rewards.go
+++ b/modules/cosmwasm-cli/cmd/rewards.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/wealdtech/go-merkletree/v2"
-	"github.com/wealdtech/go-merkletree/v2/sha3"
+	"github.com/wealdtech/go-merkletree/v2/keccak256"
 )
 
 var filePath string
@@ -228,7 +228,7 @@ func (d *Distribution) String() string {
 
 func leafHash(earner string, reward string) []byte {
 	// Create a leaf hash by concatenating the earner and reward and hashing them
-	hasher := sha3.New256()
+	hasher := keccak256.New()
 	return hasher.Hash([]byte(earner), []byte(reward))
 }
 
@@ -315,7 +315,7 @@ func createMerkleTreeFromDistribution(dist Distribution) (*RewardsMerkleTree, er
 	// Create new merkle tree with default settings - leaves are double-hashed
 	tree, err := merkletree.NewTree(
 		merkletree.WithData(data),
-		merkletree.WithHashType(sha3.New256()),
+		merkletree.WithHashType(keccak256.New()),
 		merkletree.WithSorted(true),
 	)
 	if err != nil {


### PR DESCRIPTION
#### What this PR does / why we need it:

Notable Changes:

1. Sorting of merkle leaves is turned off - no extra security value as we don't need to prove non-membership.
2. Standardise all merkle hashing to use `keccak256` inline with solidity's version

<!-- remove if not applicable -->
Closes SL-627
Closes SL-628