### PR TITLE
chore: overall contract safety refactoring

### DIFF
--- a/contracts/script/SLAYNet.s.sol
+++ b/contracts/script/SLAYNet.s.sol
@@ -2,18 +2,12 @@
 pragma solidity ^0.8.0;
 
 import {SLAYDeployment} from "./Deployment.s.sol";
-import {Core} from "@openzeppelin/foundry-upgrades/internal/Core.sol";
-import {Options} from "@openzeppelin/foundry-upgrades/Options.sol";
 import {ISLAYRegistryV2} from "../src/interface/ISLAYRegistryV2.sol";
-import {SLAYBase} from "../src/SLAYBase.sol";
 import {SLAYRegistryV2} from "../src/SLAYRegistryV2.sol";
 import {SLAYRewardsV2} from "../src/SLAYRewardsV2.sol";
 
 import {SLAYRouterV2} from "../src/SLAYRouterV2.sol";
 import {SLAYVaultFactoryV2} from "../src/SLAYVaultFactoryV2.sol";
-import {SLAYVaultV2} from "../src/SLAYVaultV2.sol";
-import {Script, console} from "forge-std/Script.sol";
-import {UnsafeUpgrades} from "@openzeppelin/foundry-upgrades/Upgrades.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";

--- a/contracts/src/SLAYRewardsV2.sol
+++ b/contracts/src/SLAYRewardsV2.sol
@@ -8,7 +8,6 @@ import {SLAYBase} from "./SLAYBase.sol";
 import {MerkleProof} from "./MerkleProof.sol";
 import {ISLAYRewardsV2} from "./interface/ISLAYRewardsV2.sol";
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
-import {ERC4626Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC4626Upgradeable.sol";
 
 /**
  * @title Rewards contract

--- a/contracts/src/SLAYRouterV2.sol
+++ b/contracts/src/SLAYRouterV2.sol
@@ -136,12 +136,13 @@ contract SLAYRouterV2 is SLAYBase, ReentrancyGuardUpgradeable, ISLAYRouterV2, IS
 
     /**
      * @dev Allows initialization of the contract without having SLAYBase initially initialized.
-     * This will run initialize from SLAYBase and then initialize2.
+     * This will run initialize from SLAYBase and then initialize2, if any initialization were previously done,
+     * it will revert with an error using the `initializer` modifier/protection.
      *
      * @custom:oz-upgrades-validate-as-initializer
      */
     function initializeAll(address initialOwner) public {
-        initialize(initialOwner);
+        SLAYBase.initialize(initialOwner);
         initialize2();
     }
 

--- a/contracts/src/SLAYRouterV2.sol
+++ b/contracts/src/SLAYRouterV2.sol
@@ -5,6 +5,7 @@ import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
 
 import {SLAYBase} from "./SLAYBase.sol";
 
@@ -29,7 +30,7 @@ import {ISLAYRouterSlashingV2, SlashingRequestId} from "./interface/ISLAYRouterS
  *
  * @custom:oz-upgrades-from src/SLAYBase.sol:SLAYBase
  */
-contract SLAYRouterV2 is SLAYBase, ISLAYRouterV2, ISLAYRouterSlashingV2 {
+contract SLAYRouterV2 is SLAYBase, ReentrancyGuardUpgradeable, ISLAYRouterV2, ISLAYRouterSlashingV2 {
     using EnumerableSet for EnumerableSet.AddressSet;
     using SafeERC20 for IERC20;
 
@@ -134,6 +135,17 @@ contract SLAYRouterV2 is SLAYBase, ISLAYRouterV2, ISLAYRouterSlashingV2 {
     }
 
     /**
+     * @dev Allows initialization of the contract without having SLAYBase initially initialized.
+     * This will run initialize from SLAYBase and then initialize2.
+     *
+     * @custom:oz-upgrades-validate-as-initializer
+     */
+    function initializeAll(address initialOwner) public {
+        initialize(initialOwner);
+        initialize2();
+    }
+
+    /**
      * @dev This function is called during the upgrade from SLAYBase to SLAYRouterV2.
      * It sets the default maximum number of vaults per operator to 10.
      *
@@ -141,6 +153,7 @@ contract SLAYRouterV2 is SLAYBase, ISLAYRouterV2, ISLAYRouterSlashingV2 {
      * it is protected by the `reinitializer` modifier.
      */
     function initialize2() public reinitializer(2) {
+        __ReentrancyGuard_init();
         _maxVaultsPerOperator = 10;
     }
 
@@ -273,7 +286,7 @@ contract SLAYRouterV2 is SLAYBase, ISLAYRouterV2, ISLAYRouterSlashingV2 {
     }
 
     /// @inheritdoc ISLAYRouterSlashingV2
-    function lockSlashing(bytes32 slashId) external override whenNotPaused onlyService(_msgSender()) {
+    function lockSlashing(bytes32 slashId) external override whenNotPaused onlyService(_msgSender()) nonReentrant {
         ISLAYRouterSlashingV2.Request storage request = _slashingRequests[slashId];
         // Only service that initiated the slash request can call this function.
         if (request.service != _msgSender()) {
@@ -294,6 +307,9 @@ contract SLAYRouterV2 is SLAYBase, ISLAYRouterV2, ISLAYRouterSlashingV2 {
         if (request.requestResolution > uint32(block.timestamp)) {
             revert ISLAYRouterSlashingV2.SlashingResolutionNotReached();
         }
+
+        // Update the slashing request status to locked state first
+        request.status = ISLAYRouterSlashingV2.Status.Locked;
 
         // Iterate through the vaults and call lockSlashing on each of them
         EnumerableSet.AddressSet storage operatorVaults = _operatorVaults[request.operator];
@@ -317,9 +333,6 @@ contract SLAYRouterV2 is SLAYBase, ISLAYRouterV2, ISLAYRouterSlashingV2 {
             }
         }
 
-        // update the slashing request status to Locked
-        request.status = ISLAYRouterSlashingV2.Status.Locked;
-
         emit ISLAYRouterSlashingV2.SlashingLocked(request.service, request.operator, slashId);
     }
 
@@ -334,7 +347,7 @@ contract SLAYRouterV2 is SLAYBase, ISLAYRouterV2, ISLAYRouterSlashingV2 {
     }
 
     /// @inheritdoc ISLAYRouterSlashingV2
-    function finalizeSlashing(bytes32 slashId) external override whenNotPaused onlyService(_msgSender()) {
+    function finalizeSlashing(bytes32 slashId) external override whenNotPaused onlyService(_msgSender()) nonReentrant {
         ISLAYRouterSlashingV2.Request storage request = _slashingRequests[slashId];
         // Only service that initiated the slash request can call this function.
         if (request.service != _msgSender()) {
@@ -351,6 +364,9 @@ contract SLAYRouterV2 is SLAYBase, ISLAYRouterV2, ISLAYRouterSlashingV2 {
             revert ISLAYRouterSlashingV2.GuardrailHaveNotApproved();
         }
 
+        // Update slash request to the finalized state first
+        request.status = ISLAYRouterSlashingV2.Status.Finalized;
+
         // get slash parameters
         ISLAYRegistryV2.SlashParameter memory slashParameter =
             REGISTRY.getSlashParameterAt(request.service, request.operator, request.timestamp);
@@ -364,8 +380,9 @@ contract SLAYRouterV2 is SLAYBase, ISLAYRouterV2, ISLAYRouterSlashingV2 {
             // Transfer the locked assets to the slashing destination
             SafeERC20.safeTransfer(IERC20(vault.asset()), slashParameter.destination, lockedAsset.amount);
 
-            // This is not strictly necessary as it won't ever be used again.
-            // But we delete this entry for gas refund.
+            // Deleting this locked asset entry is not strictly necessary for correctness,
+            // as it won't be accessed again. However, we delete it to benefit from the gas refund
+            // mechanism, since the storage slot is already warm.
             delete _lockedAssets[slashId][i];
 
             // vaultsCount is bounded to _maxVaultsPerOperator
@@ -378,9 +395,6 @@ contract SLAYRouterV2 is SLAYBase, ISLAYRouterV2, ISLAYRouterSlashingV2 {
 
         // remove pending slashing request id for the service and operator pair
         delete _pendingSlashingRequestIds[request.service][request.operator];
-
-        // update slash request to the finalized state
-        request.status = ISLAYRouterSlashingV2.Status.Finalized;
 
         emit ISLAYRouterSlashingV2.SlashingFinalized(
             request.service, request.operator, slashId, slashParameter.destination

--- a/contracts/src/SLAYRouterV2.sol
+++ b/contracts/src/SLAYRouterV2.sol
@@ -376,14 +376,11 @@ contract SLAYRouterV2 is SLAYBase, ReentrancyGuardUpgradeable, ISLAYRouterV2, IS
         for (uint256 i = 0; i < lockedAssets.length;) {
             ISLAYRouterSlashingV2.LockedAssets storage lockedAsset = lockedAssets[i];
             ISLAYVaultV2 vault = ISLAYVaultV2(lockedAsset.vault);
+            uint256 amount = lockedAsset.amount;
+            delete lockedAssets[i];
 
             // Transfer the locked assets to the slashing destination
-            SafeERC20.safeTransfer(IERC20(vault.asset()), slashParameter.destination, lockedAsset.amount);
-
-            // Deleting this locked asset entry is not strictly necessary for correctness,
-            // as it won't be accessed again. However, we delete it to benefit from the gas refund
-            // mechanism, since the storage slot is already warm.
-            delete lockedAssets[i];
+            SafeERC20.safeTransfer(IERC20(vault.asset()), slashParameter.destination, amount);
 
             // vaultsCount is bounded to _maxVaultsPerOperator
             unchecked {

--- a/contracts/src/SLAYRouterV2.sol
+++ b/contracts/src/SLAYRouterV2.sol
@@ -383,7 +383,7 @@ contract SLAYRouterV2 is SLAYBase, ReentrancyGuardUpgradeable, ISLAYRouterV2, IS
             // Deleting this locked asset entry is not strictly necessary for correctness,
             // as it won't be accessed again. However, we delete it to benefit from the gas refund
             // mechanism, since the storage slot is already warm.
-            delete _lockedAssets[slashId][i];
+            delete lockedAssets[i];
 
             // vaultsCount is bounded to _maxVaultsPerOperator
             unchecked {

--- a/contracts/src/SLAYVaultV2.sol
+++ b/contracts/src/SLAYVaultV2.sol
@@ -37,7 +37,7 @@ import {ISLAYVaultV2} from "./interface/ISLAYVaultV2.sol";
  *
  * WARNING: This contract does not support non-standard ERC20 tokens. Assets that do not conform to the ERC20 standard,
  * might lead to unexpected behavior or loss of funds. For example, tokens with fee-on-transfer mechanism are non-compliant.
- * Thus, vault with non-standard asset will be blacklisted from the SLAYRouter.
+ * Thus, vault with non-standard asset will NOT be whitelisted in the SLAYRouter.
  */
 contract SLAYVaultV2 is
     Initializable,
@@ -399,10 +399,10 @@ contract SLAYVaultV2 is
         // remove the request from pending redemption
         delete _pendingRedemption[controller];
 
-        // burn shares stored in the contract
+        // Burn shares stored in the contract first
         _burn(address(this), shares);
 
-        // transfer the assets to the receiver
+        // Transfer the assets to the receiver after
         SafeERC20.safeTransfer(IERC20(asset()), receiver, assets);
 
         emit Withdraw(caller, receiver, controller, assets, shares);

--- a/contracts/test/MerkleProof.t.sol
+++ b/contracts/test/MerkleProof.t.sol
@@ -7,7 +7,7 @@ import {Test, console} from "forge-std/Test.sol";
 import {MerkleProof} from "../src/MerkleProof.sol";
 
 contract MerkleProofTest is Test {
-    function test_verify_bbn() public {
+    function test_verify_bbn() public pure {
         bytes32 leaf = keccak256(
             abi.encodePacked(
                 keccak256(abi.encodePacked("bbn1eywhap4hwzd3lpwee4hgt2rh0rjlsq6dqck894100000000000000000"))
@@ -22,7 +22,7 @@ contract MerkleProofTest is Test {
         assertEq(MerkleProof.verify(proof, root, leaf, 1, 2), true);
     }
 
-    function test_verify_evm() public {
+    function test_verify_evm() public pure {
         bytes32 leaf = keccak256(
             abi.encodePacked(
                 keccak256(abi.encodePacked("0x86d6Fda2f439537da03a5b76D5aE26412F4c4235200000000000000000"))
@@ -39,7 +39,7 @@ contract MerkleProofTest is Test {
         assertEq(MerkleProof.verify(proof, root, leaf, 3, 5), true);
     }
 
-    function test_verify_complex() public {
+    function test_verify_complex() public pure {
         bytes32 leaf = keccak256(
             abi.encodePacked(keccak256(abi.encodePacked("bbn1j8k7l6m5n4o3p2q1r0s9t8u7v6w5x4y3z2a1b600000000000000000")))
         );

--- a/contracts/test/SLAYRouterV2.t.sol
+++ b/contracts/test/SLAYRouterV2.t.sol
@@ -21,14 +21,14 @@ contract SLAYRouterV2Test is Test, TestSuiteV2 {
 
     function test_initializers() public {
         SLAYRouterV2 v2Impl = new SLAYRouterV2(ISLAYRegistryV2(makeAddr("registry")));
-        SLAYRouterV2 v2Proxy = SLAYRouterV2(
+        SLAYRouterV2 v2Router = SLAYRouterV2(
             UnsafeUpgrades.deployUUPSProxy(address(v2Impl), abi.encodeCall(SLAYRouterV2.initializeAll, (address(this))))
         );
 
-        assertEq(v2Proxy.owner(), address(this));
-        assertEq(v2Proxy.paused(), false);
-        assertEq(v2Proxy.getMaxVaultsPerOperator(), 10, "default should be 10");
-        assertEq(v2Proxy.isVaultWhitelisted(address(0)), false);
+        assertEq(v2Router.owner(), address(this));
+        assertEq(v2Router.paused(), false);
+        assertEq(v2Router.getMaxVaultsPerOperator(), 10, "default should be 10");
+        assertEq(v2Router.isVaultWhitelisted(address(0)), false);
     }
 
     function test_paused() public {

--- a/contracts/test/SLAYRouterV2.t.sol
+++ b/contracts/test/SLAYRouterV2.t.sol
@@ -9,6 +9,7 @@ import {TestSuiteV2} from "./TestSuiteV2.sol";
 import {ISLAYRouterV2} from "../src/interface/ISLAYRouterV2.sol";
 import {ISLAYRouterSlashingV2} from "../src/interface/ISLAYRouterSlashingV2.sol";
 import {ISLAYRegistryV2} from "../src/interface/ISLAYRegistryV2.sol";
+import {UnsafeUpgrades} from "@openzeppelin/foundry-upgrades/Upgrades.sol";
 
 contract SLAYRouterV2Test is Test, TestSuiteV2 {
     function test_defaults() public view {
@@ -16,6 +17,18 @@ contract SLAYRouterV2Test is Test, TestSuiteV2 {
         assertEq(router.paused(), false);
         assertEq(router.getMaxVaultsPerOperator(), 10, "default should be 10");
         assertEq(router.isVaultWhitelisted(address(0)), false);
+    }
+
+    function test_initializers() public {
+        SLAYRouterV2 v2Impl = new SLAYRouterV2(ISLAYRegistryV2(makeAddr("registry")));
+        SLAYRouterV2 v2Proxy = SLAYRouterV2(
+            UnsafeUpgrades.deployUUPSProxy(address(v2Impl), abi.encodeCall(SLAYRouterV2.initializeAll, (address(this))))
+        );
+
+        assertEq(v2Proxy.owner(), address(this));
+        assertEq(v2Proxy.paused(), false);
+        assertEq(v2Proxy.getMaxVaultsPerOperator(), 10, "default should be 10");
+        assertEq(v2Proxy.isVaultWhitelisted(address(0)), false);
     }
 
     function test_paused() public {

--- a/contracts/test/SLAYVaultV2.gas.t.sol
+++ b/contracts/test/SLAYVaultV2.gas.t.sol
@@ -123,7 +123,7 @@ contract SLAYVaultV2Test is Test, TestSuiteV2 {
         uint256 ownerSharesBefore,
         uint256 vaultSharesBefore,
         string memory message
-    ) internal {
+    ) internal view {
         assertEq(
             vault.balanceOf(owner_addr),
             ownerSharesBefore - sharesToRequest,
@@ -383,7 +383,7 @@ contract SLAYVaultV2Test is Test, TestSuiteV2 {
         uint256 receiverAssetBalanceBefore,
         uint256 vaultSharesBalanceBefore,
         string memory message
-    ) internal {
+    ) internal view {
         assertEq(
             underlying.balanceOf(receiver),
             receiverAssetBalanceBefore + expectedAssetsReceived,


### PR DESCRIPTION
#### What this PR does / why we need it:

- Add non-reentrant for functions in SLAYRouter. We don't use the Transient (eip-1153) to support older evm versions.
- Add more documentation to describe contract safety behavior 
- Introduce a new `initializeAll` function for SLAYRouter for Upgrade safe checks.
- Refactor some parts of the contract to improve overall safety.

Closes SL-658, SL-670
