### PR TITLE
chore: document behavior of warnings in ERC4626Upgradeable

### DIFF
--- a/contracts/src/SLAYVaultV2.sol
+++ b/contracts/src/SLAYVaultV2.sol
@@ -448,6 +448,7 @@ contract SLAYVaultV2 is
     /**
      * @notice Always reverts as preview functions are not supported for asynchronous flows
      * @dev For ERC7540, preview functions MUST revert for all callers and inputs
+     * See https://eips.ethereum.org/EIPS/eip-7540#reversion-of-preview-functions-in-async-request-flows
      */
     function previewWithdraw(uint256) public pure virtual override(IERC4626, ERC4626Upgradeable) returns (uint256) {
         revert PreviewNotSupported();
@@ -456,6 +457,7 @@ contract SLAYVaultV2 is
     /**
      * @notice Always reverts as preview functions are not supported for asynchronous flows
      * @dev For ERC7540, preview functions MUST revert for all callers and inputs
+     * See https://eips.ethereum.org/EIPS/eip-7540#reversion-of-preview-functions-in-async-request-flows
      */
     function previewRedeem(uint256) public pure virtual override(IERC4626, ERC4626Upgradeable) returns (uint256) {
         revert PreviewNotSupported();

--- a/contracts/test/RelationshipV2.t.sol
+++ b/contracts/test/RelationshipV2.t.sol
@@ -8,13 +8,13 @@ import {RelationshipV2} from "../src/RelationshipV2.sol";
 contract RelationshipV2Test is Test {
     Checkpoints.Trace224 internal _checkpoints;
 
-    function test_objectDefault() external {
+    function test_objectDefault() public pure {
         RelationshipV2.Object memory rel;
         assertTrue(rel.status == RelationshipV2.Status.Inactive);
         assertEq(rel.slashParameterId, 0);
     }
 
-    function test_statusUint8Values() external {
+    function test_statusUint8Values() public pure {
         assertEq(uint8(RelationshipV2.Status.Inactive), 0);
         assertEq(uint8(RelationshipV2.Status.Active), 1);
         assertEq(uint8(RelationshipV2.Status.OperatorRegistered), 2);
@@ -25,7 +25,7 @@ contract RelationshipV2Test is Test {
         assertEq(uint8(status), uint8(0));
     }
 
-    function test_getKey() external {
+    function test_getKey() public pure {
         address service = address(0x1);
         address operator = address(0x2);
 
@@ -35,7 +35,7 @@ contract RelationshipV2Test is Test {
         assertEq(key, expectedKey);
     }
 
-    function test_encode() external {
+    function test_encode() public pure {
         RelationshipV2.Status status = RelationshipV2.Status.Active;
         uint32 slashParameterId = 123;
 
@@ -48,7 +48,7 @@ contract RelationshipV2Test is Test {
         assertEq(uint32(encoded >> 8), slashParameterId);
     }
 
-    function test_decode() external {
+    function test_decode() public pure {
         RelationshipV2.Status status = RelationshipV2.Status.OperatorRegistered;
         uint32 slashParameterId = 456;
 

--- a/contracts/test/SLAYRouterV2.t.sol
+++ b/contracts/test/SLAYRouterV2.t.sol
@@ -1230,14 +1230,14 @@ contract SLAYRouterV2Test is Test, TestSuiteV2 {
         router.setGuardrail(address(0));
     }
 
-    function test_getLockedAssets_InvalidSlashId() public {
+    function test_getLockedAssets_InvalidSlashId() public view {
         bytes32 invalidSlashId = keccak256(abi.encodePacked("invalid"));
 
         ISLAYRouterSlashingV2.LockedAssets[] memory lockedAssets = router.getLockedAssets(invalidSlashId);
         assertEq(lockedAssets.length, 0, "Should return empty array for invalid slashId");
     }
 
-    function test_getSlashingRequest_InvalidSlashId() public {
+    function test_getSlashingRequest_InvalidSlashId() public view {
         bytes32 invalidSlashId = keccak256(abi.encodePacked("invalid"));
 
         // Should return a request with default values for non-existent

--- a/contracts/test/SLAYVaultFactoryV2.t.sol
+++ b/contracts/test/SLAYVaultFactoryV2.t.sol
@@ -121,12 +121,12 @@ contract SLAYVaultFactoryV2Test is Test, TestSuiteV2 {
         assertEq(customVault.delegated(), operator);
     }
 
-    function test_immutable_beacon() public {
+    function test_immutable_beacon() public view {
         // The beacon address should not be zero
         assertTrue(vaultFactory.beacon() != address(0));
     }
 
-    function test_immutable_registry() public {
+    function test_immutable_registry() public view {
         assertEq(address(vaultFactory.registry()), address(registry));
     }
 

--- a/contracts/test/SLAYVaultFactoryV2.t.sol
+++ b/contracts/test/SLAYVaultFactoryV2.t.sol
@@ -138,7 +138,6 @@ contract SLAYVaultFactoryV2Test is Test, TestSuiteV2 {
         vm.prank(vm.randomAddress());
         vm.expectRevert();
         // Call the upgradeTo function directly
-        (bool success, bytes memory returnData) =
-            address(vaultFactory).call(abi.encodeWithSelector(bytes4(keccak256("upgradeTo(address)")), mockImpl));
+        address(vaultFactory).call(abi.encodeWithSelector(bytes4(keccak256("upgradeTo(address)")), mockImpl));
     }
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

`forge build` will create 4 warnings that cannot be fixed, as they're required to fail as described in https://eips.ethereum.org/EIPS/eip-7540#reversion-of-preview-functions-in-async-request-flows

```
Compiler run successful with warnings:
Warning (5740): Unreachable code.
   --> node_modules/@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC4626Upgradeable.sol:255:9:
    |
255 |         _withdraw(_msgSender(), receiver, owner, assets, shares);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

Warning (5740): Unreachable code.
   --> node_modules/@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC4626Upgradeable.sol:257:9:
    |
257 |         return shares;
    |         ^^^^^^^^^^^^^

Warning (5740): Unreachable code.
   --> node_modules/@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC4626Upgradeable.sol:270:9:
    |
270 |         _withdraw(_msgSender(), receiver, owner, assets, shares);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

Warning (5740): Unreachable code.
   --> node_modules/@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC4626Upgradeable.sol:272:9:
    |
272 |         return assets;
    |         ^^^^^^^^^^^^^
```


<!-- remove if not applicable -->
Closes SL-645