### PR TITLE
chore: test and document params usage for contracts

### DIFF
--- a/contracts/src/SLAYRegistryV2.sol
+++ b/contracts/src/SLAYRegistryV2.sol
@@ -333,6 +333,7 @@ contract SLAYRegistryV2 is SLAYBase, ISLAYRegistryV2 {
     function approveSlashingFor(address service) external override onlyOperator(_msgSender()) whenNotPaused {
         address operator = _msgSender();
         RelationshipV2.Object memory obj = _getRelationshipObject(service, operator);
+        // don't need onlyService(service) above since it can only be Active if it's registered.
         require(obj.status == RelationshipV2.Status.Active, "Relationship not active");
 
         uint32 slashParameterId = _services[service].slashParameterId;

--- a/contracts/src/SLAYRouterV2.sol
+++ b/contracts/src/SLAYRouterV2.sol
@@ -304,12 +304,15 @@ contract SLAYRouterV2 is SLAYBase, ISLAYRouterV2, ISLAYRouterSlashingV2 {
 
             // calculate the slash amount from mbips
             uint256 slashAmount = Math.mulDiv(vault.totalAssets(), request.mbips, 10_000_000);
+            if (slashAmount != 0) {
+                // Call the lockSlashing function on the vault
+                vault.lockSlashing(slashAmount);
 
-            // Call the lockSlashing function on the vault
-            vault.lockSlashing(slashAmount);
-
-            // Store the locked assets in the router for further processing
-            _lockedAssets[slashId].push(ISLAYRouterSlashingV2.LockedAssets({amount: slashAmount, vault: vaultAddress}));
+                // Store the locked assets in the router for further processing
+                _lockedAssets[slashId].push(
+                    ISLAYRouterSlashingV2.LockedAssets({amount: slashAmount, vault: vaultAddress})
+                );
+            }
 
             // vaultsCount is bounded to _maxVaultsPerOperator
             unchecked {

--- a/contracts/src/SLAYVaultFactoryV2.sol
+++ b/contracts/src/SLAYVaultFactoryV2.sol
@@ -90,6 +90,7 @@ contract SLAYVaultFactoryV2 is SLAYBase, ISLAYVaultFactoryV2 {
         returns (SLAYVaultV2)
     {
         _checkOperator(operator);
+        // asset, operator, name, symbol will be checked by SLAYVaultV2.initialize
         bytes memory data = abi.encodeCall(SLAYVaultV2.initialize, (asset, operator, name, symbol));
         BeaconProxy proxy = new BeaconProxy(BEACON, data);
         return SLAYVaultV2(address(proxy));

--- a/contracts/src/SLAYVaultV2.sol
+++ b/contracts/src/SLAYVaultV2.sol
@@ -138,7 +138,7 @@ contract SLAYVaultV2 is
         public
         initializer
     {
-        require(delegated_ != address(0x0), "Delegated is not a valid account");
+        require(delegated_ != address(0), "Delegated is not a valid account");
 
         __ERC20_init(name_, symbol_);
         __ERC4626_init(asset_);
@@ -216,7 +216,7 @@ contract SLAYVaultV2 is
     /// @notice The controller is the address that will be able to claim the redemption request.
     /// They take ownership of the shares and can transfer to any address during withdrawal.
     /// Only give access to controller that are trusted by the msg.sender (or set it to msg.sender).
-    /// Likewise, setting it to a random address or (0x0) is equivalent to "burning" it.
+    /// Likewise, setting it to a random address or (0) is equivalent to "burning" it.
     function requestRedeem(uint256 shares, address controller, address owner)
         public
         override
@@ -288,7 +288,7 @@ contract SLAYVaultV2 is
      * @inheritdoc IERC7540Operator
      */
     function setOperator(address operator, bool approved) external override whenNotPaused returns (bool success) {
-        require(operator != address(0x0), "Operator is not a valid account");
+        require(operator != address(0), "Operator is not a valid account");
 
         address sender = _msgSender();
         _isOperator[sender][operator] = approved;

--- a/contracts/src/SLAYVaultV2.sol
+++ b/contracts/src/SLAYVaultV2.sol
@@ -138,6 +138,8 @@ contract SLAYVaultV2 is
         public
         initializer
     {
+        require(delegated_ != address(0x0), "Delegated is not a valid account");
+
         __ERC20_init(name_, symbol_);
         __ERC4626_init(asset_);
         __ERC20Permit_init(name_);
@@ -211,6 +213,10 @@ contract SLAYVaultV2 is
     //////////////////////////////////////////////////////////////*/
 
     /// @inheritdoc IERC7540Redeem
+    /// @notice The controller is the address that will be able to claim the redemption request.
+    /// They take ownership of the shares and can transfer to any address during withdrawal.
+    /// Only give access to controller that are trusted by the msg.sender (or set it to msg.sender).
+    /// Likewise, setting it to a random address or (0x0) is equivalent to "burning" it.
     function requestRedeem(uint256 shares, address controller, address owner)
         public
         override
@@ -282,6 +288,8 @@ contract SLAYVaultV2 is
      * @inheritdoc IERC7540Operator
      */
     function setOperator(address operator, bool approved) external override whenNotPaused returns (bool success) {
+        require(operator != address(0x0), "Operator is not a valid account");
+
         address sender = _msgSender();
         _isOperator[sender][operator] = approved;
         emit OperatorSet(sender, operator, approved);

--- a/contracts/src/interface/ISLAYRegistryV2.sol
+++ b/contracts/src/interface/ISLAYRegistryV2.sol
@@ -158,6 +158,7 @@ interface ISLAYRegistryV2 {
      * @dev This function can be called by both services and operators.
      * Emits a `MetadataUpdated` event with the new URI and name.
      * Name and URI are not validated or stored on-chain.
+     * Non-compliant uri or name will not affect the REGISTRY, given its offchain uses.
      *
      * @param uri URI of the provider's project to display in the UI
      * @param name Name of the provider's project to display in the UI


### PR DESCRIPTION
#### What this PR does / why we need it:

Document some parameter usage on the contracts.

For `SLAYVaultV2.lockSlashing(uint256)`, when the amount is zero, an if condition check has been added to prevent it from being called.

Also, added more tests.

Closes SL-669, SL-674
