### PR TITLE
chore: add getSlashingRequestId to SLAYRouter

### DIFF
--- a/contracts/src/SLAYRouterV2.sol
+++ b/contracts/src/SLAYRouterV2.sol
@@ -217,6 +217,12 @@ contract SLAYRouterV2 is SLAYBase, ReentrancyGuardUpgradeable, ISLAYRouterV2, IS
     }
 
     /// @inheritdoc ISLAYRouterSlashingV2
+    function getSlashingRequestId(address service, address operator) external view override returns (bytes32) {
+        // Return the slashing request ID for the given service-operator pair
+        return _pendingSlashingRequestIds[service][operator];
+    }
+
+    /// @inheritdoc ISLAYRouterSlashingV2
     function getSlashingRequest(bytes32 slashId)
         external
         view

--- a/contracts/src/SLAYRouterV2.sol
+++ b/contracts/src/SLAYRouterV2.sol
@@ -217,7 +217,7 @@ contract SLAYRouterV2 is SLAYBase, ReentrancyGuardUpgradeable, ISLAYRouterV2, IS
     }
 
     /// @inheritdoc ISLAYRouterSlashingV2
-    function getSlashingRequestId(address service, address operator) external view override returns (bytes32) {
+    function getPendingSlashingRequestId(address service, address operator) external view override returns (bytes32) {
         // Return the slashing request ID for the given service-operator pair
         return _pendingSlashingRequestIds[service][operator];
     }

--- a/contracts/src/interface/ISLAYRouterSlashingV2.sol
+++ b/contracts/src/interface/ISLAYRouterSlashingV2.sol
@@ -202,12 +202,21 @@ interface ISLAYRouterSlashingV2 {
 
     /**
      * @dev Returns the most recent slashing request initiated by the specified service against the specified operator.
-     * If no active request exists, the returned request will have default values.
+     * If no pending request exists, the returned request will have default values.
      * @param service Address of the service that initiated the slashing request.
      * @param operator Address of the operator targeted by the slashing request.
-     * @return A Request struct containing the details of the current active slashing request.
+     * @return A Request struct containing the details of the current pending slashing request.
      */
     function getPendingSlashingRequest(address service, address operator) external view returns (Request memory);
+
+    /**
+     * @dev Returns the most recent slashing request id initiated by the specified service against the specified operator.
+     * If no pending request exists, the returned request id will be empty.
+     * @param service Address of the service that initiated the slashing request.
+     * @param operator Address of the operator targeted by the slashing request.
+     * @return bytes32 The unique identifier for the current pending slashing request.
+     */
+    function getPendingSlashingRequestId(address service, address operator) external view returns (bytes32);
 
     /**
      * @dev Returns the complete details of a slashing request identified by the provided slashId.


### PR DESCRIPTION
#### What this PR does / why we need it:
