### PR TITLE
chore(deps): update @openzeppelin dependencies together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,6 +47,9 @@ updates:
       layerzerolabs:
         patterns:
           - "@layerzerolabs/*"
+      openzeppelin:
+        patterns:
+          - "@openzeppelin/*"
 
   - package-ecosystem: cargo
     directory: "/crates"


### PR DESCRIPTION
#### What this PR does / why we need it:

As titled, it should be updated together.