### PR TITLE
chore: add index docs for evm contracts + examples

### DIFF
--- a/docs/app/evm/contracts/page.mdx
+++ b/docs/app/evm/contracts/page.mdx
@@ -1,0 +1,47 @@
+---
+asIndexPage: true
+---
+
+import {Callout, Cards} from 'nextra/components'
+import { CubeIcon, LinkIcon, ShieldCheckIcon } from '@heroicons/react/24/outline'
+
+# SLAY Contracts (EVM)
+
+SLAY contracts provide a simple, modular set of contracts to connect [Services](/architecture/services) and [Operators](/architecture/operators), manage vault-based restaking, and coordinate slashing. At a glance:
+
+### SLAY Registry ([ISLAYRegistryV2](/evm/contracts/ISLAYRegistryV2.sol))
+- Single source of truth for Services and Operators registration.
+- Establishes Service ↔ Operator relationships (two-sided consent).
+- Holds slashing parameters per Service and requires Operator approval to activate them.
+- Enforces limits (max active relationships) and withdrawal-delay compatibility.
+
+### SLAY Router ([ISLAYRouterV2](/evm/contracts/ISLAYRouterV2.sol), [ISLAYRouterSlashingV2](/evm/contracts/ISLAYRouterSlashingV2.sol))
+- Central gate for pausing and whitelisting vaults across the system.
+- Entrypoint for Services to interact with the vaults.
+- Manages Vault whitelisting.
+- Provides slashing related functionality.
+
+### SLAY Rewards ([ISLAYRewardsV2](/evm/contracts/ISLAYRewardsV2.sol))
+- Services rewards the Operators and Stakers for their contributions in the shared security.
+- Earners will be able to claim rewards.
+- Uses Merkle proofs to verify claims.
+
+### SLAY VaultFactory ([ISLAYVaultFactoryV2](/evm/contracts/ISLAYVaultFactoryV2.sol))
+- Factory for creating SLAY Vaults.
+- Delegated to Operators to manage the vaults.
+
+### SLAY Vault ([ISLAYVaultV2](/evm/contracts/ISLAYVaultV2.sol))
+- ERC-4626 tokenized vault with async redemption following ERC-7540 patterns.
+- Integrates with Registry for operator withdrawal delays used in claim windows.
+- Delegated to Operators to manage the vaults.
+
+<Callout type="info">
+    To learn more about integrating with the SLAY Contracts, check out the [Integrating](/evm/developer/integrating) section.
+</Callout>
+
+## Start building
+
+<Cards num={3}>
+  <Cards.Card icon={<CubeIcon />} title="Integrating SatLayer" href="/evm/developer/integrating" />
+  <Cards.Card icon={<ShieldCheckIcon />} title="Deploying" href="/evm/developer/deploying" />
+</Cards>

--- a/docs/app/evm/developer/integrating/page.mdx
+++ b/docs/app/evm/developer/integrating/page.mdx
@@ -3,7 +3,7 @@ import {Callout} from 'nextra/components';
 # Integrating with SatLayer
 
 ## Prerequisites
