### PR TITLE
chore: fix initVault + add getter for oracle

### DIFF
--- a/packages/testcontainers/src/evm-contracts.ts
+++ b/packages/testcontainers/src/evm-contracts.ts
@@ -38,14 +38,14 @@ export class EVMContracts {
     if (!this.mockPythContract) {
       throw new Error("MockPyth contract not initialized. run initOracle first");
     }
-    return this.mockPythContract!;
+    return this.mockPythContract;
   }
 
   get oracle(): GetContractReturnType<typeof slayOracle.abi, SuperTestClient> {
     if (!this.oracleContract) {
       throw new Error("Oracle contract not initialized. run initOracle first");
     }
-    return this.oracleContract!;
+    return this.oracleContract;
   }
 
   static async bootstrap(started: StartedAnvilContainer): Promise<EVMContracts> {


### PR DESCRIPTION
#### What this PR does / why we need it:

1. Fix initVault producing same vault address for different operators
2. move oracle and mockPyth to private and introduce getters for type safety