### PR TITLE
chore: bind _msgSender() to address and remove single use var binding in loop

### DIFF
--- a/contracts/src/SLAYRegistryV2.sol
+++ b/contracts/src/SLAYRegistryV2.sol
@@ -457,9 +457,10 @@ contract SLAYRegistryV2 is SLAYBase, ISLAYRegistryV2 {
     /// @inheritdoc ISLAYRegistryV2
     function setMinWithdrawalDelay(uint32 delay) external override whenNotPaused onlyService(_msgSender()) {
         require(delay > 0, "Delay must be more than 0");
+        address service = _msgSender();
 
         // checks for each of its active operators if their withdrawal delay is less than the new minimum delay
-        EnumerableSet.AddressSet storage activeOperators = _servicesActiveRelationships[_msgSender()];
+        EnumerableSet.AddressSet storage activeOperators = _servicesActiveRelationships[service];
         uint256 activeOperatorsCount = activeOperators.length();
         for (uint256 i = 0; i < activeOperatorsCount;) {
             require(
@@ -474,9 +475,9 @@ contract SLAYRegistryV2 is SLAYBase, ISLAYRegistryV2 {
         }
 
         // If all checks pass, set the new minimum delay for the service
-        _services[_msgSender()].minWithdrawalDelay = delay;
+        _services[service].minWithdrawalDelay = delay;
 
-        emit MinWithdrawalDelayUpdated(_msgSender(), delay);
+        emit MinWithdrawalDelayUpdated(service, delay);
     }
 
     /// @inheritdoc ISLAYRegistryV2

--- a/contracts/src/SLAYRegistryV2.sol
+++ b/contracts/src/SLAYRegistryV2.sol
@@ -462,9 +462,8 @@ contract SLAYRegistryV2 is SLAYBase, ISLAYRegistryV2 {
         EnumerableSet.AddressSet storage activeOperators = _servicesActiveRelationships[_msgSender()];
         uint256 activeOperatorsCount = activeOperators.length();
         for (uint256 i = 0; i < activeOperatorsCount;) {
-            address operator = activeOperators.at(i);
             require(
-                _operators[operator].withdrawalDelay >= delay,
+                _operators[activeOperators.at(i)].withdrawalDelay >= delay,
                 "Service's minimum withdrawal delay must be less than or equal to active operator's withdrawal delay"
             );
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Save about a negligible (at current eth prices) amount of gas 30-100 on avg. (stats tracked at when contract is not fat with states).

#### Before
<img width="935" height="60" alt="image" src="https://github.com/user-attachments/assets/5161789e-97f0-4222-9e66-9e759f974661" />

#### After
<img width="843" height="35" alt="image" src="https://github.com/user-attachments/assets/66671f56-75b7-46fb-b820-a620c920cfb0" />



<!-- remove if not applicable -->
Closes SL-678