-Read through [SatLayer's EVM core contracts](/evm/contracts) and understand how [Services](/app/architecture/services) work.
+Read through [SatLayer's EVM core contracts](/evm/contracts) and understand how [Services](/architecture/services) work.
 
 ## Getting Started
 
@@ -124,7 +124,7 @@ the SLAYRouter coordinates the programmable slashing of vaults,
 serving as the execution layer for the slashing logic.
 
 <Callout type="info">
-  See [Programmable Slashing](/app/architecture/slashing) for more information on how slashing works.
+  See [Programmable Slashing](/architecture/slashing) for more information on how slashing works.
 </Callout>
 
 ### Request Slashing

--- a/docs/app/evm/developer/page.mdx
+++ b/docs/app/evm/developer/page.mdx
@@ -4,7 +4,7 @@ asIndexPage: true
 
 import { Callout, Cards } from 'nextra/components'
 import {
-    AcademicCapIcon, ArrowDownTrayIcon,
+    ArrowDownTrayIcon,
     CommandLineIcon,
     CubeIcon,
     SparklesIcon,
@@ -28,34 +28,6 @@ You will be able to compile, deploy, and interact with your contracts.
     <Cards.Card icon={<ArrowDownTrayIcon />} title="Installation" href="/evm/developer/installation" />
     <Cards.Card icon={<SparklesIcon />} title="Integrating SatLayer" href="/evm/developer/integrating" />
     <Cards.Card icon={<CommandLineIcon />} title="Deploying" href="/evm/developer/deploying" />
+    <Cards.Card icon={<CubeIcon />} title="Examples" href="/evm/examples" />
 </Cards>
 
-## Start here
-
-<Cards num={2}>
-    <Cards.Card
-        icon={<SparklesIcon />}
-        title="Integrating SatLayer"
-        href="/evm/developer/integrating"
-        arrow>
-        <div className="x:p-4 x:grow x:bg-white x:dark:bg-black x:leading-7">
-            <>Minimal examples to register services/operators and use programmable slashing.</>
-        </div>
-    </Cards.Card>
-    <Cards.Card
-        icon={<CubeIcon />}
-        title="BVS Examples"
-        href="/evm/examples/squaring"
-        arrow>
-        <div className="x:p-4 x:grow x:bg-white x:dark:bg-black x:leading-7">
-            <>Bootstrap your project with templates and examples.</>
-        </div>
-    </Cards.Card>
-</Cards>
-
-## Related
-
-<Cards num={2}>
-    <Cards.Card icon={<AcademicCapIcon />} title="Architecture: Slashing" href="/app/architecture/slashing" />
-    <Cards.Card icon={<CommandLineIcon />} title="Contract Interfaces" href="/evm/contracts" />
-</Cards>

--- a/docs/app/evm/examples/page.mdx
+++ b/docs/app/evm/examples/page.mdx
@@ -1,0 +1,82 @@
+---
+asIndexPage: true
+---
+
+import { Callout, Cards } from 'nextra/components'
+import {
+  CubeIcon,
+  CommandLineIcon,
+  RocketLaunchIcon,
+  ShieldCheckIcon,
+  BookOpenIcon,
+} from '@heroicons/react/24/outline'
+
+# Examples (EVM)
+
+Explore end-to-end examples that show how to build Bitcoin Validated Services
+(BVS) that integrate with SatLayer on EVM chains for various use cases.
+
+## Overview
+
+These examples are designed to help you:
+
+- Understand how Services interact with SLAY contracts (Registry, Router, Vaults, Rewards).
+- See how off‑chain nodes/operators participate in verification and reward flows.
+- Learn typical patterns for broadcasting work, quorum/verification, and finalization.
+
+They are intentionally minimal and link to full README guides for details.
+
+## Available examples
+
+<Callout type="warning">
+    These examples are not production ready.
+    They are meant to be used as a reference for learning how to build BVSs.
+    They are not meant to be used in production.
+</Callout>
+
+<Cards num={2}>
+  <Cards.Card
+    icon={<ShieldCheckIcon />}
+    title="Insurance as a BVS"
+    href="https://github.com/satlayer/satlayer-bvs/tree/main/examples/evm/insurance"
+    arrow
+  >
+      <div className="x:p-4 x:grow x:bg-white x:dark:bg-black x:leading-7">
+          <>Off‑chain policy manager + EVM integration that underwrites policies, processes claims, triggers slashing, and distributes rewards to operators and stakers.</>
+      </div>
+
+  </Cards.Card>
+
+  <Cards.Card
+    icon={<RocketLaunchIcon />}
+    title="LayerZero DVN + BVS"
+    href="https://github.com/satlayer/satlayer-bvs/tree/main/examples/evm/layerzero-dvn"
+    arrow
+  >
+      <div className="x:p-4 x:grow x:bg-white x:dark:bg-black x:leading-7">
+          <>Demonstrates a custom DVN that routes packets through a BVS for operator‑secured verification in cross‑chain messaging.</>
+      </div>
+  </Cards.Card>
+</Cards>
+
+## Prerequisites
+
+- Familiarity with Solidity and EVM tooling.
+- Node.js and a package manager (pnpm or npm).
+- Foundry (for projects that compile Solidity) and/or Docker where noted by the example.
+- Access to an EVM RPC (for live deployments) — examples default to local tests.
+
+## Lifecycle
+
+Every examples comes with a README that explains the premise of the example.
+Lookout for the test file where most of the lifecycle is demonstrated.
+The lifecycle test will bring through the setup, registration, and main core lifecycle.
+Slashing and Rewards flows will also be demonstrated in some examples.
+
+## See also
+
+<Cards num={3}>
+  <Cards.Card icon={<BookOpenIcon />} title="Integrating with Solidity" href="/evm/developer/integrating" />
+  <Cards.Card icon={<CommandLineIcon />} title="Deploying" href="/evm/developer/deploying" />
+  <Cards.Card icon={<CubeIcon />} title="SLAY Contracts (EVM)" href="/evm/contracts" />
+</Cards>

--- a/examples/cw/governance/README.md
+++ b/examples/cw/governance/README.md
@@ -2,7 +2,7 @@
 sidebarTitle: Governance as a BVS
 ---
 
-# Governance as a BVS Example
+# [Governance as a BVS Example](https://github.com/satlayer/satlayer-bvs/blob/main/examples/cw/governance/README.md)
 
 ## Overview
 

--- a/examples/cw/insurance/README.md
+++ b/examples/cw/insurance/README.md
@@ -2,13 +2,13 @@
 sidebarTitle: Insurance as a BVS
 ---
 
-# Insurance as a BVS Example
+# [Insurance as a BVS Example](https://github.com/satlayer/satlayer-bvs/blob/main/examples/cw/insurance/README.md)
 
 This example demonstrates how to use the Bitcoin Validated Service (BVS) to provide insurance services.
 The service implements a complete insurance policy lifecycle with automated underwriting, claims processing,
 and rewards distribution.
 
-For EVM control plane, see [evm/examples/insurance](/examples/evm/insurance).
+For EVM control plane, see [evm/examples/insurance](/evm/examples/insurance).
 
 ## Overview
 

--- a/examples/cw/layerzero-dvn/README.md
+++ b/examples/cw/layerzero-dvn/README.md
@@ -2,7 +2,7 @@
 sidebarTitle: LayerZero DVN
 ---
 
-# LayerZero DVN Example (CosmWasm)
+# [LayerZero DVN Example (CosmWasm)](https://github.com/satlayer/satlayer-bvs/blob/main/examples/cw/layerzero-dvn/README.md)
 
 This example demonstrates how to build DVN + BVS integration with LayerZero for cross-chain packet verification
 and broadcasting leveraging on SatLayer's BVS ecosystem.

--- a/examples/cw/squaring/README.mdx
+++ b/examples/cw/squaring/README.mdx
@@ -3,7 +3,7 @@ sidebarTitle: Computational Squaring
 description: Off-chain computation with on-chain verification for squaring a number.
 ---
 
-# Computational Squaring Example
+# [Computational Squaring Example](https://github.com/satlayer/satlayer-bvs/blob/main/examples/cw/squaring/README.mdx)
 
 This example demonstrates how to use off-chain computation with on-chain verification through a
 [Service](/architecture/services). It introduces a simple squaring function (`n^2`) to illustrate the

--- a/examples/evm/insurance/README.md
+++ b/examples/evm/insurance/README.md
@@ -1,4 +1,8 @@
-# Insurance as a BVS Example (EVM)
+---
+title: Insurance as a BVS
+---
+
+# [Insurance as a BVS Example (EVM)](https://github.com/satlayer/satlayer-bvs/blob/main/examples/evm/insurance/README.md)
 
 This example demonstrates how to use the Bitcoin Validated Service (BVS) to provide insurance services.
 The service implements a complete insurance policy lifecycle with automated underwriting, claims processing,

--- a/examples/evm/layerzero-dvn/README.md
+++ b/examples/evm/layerzero-dvn/README.md
@@ -2,7 +2,7 @@
 title: LayerZero DVN
 ---
 
-# LayerZero DVN Example (EVM)
+# [LayerZero DVN Example (EVM)](https://github.com/satlayer/satlayer-bvs/blob/main/examples/evm/layerzero-dvn/README.md)
 
 This example demonstrates how to build DVN + BVS integration with LayerZero for cross-chain packet verification
 and broadcasting leveraging on SatLayer's BVS ecosystem in EVM control plane.


### PR DESCRIPTION
#### What this PR does / why we need it:

What this PR does:

1. Add index page to `evm/contracts`
2. Add index page to `evm/examples`
3. Add github repo link to all examples
4. fix minor broken links


<!-- remove if not applicable -->
Closes SL-701
Closes SL-703
Closes SL-704