### PR TITLE
chore: cleanup whenNotPaused usage

### DIFF
--- a/contracts/src/SLAYRegistryV2.sol
+++ b/contracts/src/SLAYRegistryV2.sol
@@ -146,7 +146,6 @@ contract SLAYRegistryV2 is SLAYBase, ISLAYRegistryV2 {
     function registerOperatorToService(address operator)
         external
         override
-        whenNotPaused
         onlyService(_msgSender())
         onlyOperator(operator)
     {

--- a/contracts/src/SLAYVaultFactoryV2.sol
+++ b/contracts/src/SLAYVaultFactoryV2.sol
@@ -86,7 +86,6 @@ contract SLAYVaultFactoryV2 is SLAYBase, ISLAYVaultFactoryV2 {
     function create(IERC20 asset, address operator, string memory name, string memory symbol)
         external
         override
-        whenNotPaused
         onlyOwner
         returns (SLAYVaultV2)
     {

--- a/contracts/test/SLAYVaultFactoryV2.t.sol
+++ b/contracts/test/SLAYVaultFactoryV2.t.sol
@@ -88,16 +88,18 @@ contract SLAYVaultFactoryV2Test is Test, TestSuiteV2 {
         vaultFactory.pause();
 
         // Try to create a vault when paused
-        vm.startPrank(operator);
+        vm.prank(operator);
         vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
         vaultFactory.create(underlying);
-        vm.stopPrank();
 
         // Try to create a vault with custom params when paused
-        vm.startPrank(owner);
+        vm.prank(operator);
         vm.expectRevert(PausableUpgradeable.EnforcedPause.selector);
+        vaultFactory.create(underlying);
+
+        // You can still create a vault when owner
+        vm.prank(owner);
         vaultFactory.create(underlying, operator, "Custom Name", "Custom Symbol");
-        vm.stopPrank();
     }
 
     function test_create_whenPausedAndUnpaused() public {


### PR DESCRIPTION
#### What this PR does / why we need it:

Remove redundant whenNotPaused: 
- for registerOperatorToService inner state transition already has this modifier
- for create(IERC20 asset, address operator...)` this is only callable by owner so it's already a protected state 

Closes SL-672
