### PR TITLE
chore: refactor SLAY contracts to use ownable2step

### DIFF
--- a/contracts/src/SLAYBase.sol
+++ b/contracts/src/SLAYBase.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 
@@ -22,7 +22,7 @@ import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/Pau
  * - SLAYRouter
  * - SLAYVaultFactory
  */
-contract SLAYBase is Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
+contract SLAYBase is Initializable, UUPSUpgradeable, Ownable2StepUpgradeable, PausableUpgradeable {
     /**
      * @dev Constructor that disables initializers to prevent the implementation contract from being initialized.
      * This is a security measure to ensure that the implementation contract itself cannot be used directly.
@@ -41,6 +41,7 @@ contract SLAYBase is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
      */
     function initialize(address initialOwner) public initializer {
         __Ownable_init(initialOwner);
+        __Ownable2Step_init();
         __UUPSUpgradeable_init();
         __Pausable_init();
     }

--- a/contracts/src/SLAYRegistryV2.sol
+++ b/contracts/src/SLAYRegistryV2.sol
@@ -1,10 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.0;
 
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
-import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {Checkpoints} from "@openzeppelin/contracts/utils/structs/Checkpoints.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
@@ -26,14 +22,7 @@ import {ISLAYRouterV2} from "./interface/ISLAYRouterV2.sol";
  *
  * @custom:oz-upgrades-from src/SLAYBase.sol:SLAYBase
  */
-contract SLAYRegistryV2 is
-    Initializable,
-    UUPSUpgradeable,
-    OwnableUpgradeable,
-    PausableUpgradeable,
-    SLAYBase,
-    ISLAYRegistryV2
-{
+contract SLAYRegistryV2 is SLAYBase, ISLAYRegistryV2 {
     using EnumerableSet for EnumerableSet.AddressSet;
 
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable

--- a/contracts/src/SLAYRewardsV2.sol
+++ b/contracts/src/SLAYRewardsV2.sol
@@ -19,14 +19,7 @@ import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
  *
  * @custom:oz-upgrades-from src/SLAYBase.sol:SLAYBase
  */
-contract SLAYRewardsV2 is
-    Initializable,
-    UUPSUpgradeable,
-    OwnableUpgradeable,
-    PausableUpgradeable,
-    SLAYBase,
-    ISLAYRewardsV2
-{
+contract SLAYRewardsV2 is SLAYBase, ISLAYRewardsV2 {
     using SafeERC20 for IERC20;
 
     /**

--- a/contracts/src/SLAYRewardsV2.sol
+++ b/contracts/src/SLAYRewardsV2.sol
@@ -2,11 +2,7 @@
 pragma solidity ^0.8.0;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
 import {SLAYBase} from "./SLAYBase.sol";
 import {MerkleProof} from "./MerkleProof.sol";

--- a/contracts/src/SLAYRouterV2.sol
+++ b/contracts/src/SLAYRouterV2.sol
@@ -34,15 +34,7 @@ import {ISLAYRouterSlashingV2, SlashingRequestId} from "./interface/ISLAYRouterS
  *
  * @custom:oz-upgrades-from src/SLAYBase.sol:SLAYBase
  */
-contract SLAYRouterV2 is
-    Initializable,
-    UUPSUpgradeable,
-    OwnableUpgradeable,
-    PausableUpgradeable,
-    SLAYBase,
-    ISLAYRouterV2,
-    ISLAYRouterSlashingV2
-{
+contract SLAYRouterV2 is SLAYBase, ISLAYRouterV2, ISLAYRouterSlashingV2 {
     using EnumerableSet for EnumerableSet.AddressSet;
     using SafeERC20 for IERC20;
 

--- a/contracts/src/SLAYRouterV2.sol
+++ b/contracts/src/SLAYRouterV2.sol
@@ -2,11 +2,6 @@
 pragma solidity ^0.8.0;
 
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
-
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/src/SLAYVaultFactoryV2.sol
+++ b/contracts/src/SLAYVaultFactoryV2.sol
@@ -1,12 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.0;
 
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 import {BeaconProxy} from "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
-
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 

--- a/contracts/src/SLAYVaultFactoryV2.sol
+++ b/contracts/src/SLAYVaultFactoryV2.sol
@@ -23,14 +23,7 @@ import {ISLAYVaultFactoryV2} from "./interface/ISLAYVaultFactoryV2.sol";
  * It inherits from SLAYBase which provides basic functionality like initialization,
  * upgradeability, ownership, and pause/unpause functions.
  */
-contract SLAYVaultFactoryV2 is
-    Initializable,
-    UUPSUpgradeable,
-    OwnableUpgradeable,
-    PausableUpgradeable,
-    SLAYBase,
-    ISLAYVaultFactoryV2
-{
+contract SLAYVaultFactoryV2 is SLAYBase, ISLAYVaultFactoryV2 {
     /**
      * @dev The address of the UpgradeableBeacon that points to the SLAYVaultV2 implementation.
      * This is used when creating new vault instances via BeaconProxy.

--- a/contracts/test/SLAYBase.t.sol
+++ b/contracts/test/SLAYBase.t.sol
@@ -114,4 +114,82 @@ contract SLAYBaseTest is Test {
 
         assertTrue(impl.paused(), "Contract should still be paused after upgrade");
     }
+
+    function test_transfer_ownership() public {
+        address initialOwner = makeAddr("Initial Owner");
+        address proxy =
+            UnsafeUpgrades.deployUUPSProxy(address(initialImpl), abi.encodeCall(SLAYBase.initialize, (initialOwner)));
+        SLAYBase impl = SLAYBase(proxy);
+
+        address newOwner = makeAddr("New Owner");
+
+        // first step to transfer ownership
+        vm.prank(initialOwner);
+        impl.transferOwnership(newOwner);
+
+        // assert that the ownership is not yet transferred
+        assertEq(impl.owner(), initialOwner, "Ownership should not be transferred yet");
+
+        // assert that pending owner is new owner
+        assertEq(impl.pendingOwner(), newOwner, "Pending owner should be set to the new owner");
+
+        // second step to transfer ownership
+        vm.prank(newOwner);
+        impl.acceptOwnership();
+
+        // assert that the ownership is now transferred
+        assertEq(impl.owner(), newOwner, "Ownership should be transferred to the new owner");
+    }
+
+    function test_transfer_ownership_multiple() public {
+        address initialOwner = makeAddr("Initial Owner");
+        address proxy =
+            UnsafeUpgrades.deployUUPSProxy(address(initialImpl), abi.encodeCall(SLAYBase.initialize, (initialOwner)));
+        SLAYBase impl = SLAYBase(proxy);
+
+        address newOwner = makeAddr("New Owner");
+        address anotherNewOwner = makeAddr("Another New Owner");
+
+        // first step to transfer ownership
+        vm.prank(initialOwner);
+        impl.transferOwnership(newOwner);
+
+        // assert that the ownership is not yet transferred
+        assertEq(impl.owner(), initialOwner, "Ownership should not be transferred yet");
+
+        // assert that pending owner is new owner
+        assertEq(impl.pendingOwner(), newOwner, "Pending owner should be set to the new owner");
+
+        // initial owner changes mind and wants to transfer ownership to another address
+        vm.prank(initialOwner);
+        impl.transferOwnership(anotherNewOwner);
+
+        // assert that the pending owner is now set to the another new owner
+        assertEq(impl.pendingOwner(), anotherNewOwner, "Pending owner should be set to the another new owner");
+
+        // new owner should not be able to accept ownership
+        vm.prank(newOwner);
+        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, newOwner));
+        impl.acceptOwnership();
+
+        // another new owner accepts ownership
+        vm.prank(anotherNewOwner);
+        impl.acceptOwnership();
+        // assert that the ownership is now transferred to the another new owner
+        assertEq(impl.owner(), anotherNewOwner, "Ownership should be transferred to the another new owner");
+
+        // another new owner can transfer ownership back to the initial owner
+        vm.prank(anotherNewOwner);
+        impl.transferOwnership(initialOwner);
+        // assert that the ownership is not yet transferred
+        assertEq(impl.owner(), anotherNewOwner, "Ownership should not be transferred yet");
+        // assert that pending owner is initial owner
+        assertEq(impl.pendingOwner(), initialOwner, "Pending owner should be set to the initial owner");
+
+        // initial owner accepts ownership
+        vm.prank(initialOwner);
+        impl.acceptOwnership();
+        // assert that the ownership is now transferred back to the initial owner
+        assertEq(impl.owner(), initialOwner, "Ownership should be transferred back to the initial owner");
+    }
 }

--- a/contracts/test/SLAYVaultFactoryV2.t.sol
+++ b/contracts/test/SLAYVaultFactoryV2.t.sol
@@ -6,6 +6,7 @@ import "../src/SLAYVaultV2.sol";
 import "../src/SLAYVaultFactoryV2.sol";
 import {Test, console} from "forge-std/Test.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 import {TestSuiteV2} from "./TestSuiteV2.sol";
 import {ISLAYVaultFactoryV2} from "../src/interface/ISLAYVaultFactoryV2.sol";
 


### PR DESCRIPTION
#### What this PR does / why we need it:



<!-- remove if not applicable -->
Closes SL-665